### PR TITLE
fix: parsing error response for queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 1. [#81](https://github.com/influxdata/influxdb-client-csharp/pull/81): Fixed potentially hangs on of WriteApi.Dispose()
 1. [#82](https://github.com/influxdata/influxdb-client-csharp/pull/82): Avoid to deadlock when is client used in UI
+1. [#83](https://github.com/influxdata/influxdb-client-csharp/pull/83): Fixed parsing error response for 1.x
 
 ## 1.7.0 [2020-04-17]
 

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -416,7 +416,7 @@ namespace InfluxDB.Client.Flux
 
             var response = await Task.Run(() => RestClient.Execute(request)).ConfigureAwait(false);
 
-            RaiseForInfluxError(response);
+            RaiseForInfluxError(response, response.Content);
 
             response.Content = AfterIntercept(
                 (int) response.StatusCode,

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client
             _apiClient.RestClient.UserAgent = $"influxdb-client-csharp/{version}";
 
             _exceptionFactory = (methodName, response) =>
-                !response.IsSuccessful ? HttpException.Create(response) : null;
+                !response.IsSuccessful ? HttpException.Create(response, response.Content) : null;
 
             _setupService = new SetupService((Configuration) _apiClient.Configuration)
             {

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -148,7 +148,7 @@ namespace InfluxDB.Client
                             // ReSharper disable once ConvertIfStatementToReturnStatement
                             if (result.IsSuccessful) return Notification.CreateOnNext(result);
 
-                            return Notification.CreateOnError<IRestResponse>(HttpException.Create(result));
+                            return Notification.CreateOnError<IRestResponse>(HttpException.Create(result, result.Content));
                         })
                         .Catch<Notification<IRestResponse>, Exception>(ex =>
                         {


### PR DESCRIPTION
Closes #80

The error response for queries is encoded as a `stream` not as a "simple" `string`.

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)