### PR TITLE
fix: Remove console output when disposing WriteApi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 ## 1.9.0 [unreleased]
 
 ### API
-
 1. [#94](https://github.com/influxdata/influxdb-client-csharppull/94): Update swagger to latest version
 
 ### Bug Fixes
 1. [#100](https://github.com/influxdata/influxdb-client-csharp/pull/100): Thread-safety disposing of clients 
+1. [#101](https://github.com/influxdata/influxdb-client-csharp/pull/101/): Use Trace output when disposing WriteApi 
 
 ## 1.8.0 [2020-05-15]
 

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -194,12 +194,12 @@ namespace InfluxDB.Client
                     exception =>
                     {
                         _disposed = true;
-                        Console.WriteLine($"The unhandled exception occurs: {exception}");
+                        Trace.WriteLine($"The unhandled exception occurs: {exception}");
                     },
                     () =>
                     {
                         _disposed = true;
-                        Console.WriteLine("The WriteApi was disposed.");
+                        Trace.WriteLine("The WriteApi was disposed.");
                     });
         }
 


### PR DESCRIPTION
Changed from `Console.WriteLine` to `Trace.WriteLine` to avoid console output when disposing `WriteApi`.

- [ ] CHANGELOG.md updated
- [X] Rebased/mergeable
- [ ] Tests pass
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)