### PR TITLE
fix: thread-safety disposing of clients

### DIFF
--- a/Client.Test/ItWriteApiRaceTest.cs
+++ b/Client.Test/ItWriteApiRaceTest.cs
@@ -67,7 +67,7 @@ namespace InfluxDB.Client.Test
                                  .Tag("test", "stress")
                                  .Field("value", 1);
 
-            const int RANGE = 100;
+            const int RANGE = 1000;
             using (var gateStart = new ManualResetEventSlim(false))
             using (var gate = new CountdownEvent(RANGE))
             using (var gateEnd = new CountdownEvent(RANGE))

--- a/Client.Test/ItWriteApiRaceTest.cs
+++ b/Client.Test/ItWriteApiRaceTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Configuration;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core;
+using InfluxDB.Client.Writes;
+using NodaTime;
+using NUnit.Framework;
+using Duration = NodaTime.Duration;
+using Task = System.Threading.Tasks.Task;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class ItWriteApiRaceTest : AbstractItClientTest
+    {
+        [SetUp]
+        public new async Task SetUp()
+        {
+            _organization = await FindMyOrg();
+
+            var retention = new BucketRetentionRules(BucketRetentionRules.TypeEnum.Expire, 3600);
+
+            _bucket = await Client.GetBucketsApi()
+                .CreateBucketAsync(GenerateName("h2o"), retention, _organization);
+
+            //
+            // Add Permissions to read and write to the Bucket
+            //
+            var resource =
+                new PermissionResource(PermissionResource.TypeEnum.Buckets, _bucket.Id, null, _organization.Id);
+
+            var readBucket = new Permission(Permission.ActionEnum.Read, resource);
+            var writeBucket = new Permission(Permission.ActionEnum.Write, resource);
+
+            var loggedUser = await Client.GetUsersApi().MeAsync();
+            Assert.IsNotNull(loggedUser);
+
+            var authorization = await Client.GetAuthorizationsApi()
+                .CreateAuthorizationAsync(await FindMyOrg(), new List<Permission> { readBucket, writeBucket });
+
+            _token = authorization.Token;
+
+            Client.Dispose();
+            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl).AuthenticateToken(_token.ToCharArray())
+                .Org(_organization.Id).Bucket(_bucket.Id).Build();
+            Client = InfluxDBClientFactory.Create(options);
+        }
+
+        private Bucket _bucket;
+        private Organization _organization;
+        private string _token;
+
+
+        [Test]
+        public void Race()
+        {
+            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
+                .LoadConfig()
+                .Url(InfluxDbUrl)
+                .AuthenticateToken(_token.ToCharArray())
+                .Build();
+            var point = PointData.Measurement("race-test")
+                                 .Tag("test", "stress")
+                                 .Field("value", 1);
+
+            const int RANGE = 100;
+            using (var gateStart = new ManualResetEventSlim(false))
+            using (var gate = new CountdownEvent(RANGE))
+            using (var gateEnd = new CountdownEvent(RANGE))
+            {
+                for (int i = 0; i < RANGE; i++)
+                {
+                    var trd = new Thread(() =>
+                    {
+                        gateStart.Wait();
+                        using (WriteApi writer = Client.GetWriteApi())
+                        {
+                            writer.WritePoint(point);
+                            gate.Signal();
+                            gate.Wait();
+                        }
+                        gateEnd.Signal();
+                    });
+                    trd.Start();
+                }
+                gateStart.Set();
+                gateEnd.Wait();
+            }
+        }
+    }
+}

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -97,7 +97,7 @@ namespace InfluxDB.Client.Test
             mock.Setup(disposable => disposable.Dispose());
 
             Assert.AreEqual(1, _influxDbClient.Apis.Count);
