### PR TITLE
fix: WriteApi is disposed after a buffer is fully processed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### CI
 1. [#54](https://github.com/influxdata/influxdb-client-java/pull/54): Added beta release to continuous integration
 
+### Bugs
+1. [#56](https://github.com/influxdata/influxdb-client-csharp/issues/56): WriteApi is disposed after a buffer is fully processed
+
 ## 1.3.0 [2019-12-06]
 
 ### Performance

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -491,7 +491,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task SimpleWrite()
         {
-            var client = InfluxDBClientFactory.Create("http://localhost:9999", _token.ToCharArray());
+            var client = InfluxDBClientFactory.Create(InfluxDbUrl, _token.ToCharArray());
 
             using (var writeApi = client.GetWriteApi())
             {

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading;
 using InfluxDB.Client.Api.Domain;
@@ -298,6 +299,19 @@ namespace InfluxDB.Client.Test
 
             _influxDbClient.Dispose();
             _influxDbClient.Dispose();
+        }
+
+        [Test]
+        public void WaitToCondition()
+        {
+            var writer = new StringWriter();
+            Trace.Listeners.Add(new TextWriterTraceListener(writer));
+            
+            WriteApi.WaitToCondition(() => true, 30000);
+            WriteApi.WaitToCondition(() => false, 1);
+
+            StringAssert.Contains("The WriteApi can't be gracefully dispose! - 1ms", writer.ToString());
+            StringAssert.DoesNotContain("The WriteApi can't be gracefully dispose! - 30000ms", writer.ToString());
         }
     }
 }


### PR DESCRIPTION
cc #53

`WriteApi` could be disposed after whole buffer is processed.

  - [x] CHANGELOG.md updated
  - [x] Rebased/mergeable
  - [x] Tests pass
  - [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)