### PR TITLE
fix: write buffer uses correct flush interval and batch size under heavy load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 1.7.0 [unreleased]
 
+1. [#69](https://github.com/influxdata/influxdb-client-csharp/pull/69): Write buffer uses correct flush interval and batch size under heavy load
+
 ## 1.6.0 [2020-03-13]
 
 ### Features


### PR DESCRIPTION
part of #68 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)