### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol,  `=` is valid sign for measurement name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#102](https://github.com/influxdata/influxdb-client-csharp/pull/102): Added WriteApiAsync for asynchronous write without batching
 
 ### Bug Fixes
-1. [#106](https://github.com/influxdata/influxdb-client-csharp/pull/106): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+1. [#106](https://github.com/influxdata/influxdb-client-csharp/pull/106): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name  
 
 ## 1.9.0 [2020-06-19]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.10.0 [unreleased]
 
 ### Features
-1. [#23](https://github.com/influxdata/influxdb-client-csharp/pull/102): Added WriteApiAsync for asynchronous write without batching
+1. [#102](https://github.com/influxdata/influxdb-client-csharp/pull/102): Added WriteApiAsync for asynchronous write without batching
+
+### Bug Fixes
+1. [#106](https://github.com/influxdata/influxdb-client-csharp/pull/106): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
 
 ## 1.9.0 [2020-06-19]
 

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -22,6 +22,18 @@ namespace InfluxDB.Client.Test
         }
         
         [Test]
+        public void TagEscapingKeyAndValue() {
+
+            var point = PointData.Measurement("h\n2\ro\t_data")
+                .Tag("new\nline", "new\nline")
+                .Tag("carriage\rreturn", "carriage\rreturn")
+                .Tag("t\tab", "t\tab")
+                .Field("level", 2);
+
+            Assert.AreEqual("h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\rreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i", point.ToLineProtocol());
+        }
+        
+        [Test]
         public void Immutability()
         {
             var point = PointData.Measurement("h2 o")

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -34,6 +34,16 @@ namespace InfluxDB.Client.Test
         }
         
         [Test]
+        public void EqualSignEscaping() {
+
+            var point = PointData.Measurement("h=2o")
+                .Tag("l=ocation", "e=urope")
+                .Field("l=evel", 2);
+
+            Assert.AreEqual("h=2o,l\\=ocation=e\\=urope l\\=evel=2i", point.ToLineProtocol());
+        }
+        
+        [Test]
         public void Immutability()
         {
             var point = PointData.Measurement("h2 o")
@@ -72,7 +82,7 @@ namespace InfluxDB.Client.Test
                 .Tag("", "warn")
                 .Field("level", 2);
 
-            Assert.AreEqual("h2\\=o,location=europe level=2i", point.ToLineProtocol());
+            Assert.AreEqual("h2=o,location=europe level=2i", point.ToLineProtocol());
 
             point = PointData.Measurement("h2,o")
                 .Tag("location", "europe")

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -298,7 +298,7 @@ namespace InfluxDB.Client.Writes
         {
             var sb = new StringBuilder();
 
-            EscapeKey(sb, _measurementName);
+            EscapeKey(sb, _measurementName, false);
             AppendTags(sb, pointSettings);
             var appendedFields = AppendFields(sb);
             if (!appendedFields)
@@ -469,7 +469,8 @@ namespace InfluxDB.Client.Writes
         /// </summary>
         /// <param name="sb">The sb.</param>
         /// <param name="key">The key.</param>
-        private void EscapeKey(StringBuilder sb, string key)
+        /// <param name="escapeEqual">Configure to escaping equal.</param>
+        private void EscapeKey(StringBuilder sb, string key, bool escapeEqual = true)
         {
             foreach (var c in key)
             {
@@ -486,8 +487,13 @@ namespace InfluxDB.Client.Writes
                         continue;
                     case ' ':
                     case ',':
-                    case '=':
                         sb.Append("\\");
+                        break;
+                    case '=':
+                        if (escapeEqual)
+                        {
+                            sb.Append("\\");
+                        }
                         break;
                 }
 

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -475,6 +475,15 @@ namespace InfluxDB.Client.Writes
             {
                 switch (c)
                 {
+                    case '\n':
+                        sb.Append("\\n");
+                        continue;
+                    case '\r':
+                        sb.Append("\\r");
+                        continue;
+                    case '\t':
+                        sb.Append("\\t");
+                        continue;
                     case ' ':
                     case ',':
                     case '=':


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

* serialization of `\n`, `\r` and `\t` to Line Protocol
* `=` is valid sign for measurement name 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)