### PR TITLE
feat: added IAsyncEnumerable<T> query overloads to QueryAPI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,7 +160,7 @@ workflows:
       - deploy-preview:
           requires:
             - dotnet-2.2
-            - dotnet-2.2-nightly
+            - dotnet-3.1-nightly
             - dotnet-3.0
             - dotnet-3.1
             - dotnet-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,11 +56,16 @@ jobs:
       dotnet-image:
         type: string
         default: &default-dotnet-image "mcr.microsoft.com/dotnet/core/sdk:3.1"
+      dotnet-target-version:
+        type: string
+        default: "netstandard2.1"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:2.0.0-rc"
     docker:
       - image: << parameters.dotnet-image >>
+        environment:
+          NET_TARGET_VERSION: << parameters.dotnet-target-version >>
       - image: &influx-image quay.io/influxdb/<< parameters.influxdb-image >>
         environment:
           INFLUXD_HTTP_BIND_ADDRESS: :9999
@@ -147,6 +152,7 @@ workflows:
       - tests-dotnet:
           name: dotnet-2.2
           dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:2.2"
+          dotnet-target-version: "netstandard2.0"
       - tests-dotnet:
           name: dotnet-3.1-nightly
           influxdb-image: "influx:nightly"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
     parameters:
       dotnet-image:
         type: string
-        default: &default-dotnet-image "mcr.microsoft.com/dotnet/core/sdk:2.2"
+        default: &default-dotnet-image "mcr.microsoft.com/dotnet/core/sdk:3.1"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:2.0.0-rc"
@@ -146,15 +146,15 @@ workflows:
     jobs:
       - tests-dotnet:
           name: dotnet-2.2
+          dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:2.2"
       - tests-dotnet:
-          name: dotnet-2.2-nightly
+          name: dotnet-3.1-nightly
           influxdb-image: "influx:nightly"
       - tests-dotnet:
           name: dotnet-3.0
           dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.0"
       - tests-dotnet:
           name: dotnet-3.1
-          dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.1"
       - tests-windows:
           name: dotnet-windows
       - deploy-preview:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 ## 1.13.0 [unreleased]
 
