### PR TITLE
fix: PackageIconUrl is deprecated => we have to use PackageIcon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bugs
 1. [#45](https://github.com/influxdata/influxdb-client-csharp/issues/45): Assemblies are strong-named
+2. [#48](https://github.com/influxdata/influxdb-client-csharp/pull/48): Packing library icon into a package
 
 ## 1.2.0 [2019-11-08]
 

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -10,7 +10,7 @@
 
         <PackageId>InfluxDB.Client.Core</PackageId>
         <PackageTags>influxdata;timeseries;flux;influxdb</PackageTags>
-        <PackageIconUrl>https://raw.githubusercontent.com/influxdata/influxdb-client-csharp/master/Assets/influxdata.jpg</PackageIconUrl>
+        <PackageIcon>influxdata.jpg</PackageIcon>
         <PackageProjectUrl>https://github.com/influxdata/influxdb-client-csharp/tree/master/Client.Core</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/influxdata/influxdb-client-csharp</RepositoryUrl>
@@ -24,6 +24,10 @@
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
+    <ItemGroup>
+        <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath=""/>
+    </ItemGroup>
+    
     <ItemGroup>
       <PackageReference Include="CsvHelper" Version="8.1.1" />
       <PackageReference Include="Newtonsoft.Json" Version="	11.0.2" />

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -2,30 +2,31 @@
 
     <PropertyGroup>
         <TargetFramework>netstandard2.0</TargetFramework>
-        
+
         <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Flux</AssemblyName>
         <Version>1.3.0-preview</Version>
-        
+
         <PackageId>InfluxDB.Client.Flux</PackageId>
         <PackageTags>influxdata;timeseries;flux;influxdb</PackageTags>
-        <PackageIconUrl>https://raw.githubusercontent.com/influxdata/influxdb-client-csharp/master/Assets/influxdata.jpg</PackageIconUrl>
+        <PackageIcon>influxdata.jpg</PackageIcon>
         <PackageProjectUrl>https://github.com/influxdata/influxdb-client-csharp/tree/master/Client.Legacy</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/influxdata/influxdb-client-csharp</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        
+
         <PackageReleaseNotes>https://github.com/influxdata/influxdb-client-csharp/blob/master/CHANGELOG.md</PackageReleaseNotes>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <RootNamespace>InfluxDB.Client.Flux</RootNamespace>
-        
+
         <AssemblyOriginatorKeyFile>../Keys/Key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
+        <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath=""/>
+        <ProjectReference Include="..\Client.Core\Client.Core.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -10,7 +10,7 @@
 
         <PackageId>InfluxDB.Client</PackageId>
         <PackageTags>influxdata;timeseries;flux;influxdb</PackageTags>
-        <PackageIconUrl>https://raw.githubusercontent.com/influxdata/influxdb-client-csharp/master/Assets/influxdata.jpg</PackageIconUrl>
+        <PackageIcon>influxdata.jpg</PackageIcon>
         <PackageProjectUrl>https://github.com/influxdata/influxdb-client-csharp/tree/master/Client</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
         <RepositoryUrl>https://github.com/influxdata/influxdb-client-csharp</RepositoryUrl>
@@ -19,20 +19,21 @@
         <PackageReleaseNotes>https://github.com/influxdata/influxdb-client-csharp/blob/master/CHANGELOG.md</PackageReleaseNotes>
         <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
         <RootNamespace>InfluxDB.Client</RootNamespace>
-        
+
         <AssemblyOriginatorKeyFile>../Keys/Key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
+        <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath=""/>
+        <ProjectReference Include="..\Client.Core\Client.Core.csproj"/>
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="JsonSubTypes" Version="1.5.2" />
-      <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1" />
-      <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0" />
-      <PackageReference Include="System.Reactive" Version="4.1.2" />
+        <PackageReference Include="JsonSubTypes" Version="1.5.2"/>
+        <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.1.1"/>
+        <PackageReference Include="System.Configuration.ConfigurationManager" Version="4.5.0"/>
+        <PackageReference Include="System.Reactive" Version="4.1.2"/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
PackageIconUrl is deprecated => we have to use PackageIcon

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)