### PR TITLE
#31: Skip NaN and infinity values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.1.0 [unreleased]
 
+### Bugs
+1. [#31](https://github.com/influxdata/influxdb-client-csharp/issues/31): Drop NaN and infinity values from fields when writing to InfluxDB
+
 ## 1.0.0 [2019-08-23]
 
 ### Features

--- a/Client.Test/PointTest.cs
+++ b/Client.Test/PointTest.cs
@@ -325,5 +325,36 @@ namespace InfluxDB.Client.Test
             Assert.IsTrue(Point.Measurement("h2o").Field("level", "2").HasFields());
             Assert.IsTrue(Point.Measurement("h2o").Tag("location", "europe").Field("level", "2").HasFields());
         }
+
+        [Test]
+        public void InfinityValues()
+        {
+            var point = Point.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("double-infinity-positive", double.PositiveInfinity)
+                .Field("double-infinity-negative", double.NegativeInfinity)
+                .Field("double-nan", double.NaN)
+                .Field("flout-infinity-positive", float.PositiveInfinity)
+                .Field("flout-infinity-negative", float.NegativeInfinity)
+                .Field("flout-nan", float.NaN)
+                .Field("level", 2);
+
+            Assert.AreEqual("h2o,location=europe level=2i", point.ToLineProtocol());
+        }
+
+        [Test]
+        public void OnlyInfinityValues()
+        {
+            var point = Point.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("double-infinity-positive", double.PositiveInfinity)
+                .Field("double-infinity-negative", double.NegativeInfinity)
+                .Field("double-nan", double.NaN)
+                .Field("flout-infinity-positive", float.PositiveInfinity)
+                .Field("flout-infinity-negative", float.NegativeInfinity)
+                .Field("flout-nan", float.NaN);
+
+            Assert.AreEqual("", point.ToLineProtocol());
+        }
     }
 }


### PR DESCRIPTION
Closes #31 

Drop NaN and infinity values from fields when writing to InfluxDB

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)