+### Features
+1. [#121](https://github.com/influxdata/influxdb-client-csharp/pull/121): Added IAsyncEnumerable&lt;T&gt; query overloads to QueryAPI
+
 ## 1.12.0 [2020-10-02]
 
 ### Features
 1. [#117](https://github.com/influxdata/influxdb-client-csharp/issues/117): Added support for string token
+1. [#121](https://github.com/influxdata/influxdb-client-csharp/pull/121): Added IAsyncEnumerable&lt;T&gt; query overloads to QueryAPI
 
 ### API
 1. [#122](https://github.com/influxdata/influxdb-client-csharp/issues/122): Default port changed from 9999 to 8086
 1. [#124](https://github.com/influxdata/influxdb-client-csharp/pull/124): Removed labels in organization API, removed Pkg* structure and package service
+
+### Bug Fixes
+1. [#119](https://github.com/influxdata/influxdb-client-csharp/issues/119): No timestamp returned via POCO based QueryAsync&lt;T&gt;
 
 ## 1.11.0 [2020-08-14]
 

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
         <AssemblyName>InfluxDB.Client.Core.Test</AssemblyName>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+        <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
         
         <Description>InfluxDB Client Core - exceptions, validations, REST client.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
-        
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
+
         <Description>InfluxDB Client Core - exceptions, validations, REST client.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Core</AssemblyName>
@@ -38,5 +39,4 @@
       <PackageReference Include="RestSharp" Version="106.6.10" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
-    
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -39,4 +39,8 @@
       <PackageReference Include="RestSharp" Version="106.6.10" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
+
+    <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">
+      <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.1" />
+    </ItemGroup>
 </Project>

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -12,7 +12,7 @@ namespace InfluxDB.Client.Core.Exceptions
 {
     public class InfluxException : Exception
     {
-        public InfluxException(string message) : this(message, 0)
+        public InfluxException(string message, Exception exception = null) : this(message, 0, exception)
         {
         }
 
@@ -21,7 +21,7 @@ namespace InfluxDB.Client.Core.Exceptions
             Code = 0;
         }
 
-        public InfluxException(string message, int code) : base(message)
+        public InfluxException(string message, int code, Exception exception = null) : base(message, exception)
         {
             Code = code;
             Status = 0;
@@ -40,7 +40,7 @@ namespace InfluxDB.Client.Core.Exceptions
 
     public class HttpException : InfluxException
     {
-        public HttpException(string message, int status) : base(message, 0)
+        public HttpException(string message, int status, Exception exception = null) : base(message, 0, exception)
         {
             Status = status;
         }

--- a/Client.Core/Flux/Domain/FluxRecord.cs
+++ b/Client.Core/Flux/Domain/FluxRecord.cs
@@ -50,7 +50,7 @@ namespace InfluxDB.Client.Core.Flux.Domain
         }
         
         ///<summary>
-        /// The timestamp as a <see cref="Instant"/>
+        /// The timestamp as a <see cref="DateTime"/>
         /// </summary>
         /// <returns>the time of the record</returns>
         public DateTime? GetTimeInDateTime()
@@ -61,7 +61,7 @@ namespace InfluxDB.Client.Core.Flux.Domain
         }
 
         /// <returns>the value of the record</returns>
-        public Object GetValue()
+        public object GetValue()
         {
             return GetValueByKey("_value");
         }

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -1,11 +1,9 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Runtime.CompilerServices;
 using System.Threading;
-using System.Threading.Tasks;
 using CsvHelper;
 using InfluxDB.Client.Core.Flux.Domain;
 using InfluxDB.Client.Core.Flux.Exceptions;
@@ -77,7 +75,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
             Arguments.CheckNotNull(source, "source");
 
             using var csv = new CsvReader(new StreamReader(source), CultureInfo.InvariantCulture);
-            ParseFluxResponseState state = new ParseFluxResponseState { csv = csv };
+            var state = new ParseFluxResponseState { csv = csv };
 
             while (csv.Read())
             {
@@ -106,7 +104,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
             Arguments.CheckNotNull(reader, nameof(reader));
 
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
-            ParseFluxResponseState state = new ParseFluxResponseState { csv = csv };
+            var state = new ParseFluxResponseState { csv = csv };
 
             while (await csv.ReadAsync() && !cancellationToken.IsCancellationRequested)
             {

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -96,7 +96,6 @@ namespace InfluxDB.Client.Core.Flux.Internal
             }
         }
 
-#if NETSTANDARD2_1
         /// <summary>
         /// Parse Flux CSV response to <see cref="IAsyncEnumerable{T}"/>.
         /// </summary>
@@ -115,7 +114,6 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     yield return response;   
             }
         }
-#endif
 
         private class ParseFluxResponseState
         {

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -155,7 +155,12 @@ namespace InfluxDB.Client.Core.Flux.Internal
                 return instant.InUtc().ToDateTimeUtc();
             }
 
-            return (DateTime) value;
+            if (value is IConvertible)
+            {
+                return (DateTime)Convert.ChangeType(value, typeof(DateTime));
+            }
+
+            throw new InvalidCastException($"Object value of type {value.GetType().Name} cannot be converted to {nameof(DateTime)}");
         }
 
         private Instant ToInstantValue(object value)
@@ -170,7 +175,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
                 return Instant.FromDateTimeUtc(dateTime);
             }
 
-            return (Instant) value;
+            throw new InvalidCastException($"Object value of type {value.GetType().Name} cannot be converted to {nameof(Instant)}");
         }
     }
 }

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -110,85 +110,57 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     return;
                 }
 
-                //convert primitives
-                if (typeof(double).IsAssignableFrom(propertyType))
-                {
-                    property.SetValue(poco, ToDoubleValue(value));
-                    return;
-                }
-
-                if (typeof(long).IsAssignableFrom(propertyType))
-                {
-                    property.SetValue(poco, ToLongValue(value));
-                    return;
-                }
-
-                if (typeof(int).IsAssignableFrom(propertyType))
-                {
-                    property.SetValue(poco, ToIntValue(value));
-                    return;
-                }
-
-                if (typeof(bool).IsAssignableFrom(propertyType))
-                {
-                    property.SetValue(poco, bool.TryParse(value.ToString(), out var v) && v);
-                    return;
-                }
-
-                if (typeof(DateTime).IsAssignableFrom(propertyType))
+                //handle time primitives
+                if (propertyType == typeof(DateTime))
                 {
                     property.SetValue(poco, ToDateTimeValue(value));
                     return;
                 }
 
-                property.SetValue(poco, value);
+                if (propertyType == typeof(Instant))
+                {
+                    property.SetValue(poco, ToInstantValue(value));
+                    return;
+                }
+
+                property.SetValue(poco, Convert.ChangeType(value, propertyType));
             }
