### PR TITLE
FluxCSVParser uses a CultureInfo for parsing string to double

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bugs
 1. [#31](https://github.com/influxdata/influxdb-client-csharp/issues/31): Drop NaN and infinity values from fields when writing to InfluxDB
+1. [#39](https://github.com/influxdata/influxdb-client-csharp/pull/39): Drop NaN and infinity values from fields when writing to InfluxDB
 
 ## 1.0.0 [2019-08-23]
 

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using CsvHelper;
 using InfluxDB.Client.Core.Flux.Domain;
@@ -220,7 +221,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     case "long":
                         return Convert.ToInt64(strValue);
                     case "double":
-                        return Convert.ToDouble(strValue);
+                        return Convert.ToDouble(strValue, CultureInfo.InvariantCulture);
                     case "base64Binary":
                         return Convert.FromBase64String(strValue);
                     case "dateTime:RFC3339":

--- a/Client.Legacy.Test/FluxCsvParserTest.cs
+++ b/Client.Legacy.Test/FluxCsvParserTest.cs
@@ -500,6 +500,30 @@ namespace Client.Legacy.Test
             }
         }
 
+        [Test]
+        [SetCulture("de-DE")]
+        public void CustomCultureInfo()
+        {
+            var data =
+                "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,long,string,string,string,double,long,unsignedLong\n"
+                + "#group,false,false,false,false,false,false,false,false,false,true,true,true\n"
+                + "#default,_result,,,,,,,,,,,\n"
+                + ",result,table,_start,_stop,_time,_value,_field,_measurement,host,value-double,value-long,value-unsignedLong\n"
+                + ",,0,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,10,free,mem,A,6.1949943235120708,61949943235120708,61949943235120708\n";
+
+            var tables = ParseFluxResponse(data);
+
+            Assert.IsNotNull(tables.Count == 1);
+
+            var records = tables[0].Records;
+
+            Assert.That(records.Count == 1);
+
+            Assert.AreEqual(6.1949943235120708D, records[0].GetValueByKey("value-double"));
+            Assert.AreEqual(61949943235120708L, records[0].GetValueByKey("value-long"));
+            Assert.AreEqual(61949943235120708UL, records[0].GetValueByKey("value-unsignedLong"));
+        }
+
         private List<FluxTable> ParseFluxResponse(string data)
         {
             var consumer = new FluxCsvParser.FluxResponseConsumerTable();


### PR DESCRIPTION
Closes #37

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)