-            _influxDbClient.Apis.Add(mock.Object);
+            _influxDbClient.Apis.TryAdd(mock.Object, null);
             Assert.AreEqual(2, _influxDbClient.Apis.Count);
 
             _influxDbClient.Dispose();

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -93,24 +93,24 @@ namespace InfluxDB.Client.Test
         [Test]
         public void DisposeCallFromInfluxDbClientToWriteApi()
         {
-            var mock = new Mock<IDisposable>();
-            mock.Setup(disposable => disposable.Dispose());
+            var writeApi = _influxDbClient.GetWriteApi();
 
-            Assert.AreEqual(1, _influxDbClient.Apis.Count);
-            _influxDbClient.Apis.TryAdd(mock.Object, null);
-            Assert.AreEqual(2, _influxDbClient.Apis.Count);
-
+            Assert.False(writeApi.Disposed);
             _influxDbClient.Dispose();
-
-            mock.Verify(disposable => disposable.Dispose(), Times.Once);
+            Assert.True(writeApi.Disposed);
         }
 
         [Test]
         public void DisposedClientRemovedFromApis()
         {
-            Assert.AreEqual(1, _influxDbClient.Apis.Count);
-            _writeApi.Dispose();
-            Assert.AreEqual(0, _influxDbClient.Apis.Count);
+            var writeApi = _influxDbClient.GetWriteApi();
+
+            Assert.False(writeApi.Disposed);
+            writeApi.Dispose();
+            Assert.True(writeApi.Disposed);
+
+            _influxDbClient.Dispose();
+            // nothing bad happens
         }
 
         [Test]

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace InfluxDB.Client
         private readonly SetupService _setupService;
         private readonly InfluxDBClientOptions _options;
 
-        internal readonly List<IDisposable> Apis = new List<IDisposable>();
+        internal readonly ConcurrentDictionary<IDisposable, object> Apis = new ConcurrentDictionary<IDisposable, object>();
 
         protected internal InfluxDBClient(InfluxDBClientOptions options)
         {
@@ -63,7 +64,7 @@ namespace InfluxDB.Client
             //
             // Dispose child APIs
             //
-            foreach (var disposable in Apis.ToList()) disposable.Dispose();
+            foreach (var disposable in Apis.Keys) disposable.Dispose();
 
             //
             // signout
@@ -115,7 +116,7 @@ namespace InfluxDB.Client
             };
 
             var writeApi = new WriteApi(_options, service, writeOptions, this);
-            Apis.Add(writeApi);
+            Apis.TryAdd(writeApi, null);
 
             return writeApi;
         }

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -197,7 +197,7 @@ namespace InfluxDB.Client
 
         public void Dispose()
         {
-            _influxDbClient.Apis.Remove(this);
+            _influxDbClient.Apis.TryRemove(this, out object _);
 
             Trace.WriteLine("Flushing batches before shutdown.");
 

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -26,17 +26,25 @@ namespace InfluxDB.Client
         private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
         private readonly InfluxDBClientOptions _options;
         private readonly Subject<BatchWriteData> _subject = new Subject<BatchWriteData>();
+        private readonly IDisposable _unsubscribeDisposeCommand;
 
         private bool _disposed;
-        protected internal WriteApi(InfluxDBClientOptions options, WriteService service, WriteOptions writeOptions,
-            InfluxDBClient influxDbClient)
+        protected internal WriteApi(
+            InfluxDBClientOptions options, 
+            WriteService service, 
+            WriteOptions writeOptions,
+            InfluxDBClient influxDbClient,
+            IObservable<Unit> disposeCommand)
         {
             Arguments.CheckNotNull(service, nameof(service));
             Arguments.CheckNotNull(writeOptions, nameof(writeOptions));
             Arguments.CheckNotNull(influxDbClient, nameof(_influxDbClient));
+            Arguments.CheckNotNull(disposeCommand, nameof(disposeCommand));
 
             _options = options;
             _influxDbClient = influxDbClient;
+
+            _unsubscribeDisposeCommand= disposeCommand.Subscribe(_ => Dispose());
 
             // backpreasure - is not implemented in C#
             // 
@@ -197,7 +205,7 @@ namespace InfluxDB.Client
 
         public void Dispose()
         {
-            _influxDbClient.Apis.TryRemove(this, out object _);
+            _unsubscribeDisposeCommand.Dispose(); // avoid duplicate call to dispose
 
             Trace.WriteLine("Flushing batches before shutdown.");
 
@@ -210,6 +218,8 @@ namespace InfluxDB.Client
 
             WaitToCondition(() => _disposed, 30000);
         }
+
+        public bool Disposed => _disposed;
 
         public event EventHandler EventHandler;
 


### PR DESCRIPTION
Alternative to https://github.com/influxdata/influxdb-client-csharp/pull/99

I believe this is better approach (less coupling)
The subject notification is synchronously therefore safe for use in this scenario. 