-            catch (InvalidCastException)
+            catch (InvalidCastException ex)
             {
                 throw new InfluxException(
-                    $"Class '{poco.GetType().Name}' field '{property.Name}' was defined with a different field type and caused a InvalidCastException. " +
-                    $"The correct type is '{value.GetType().Name}' (current field value: '{value}').");
+                    $"Class '{poco.GetType().Name}' field '{property.Name}' was defined with a different field type and caused an exception. " +
+                    $"The correct type is '{value.GetType().Name}' (current field value: '{value}'). Exception: {ex.Message}", ex);
             }
         }
 
-        private double ToDoubleValue(object value)
-        {
-            if (value.GetType().IsAssignableFrom(typeof(double)))
-            {
-                return (double) value;
-            }
-
-            return (double) value;
-        }
-
-        private long ToLongValue(object value)
-        {
-            if (value.GetType().IsAssignableFrom(typeof(long)))
-            {
-                return (long) value;
-            }
-
-            return (long) value;
-        }
-
-        private int ToIntValue(object value)
-        {
-            if (value.GetType().IsAssignableFrom(typeof(int)))
-            {
-                return (int) value;
-            }
-
-            return (int) value;
-        }
-        
         private DateTime ToDateTimeValue(object value)
         {
+            if (value is DateTime dateTime)
+            {
+                return dateTime;
+            }
+
             if (value is Instant instant)
             {
                 return instant.InUtc().ToDateTimeUtc();
             }
-            
+
             return (DateTime) value;
+        }
+
+        private Instant ToInstantValue(object value)
+        {
+            if (value is Instant instant)
+            {
+                return instant;
+            }
+
+            if (value is DateTime dateTime)
+            {
+                return Instant.FromDateTimeUtc(dateTime);
+            }
+
+            return (Instant) value;
         }
     }
 }

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -53,7 +53,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
 
                     if (attribute != null && attribute.IsTimestamp)
                     {
-                        SetFieldValue(poco, property, record.GetTimeInDateTime());
+                        SetFieldValue(poco, property, record.GetTime());
                     }
                     else
                     {

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -45,7 +45,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
 
                 foreach (var property in properties)
                 {
-                    Column attribute = AttributeCache.GetOrAdd(property, _ =>
+                    var attribute = AttributeCache.GetOrAdd(property, _ =>
                     {
                         var attributes = property.GetCustomAttributes(typeof(Column), false);
                         return attributes.Length > 0 ? attributes[0] as Column : null;

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -127,7 +127,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
                 {
                     // Nullable types cannot be used in type conversion, but we can use Nullable.GetUnderlyingType()
                     // to determine whether the type is nullable and convert to the underlying type instead
-                    Type targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+                    var targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
                     property.SetValue(poco, Convert.ChangeType(value, targetType));
                 }
                 else

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -123,7 +123,17 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     return;
                 }
 
-                property.SetValue(poco, Convert.ChangeType(value, propertyType));
+                if (value is IConvertible)
+                {
+                    // Nullable types cannot be used in type conversion, but we can use Nullable.GetUnderlyingType()
+                    // to determine whether the type is nullable and convert to the underlying type instead
+                    Type targetType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
+                    property.SetValue(poco, Convert.ChangeType(value, targetType));
+                }
+                else
+                {
+                    property.SetValue(poco, value);
+                }
             }
             catch (InvalidCastException ex)
             {

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -105,7 +105,7 @@ namespace InfluxDB.Client.Core.Internal
             }
         }
 
-        protected async IAsyncEnumerable<T> QueryRecords<T>(RestRequest query, [EnumeratorCancellation] CancellationToken cancellationToken)
+        protected async IAsyncEnumerable<T> QueryEnumerable<T>(RestRequest query, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             Arguments.CheckNotNull(query, nameof(query));
 

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -117,7 +117,7 @@ namespace InfluxDB.Client.Core.Internal
 
             RaiseForInfluxError(response, response.Content);
 
-            await foreach((FluxTable _, FluxRecord record) in _csvParser.ParseFluxResponseAsync(new StringReader(response.Content), cancellationToken))
+            await foreach(var (_, record) in _csvParser.ParseFluxResponseAsync(new StringReader(response.Content), cancellationToken))
             {
                 if (!(record is null))
                     yield return Mapper.ToPoco<T>(record);

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -105,7 +105,6 @@ namespace InfluxDB.Client.Core.Internal
             }
         }
 
-#if NETSTANDARD2_1
         protected async IAsyncEnumerable<T> QueryRecords<T>(RestRequest query, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             Arguments.CheckNotNull(query, nameof(query));
@@ -124,7 +123,6 @@ namespace InfluxDB.Client.Core.Internal
                     yield return Mapper.ToPoco<T>(record);
             }
         }
-#endif
 
         protected abstract void BeforeIntercept(RestRequest query);
 

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
         

--- a/Client.Legacy.Test/FluxCsvParserTest.cs
+++ b/Client.Legacy.Test/FluxCsvParserTest.cs
@@ -431,7 +431,6 @@ namespace Client.Legacy.Test
             Assert.That(records.Count == 2);
         }
 
