### PR TITLE
fix: unnecessary API call when writing collection of DataPoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#97](https://github.com/influxdata/influxdb-client-csharp/pull/97): Improved WriteApi performance
 
+### Bug Fixes
+1. [#113](https://github.com/influxdata/influxdb-client-csharp/pull/113): Fixed unnecessary API call when writing collection of DataPoints
+
 ## 1.10.0 [2020-07-17]
 
 ### Features

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Test;
+using InfluxDB.Client.Writes;
+using NUnit.Framework;
+using WireMock.RequestBuilders;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class WriteApiAsyncTest : AbstractMockServerTest
+    {
+        private InfluxDBClient _influxDbClient;
+
+        [SetUp]
+        public new void SetUp()
+        {
+            _influxDbClient = InfluxDBClientFactory.Create(MockServerUrl, "token".ToCharArray());
+        }
+
+        [TearDown]
+        public new void ResetServer()
+        {
+            _influxDbClient.Dispose();
+        }
+
+        [Test]
+        public async Task GroupPointsByPrecisionSame()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+                .RespondWith(CreateResponse("{}"));
+
+            var writeApi = _influxDbClient.GetWriteApiAsync();
+            await writeApi.WritePointsAsync("my-org", "my-bucket", new List<PointData>
+            {
+                PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
+                    .Timestamp(9L, WritePrecision.S),
+                PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 10.0D)
+                    .Timestamp(10L, WritePrecision.S)
+            });
+
+            Assert.AreEqual(1, MockServer.LogEntries.Count());
+
+            var request = MockServer.LogEntries.Last();
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=s",
+                request.RequestMessage.AbsoluteUrl);
+            Assert.AreEqual("h2o,location=coyote_creek water_level=9 9\nh2o,location=coyote_creek water_level=10 10",
+                request.RequestMessage.Body);
+        }
+
+        [Test]
+        public async Task GroupPointsByPrecisionDifferent()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+                .RespondWith(CreateResponse("{}"));
+
+            var writeApi = _influxDbClient.GetWriteApiAsync();
+            await writeApi.WritePointsAsync("my-org", "my-bucket", new List<PointData>
+            {
+                PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
+                    .Timestamp(9L, WritePrecision.S),
+                PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 10.0D)
+                    .Timestamp(10L, WritePrecision.Ms)
+            });
+
+            Assert.AreEqual(2, MockServer.LogEntries.Count());
+
+            var request = MockServer.LogEntries.ToList()[0];
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=s",
+                request.RequestMessage.AbsoluteUrl);
+            Assert.AreEqual("h2o,location=coyote_creek water_level=9 9",
+                request.RequestMessage.Body);
+
+            request = MockServer.LogEntries.ToList()[1];
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=ms",
+                request.RequestMessage.AbsoluteUrl);
+            Assert.AreEqual("h2o,location=coyote_creek water_level=10 10",
+                request.RequestMessage.Body);
+        }
+    }
+}

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -34,7 +34,7 @@ namespace InfluxDB.Client.Test
                 .RespondWith(CreateResponse("{}"));
 
             var writeApi = _influxDbClient.GetWriteApiAsync();
-            await writeApi.WritePointsAsync("my-org", "my-bucket", new List<PointData>
+            await writeApi.WritePointsAsync("my-bucket", "my-org", new List<PointData>
             {
                 PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
                     .Timestamp(9L, WritePrecision.S),
@@ -45,7 +45,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(1, MockServer.LogEntries.Count());
 
             var request = MockServer.LogEntries.Last();
-            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=s",
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-org&bucket=my-bucket&precision=s",
                 request.RequestMessage.AbsoluteUrl);
             Assert.AreEqual("h2o,location=coyote_creek water_level=9 9\nh2o,location=coyote_creek water_level=10 10",
                 request.RequestMessage.Body);
@@ -59,7 +59,7 @@ namespace InfluxDB.Client.Test
                 .RespondWith(CreateResponse("{}"));
 
             var writeApi = _influxDbClient.GetWriteApiAsync();
-            await writeApi.WritePointsAsync("my-org", "my-bucket", new List<PointData>
+            await writeApi.WritePointsAsync("my-bucket", "my-org", new List<PointData>
             {
                 PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
                     .Timestamp(9L, WritePrecision.S),
@@ -70,13 +70,13 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(2, MockServer.LogEntries.Count());
 
             var request = MockServer.LogEntries.ToList()[0];
-            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=s",
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-org&bucket=my-bucket&precision=s",
                 request.RequestMessage.AbsoluteUrl);
             Assert.AreEqual("h2o,location=coyote_creek water_level=9 9",
                 request.RequestMessage.Body);
 
             request = MockServer.LogEntries.ToList()[1];
-            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-bucket&bucket=my-org&precision=ms",
+            Assert.AreEqual(MockServerUrl + "/api/v2/write?org=my-org&bucket=my-bucket&precision=ms",
                 request.RequestMessage.AbsoluteUrl);
             Assert.AreEqual("h2o,location=coyote_creek water_level=10 10",
                 request.RequestMessage.Body);

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -8,7 +8,6 @@ using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Core.Test;
 using InfluxDB.Client.Writes;
-using Moq;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;


### PR DESCRIPTION
Closes #112

## Proposed Changes

Fixed unnecessary API call when writing collection of DataPoints.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