-#if NETCOREAPP3_1
         [Test]
         public async Task ParsingToAsyncEnumerable()
         {
@@ -453,7 +452,6 @@ namespace Client.Legacy.Test
 
             Assert.That(records.Count == 2);
         }
-#endif
 
         [Test]
         public void CancelParsing()
@@ -483,7 +481,6 @@ namespace Client.Legacy.Test
             Assert.That(records.Count == 1);
         }
 
-#if NETCOREAPP3_1
         [Test]
         public async Task CancelParsingAsync()
         {
@@ -510,7 +507,6 @@ namespace Client.Legacy.Test
 
             Assert.That(records.Count == 1);
         }
-#endif
 
         [Test]
         public void ParseDifferentSchemas()

--- a/Client.Legacy.Test/FluxResultMapperTest.cs
+++ b/Client.Legacy.Test/FluxResultMapperTest.cs
@@ -1,6 +1,8 @@
+using System;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Flux.Domain;
 using InfluxDB.Client.Core.Flux.Internal;
+using NodaTime;
 using NUnit.Framework;
 
 namespace Client.Legacy.Test
@@ -36,6 +38,66 @@ namespace Client.Legacy.Test
 
             [Column("region")]
             public string DifferentName { get; set; }
+        }
+
+        [Test]
+        public void MapTimestampWithInstantTime()
+        {
+            var now = DateTime.UtcNow;
+
+            var fluxRecord = new FluxRecord(0);
+            fluxRecord.Values["tag"] = "production";
+            fluxRecord.Values["min"] = 10.5;
+            fluxRecord.Values["max"] = 20.0;
+            fluxRecord.Values["avg"] = 18.0D;
+            fluxRecord.Values["_time"] = Instant.FromDateTimeUtc(now);
+
+            var poco = _parser.ToPoco<PointWithoutTimestampNameInstant>(fluxRecord);
+
+            Assert.AreEqual("production", poco.Tag);
+            Assert.AreEqual(10.5, poco.Minimum);
+            Assert.AreEqual(20, poco.Maximum);
+            Assert.AreEqual(18, poco.Average);
+            Assert.AreEqual(Instant.FromDateTimeUtc(now), poco.Timestamp);
+        }
+
+        private class PointWithoutTimestampNameInstant
+        {
+            [Column("tag", IsTag = true)] public string Tag { get; set; }
+            [Column("min")] public double Minimum { get; set; }
+            [Column("max")] public double Maximum { get; set; }
+            [Column("avg")] public double Average { get; set; }
+            [Column(IsTimestamp = true)] public Instant Timestamp { get; set; }
+        }
+
+        [Test]
+        public void MapTimestampDifferentName()
+        {
+            var now = DateTime.UtcNow;
+
+            var fluxRecord = new FluxRecord(0);
+            fluxRecord.Values["tag"] = "production";
+            fluxRecord.Values["min"] = 10.5;
+            fluxRecord.Values["max"] = 20.0;
+            fluxRecord.Values["avg"] = (Double)18;
+            fluxRecord.Values["_time"] = Instant.FromDateTimeUtc(now);
+
+            var poco = _parser.ToPoco<PointWithoutTimestampName>(fluxRecord);
+
+            Assert.AreEqual("production", poco.Tag);
+            Assert.AreEqual(10.5, poco.Minimum);
+            Assert.AreEqual(20, poco.Maximum);
+            Assert.AreEqual(18, poco.Average);
+            Assert.AreEqual(now, poco.Timestamp);
+        }
+
+        private class PointWithoutTimestampName
+        {
+            [Column("tag", IsTag = true)] public string Tag { get; set; }
+            [Column("min")] public double Minimum { get; set; }
+            [Column("max")] public double Maximum { get; set; }
+            [Column("avg")] public Double Average { get; set; }
+            [Column(IsTimestamp = true)] public DateTime Timestamp { get; set; }
         }
     }
 }

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 
-        <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
+      <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Flux</AssemblyName>
         <VersionPrefix>1.13.0</VersionPrefix>
@@ -27,8 +27,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath=""/>
-        <ProjectReference Include="..\Client.Core\Client.Core.csproj"/>
+        <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath="" />
+        <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Client.Test/AbstractItClientTest.cs
+++ b/Client.Test/AbstractItClientTest.cs
@@ -47,7 +47,7 @@ namespace InfluxDB.Client.Test
         protected async Task<Organization> FindMyOrg()
         {
             return (await Client.GetOrganizationsApi().FindOrganizationsAsync())
-                .First(organization => organization.Name.Equals("my-org"));
+                .FirstOrDefault(organization => organization.Name.Equals("my-org"));
         }
     }
 }

--- a/Client.Test/AbstractItClientTest.cs
+++ b/Client.Test/AbstractItClientTest.cs
@@ -46,8 +46,12 @@ namespace InfluxDB.Client.Test
 
         protected async Task<Organization> FindMyOrg()
         {
-            return (await Client.GetOrganizationsApi().FindOrganizationsAsync())
+            var org = (await Client.GetOrganizationsApi().FindOrganizationsAsync())
                 .FirstOrDefault(organization => organization.Name.Equals("my-org"));
+
+            Assert.IsNotNull(org, "my-org is required for integration tests");
+
+            return org;
         }
     }
 }

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
         <RootNamespace>InfluxDB.Client.Test</RootNamespace>

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -9,6 +9,7 @@ using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Core.Test;
 using InfluxDB.Client.Writes;
 using NUnit.Framework;
+using RestSharp.Extensions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 
@@ -73,7 +74,12 @@ namespace InfluxDB.Client.Test
                 _events.RemoveAt(0);
                 Trace.WriteLine(args);
 
-                return (T) Convert.ChangeType(args, typeof(T));
+                if (args is T result)
+                {
+                    return result;
+                }
+
+                throw new InvalidCastException($"{args.GetType().FullName} cannot be cast to {typeof(T).FullName}");
             }
 
             internal int EventCount()

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -9,7 +9,6 @@ using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Core.Test;
 using InfluxDB.Client.Writes;
 using NUnit.Framework;
-using RestSharp.Extensions;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -58,7 +58,7 @@ namespace InfluxDB.Client.Test
                 };
             }
 
-            internal T Get<T>()
+            internal T Get<T>() where T : EventArgs
             {
                 if (_events.Count == 0)
                 {

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
+      <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
 
-        <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.0.</Description>
+      <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.0.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client</AssemblyName>
         <VersionPrefix>1.13.0</VersionPrefix>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.1;netstandard2.0</TargetFrameworks>
+      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+      <LangVersion>8</LangVersion>
 
       <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.0.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Reactive.Disposables;
+using System.Runtime.CompilerServices;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -131,7 +134,7 @@ namespace InfluxDB.Client
         ///
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsyncAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
@@ -151,7 +154,7 @@ namespace InfluxDB.Client
         ///
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsyncAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
@@ -167,13 +170,53 @@ namespace InfluxDB.Client
             return await QueryAsync<T>(CreateQuery(query), org);
         }
 
+#if NETSTANDARD2_1
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously maps
+        /// response to enumerable of objects of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public async IAsyncEnumerable<T> QueryRecordsAsync<T>(string query, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+
+            var requestMessage = CreateRequest(CreateQuery(query), _options.Org);
+
+            await foreach (T record in QueryRecords<T>(requestMessage, cancellationToken))
+                yield return record;
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously maps
+        /// response to enumerable of objects of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public async IAsyncEnumerable<T> QueryRecordsAsync<T>(string query, string org, [EnumeratorCancellation] CancellationToken cancellationToken)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNonEmptyString(org, nameof(org));
+
+            var requestMessage = CreateRequest(CreateQuery(query), org);
+
+            await foreach (T record in QueryRecords<T>(requestMessage, cancellationToken))
+                yield return record;
+        }
+#endif
+
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to list of object with given type.
         ///
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsyncAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
@@ -193,7 +236,7 @@ namespace InfluxDB.Client
         ///
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsyncAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -183,7 +183,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), _options.Org);
 
-            await foreach (T record in QueryEnumerable<T>(requestMessage, cancellationToken))
+            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken))
                 yield return record;
         }
 
@@ -203,7 +203,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), org);
 
-            await foreach (T record in QueryEnumerable<T>(requestMessage, cancellationToken))
+            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken))
                 yield return record;
         }
 

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -183,7 +183,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), _options.Org);
 
-            await foreach (T record in QueryRecords<T>(requestMessage, cancellationToken))
+            await foreach (T record in QueryEnumerable<T>(requestMessage, cancellationToken))
                 yield return record;
         }
 
@@ -203,7 +203,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), org);
 
-            await foreach (T record in QueryRecords<T>(requestMessage, cancellationToken))
+            await foreach (T record in QueryEnumerable<T>(requestMessage, cancellationToken))
                 yield return record;
         }
 

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -169,7 +169,6 @@ namespace InfluxDB.Client
             return await QueryAsync<T>(CreateQuery(query), org);
         }
 
-#if NETSTANDARD2_1
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and asynchronously maps
         /// response to enumerable of objects of type <typeparamref name="T"/>.
@@ -207,7 +206,6 @@ namespace InfluxDB.Client
             await foreach (T record in QueryRecords<T>(requestMessage, cancellationToken))
                 yield return record;
         }
-#endif
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -177,7 +177,7 @@ namespace InfluxDB.Client
         /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async IAsyncEnumerable<T> QueryRecordsAsync<T>(string query, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<T> QueryAsyncEnumerable<T>(string query, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
@@ -196,7 +196,7 @@ namespace InfluxDB.Client
         /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async IAsyncEnumerable<T> QueryRecordsAsync<T>(string query, string org, [EnumeratorCancellation] CancellationToken cancellationToken)
+        public async IAsyncEnumerable<T> QueryAsyncEnumerable<T>(string query, string org, [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Reactive.Disposables;
 using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -2,7 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <LangVersion>8</LangVersion>
         <VersionPrefix>1.13.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
         <IsPackable>false</IsPackable>

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -9,9 +9,9 @@ NET_VERSION=`dotnet --version | awk -F. '{printf "netcoreapp"$1"."$2;}'`
 
 echo "$NET_VERSION"
 
-sed -i '/<TargetFramework>netcoreapp2.2<\/TargetFramework>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
-sed -i '/<TargetFramework>netcoreapp2.2<\/TargetFramework>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
-sed -i '/<TargetFramework>netcoreapp2.2<\/TargetFramework>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
 
 #
 # Install testing tools

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -14,6 +14,7 @@ NET_TARGET_VERSION="${NET_TARGET_VERSION:-$DEFAULT_NET_TARGET_VERSION}"
 sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
 sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
 sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Examples/Examples.csproj
 
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client/Client.csproj

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -5,17 +5,19 @@ set -e
 #
 # Prepare compatible version
 #
-NET_VERSION=`dotnet --version | awk -F. '{printf "netcoreapp"$1"."$2;}'`
+NET_TEST_VERSION=$(dotnet --version | awk -F. '{printf "netcoreapp"$1"."$2;}')
+echo "$NET_TEST_VERSION"
 
-echo "$NET_VERSION"
+DEFAULT_NET_TARGET_VERSION="netstandard2.1"
+NET_TARGET_VERSION="${NET_TARGET_VERSION:-$DEFAULT_NET_TARGET_VERSION}"
 
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
 
-sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
-sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client/Client.csproj
-sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy/Client.Legacy.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client/Client.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Legacy/Client.Legacy.csproj
 
 #
 # Install testing tools

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -13,6 +13,10 @@ sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<Ta
 sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
 sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
 
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client/Client.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_VERSION}"'<\/TargetFramework>' Client.Legacy/Client.Legacy.csproj
+
 #
 # Install testing tools
 #


### PR DESCRIPTION
This adds [`IAsyncEnumerable<T>`](https://docs.microsoft.com/en-us/archive/msdn-magazine/2019/november/csharp-iterating-with-async-enumerables-in-csharp-8) support to the QueryAPI for .NET Standard 2.1 deployments. To support .NET Standard 2.1, client and client projects were modified to dual target .NET standard 2.1 and 2.0.

Closes #119 - both timestamp issue and suggested `IAsyncEnumerable` feature

