### PR TITLE
feat: add exponential backoff strategy for retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#121](https://github.com/influxdata/influxdb-client-csharp/pull/121): Added IAsyncEnumerable&lt;T&gt; query overloads to QueryAPI
+1. [#127](https://github.com/influxdata/influxdb-client-csharp/pull/127): Added exponential backoff strategy for batching writes. Default value for `RetryInterval` is 5_000 milliseconds.
 
 ## 1.12.0 [2020-10-02]
 

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -61,17 +61,20 @@ namespace InfluxDB.Client.Core.Exceptions
 
             var httpHeaders = LoggingHandler.ToHeaders(requestResult.Headers);
             
-            return Create(body, httpHeaders, requestResult.ErrorMessage, requestResult.StatusCode);
+            return Create(body, httpHeaders, requestResult.ErrorMessage, requestResult.StatusCode, 
+                requestResult.ErrorException);
         }
 
         public static HttpException Create(IHttpResponse requestResult, object body)
         {
             Arguments.CheckNotNull(requestResult, nameof(requestResult));
 
-            return Create(body, requestResult.Headers, requestResult.ErrorMessage, requestResult.StatusCode);
+            return Create(body, requestResult.Headers, requestResult.ErrorMessage, requestResult.StatusCode, 
+                requestResult.ErrorException);
         }
         
-        public static HttpException Create(object content, IList<HttpHeader> headers, string ErrorMessage, HttpStatusCode statusCode)
+        public static HttpException Create(object content, IList<HttpHeader> headers, string ErrorMessage, 
+            HttpStatusCode statusCode, Exception exception = null)
         {
             string stringBody = null;
             var errorBody = new JObject();
@@ -123,7 +126,7 @@ namespace InfluxDB.Client.Core.Exceptions
             if (string.IsNullOrEmpty(errorMessage)) errorMessage = ErrorMessage;
             if (string.IsNullOrEmpty(errorMessage)) errorMessage = stringBody;
 
-            return new HttpException(errorMessage, (int) statusCode)
+            return new HttpException(errorMessage, (int) statusCode, exception)
                 {ErrorBody = errorBody, RetryAfter = retryAfter};
         }
     }

--- a/Client.Test/RetryAttemptTest.cs
+++ b/Client.Test/RetryAttemptTest.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.Net;
+using InfluxDB.Client.Core.Exceptions;
+using InfluxDB.Client.Internal;
+using NUnit.Framework;
+using RestSharp;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class RetryAttemptTest
+    {
+        private readonly WriteOptions _default = WriteOptions.CreateNew().Build();
+
+        [Test]
+        public void ErrorType()
+        {
+            var retry = new RetryAttempt(new ArgumentException(""), 1, _default);
+            Assert.IsFalse(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new WebException("", WebExceptionStatus.Timeout), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 0, new WebException("", WebExceptionStatus.Timeout)), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+            
+            retry = new RetryAttempt(new WebException("", WebExceptionStatus.ProtocolError), 1, _default);
+            Assert.IsFalse(retry.IsRetry());
+        }
+
+        [Test]
+        public void RetryableHttpErrorCodes()
+        {
+            var retry = new RetryAttempt(new HttpException("", 428), 1, _default);
+            Assert.IsFalse(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 504), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+        }
+
+        [Test]
+        public void MaxRetries()
+        {
+            var options = WriteOptions.CreateNew().MaxRetries(5).Build();
+
+            var retry = new RetryAttempt(new HttpException("", 429), 1, _default);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 2, options);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 3, options);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 4, options);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 5, options);
+            Assert.IsTrue(retry.IsRetry());
+
+            retry = new RetryAttempt(new HttpException("", 429), 6, options);
+            Assert.IsFalse(retry.IsRetry());
+        }
+
+        [Test]
+        public void HeaderHasPriority()
+        {
+            var exception = CreateException();
+
+            var retry = new RetryAttempt(exception, 1, _default);
+            Assert.AreEqual(10_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 1, _default);
+            Assert.AreEqual(5_000, retry.GetRetryInterval());
+        }
+
+        [Test]
+        public void ExponentialBase()
+        {
+            var options = WriteOptions.CreateNew()
+                .RetryInterval(5_000)
+                .ExponentialBase(5)
+                .MaxRetryDelay(int.MaxValue)
+                .Build();
+
+            var retry = new RetryAttempt(new HttpException("", 429), 1, options);
+            Assert.AreEqual(5_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 2, options);
+            Assert.AreEqual(25_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 3, options);
+            Assert.AreEqual(125_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 4, options);
+            Assert.AreEqual(625_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 5, options);
+            Assert.AreEqual(3_125_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 6, options);
+            Assert.AreEqual(15_625_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(CreateException(3), 7, options);
+            Assert.AreEqual(3_000, retry.GetRetryInterval());
+        }
+
+        [Test]
+        public void MaxRetryDelay()
+        {
+            var options = WriteOptions.CreateNew()
+                .RetryInterval(2_000)
+                .ExponentialBase(2)
+                .MaxRetryDelay(50_000)
+                .Build();
+
+            var retry = new RetryAttempt(new HttpException("", 429), 1, options);
+            Assert.AreEqual(2_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 2, options);
+            Assert.AreEqual(4_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 3, options);
+            Assert.AreEqual(8_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 4, options);
+            Assert.AreEqual(16_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 5, options);
+            Assert.AreEqual(32_000, retry.GetRetryInterval());
+
+            retry = new RetryAttempt(new HttpException("", 429), 6, options);
+            Assert.AreEqual(50_000, retry.GetRetryInterval());
+        }
+
+        private HttpException CreateException(int retryAfter = 10)
+        {
+            var headers = new List<HttpHeader> {new HttpHeader {Name = "Retry-After", Value = retryAfter.ToString()}};
+            var exception = HttpException.Create("", headers, "", HttpStatusCode.TooManyRequests);
+            return exception;
+        }
+    }
+}

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -21,7 +21,7 @@ namespace InfluxDB.Client.Test
         public new void SetUp()
         {
             _influxDbClient = InfluxDBClientFactory.Create(MockServerUrl, "token");
-            _writeApi = _influxDbClient.GetWriteApi();
+            _writeApi = _influxDbClient.GetWriteApi(WriteOptions.CreateNew().RetryInterval(1_000).Build());
         }
 
         [TearDown]
@@ -337,6 +337,33 @@ namespace InfluxDB.Client.Test
             var request= MockServer.LogEntries.Last();
             StringAssert.StartsWith("influxdb-client-csharp/1.", request.RequestMessage.Headers["User-Agent"].First());
             StringAssert.EndsWith(".0.0", request.RequestMessage.Headers["User-Agent"].First());
+        }
+
+        [Test]
+        public void WriteOptionsDefaults()
+        {
+            var options = WriteOptions.CreateNew().Build();
+            
+            Assert.AreEqual(5_000, options.RetryInterval);
+            Assert.AreEqual(3, options.MaxRetries);
+            Assert.AreEqual(180_000, options.MaxRetryDelay);
+            Assert.AreEqual(5, options.ExponentialBase);
+        }
+
+        [Test]
+        public void WriteOptionsCustom()
+        {
+            var options = WriteOptions.CreateNew()
+                .RetryInterval(1_250)
+                .MaxRetries(25)
+                .MaxRetryDelay(1_800_000)
+                .ExponentialBase(2)
+                .Build();
+            
+            Assert.AreEqual(1_250, options.RetryInterval);
+            Assert.AreEqual(25, options.MaxRetries);
+            Assert.AreEqual(1_800_000, options.MaxRetryDelay);
+            Assert.AreEqual(2, options.ExponentialBase);
         }
     }
 }

--- a/Client/Internal/RetryAttempt.cs
+++ b/Client/Internal/RetryAttempt.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Net;
+using InfluxDB.Client.Core.Exceptions;
+
+namespace InfluxDB.Client.Internal
+{
+    /// <summary>
+    /// RetryConfiguration.
+    /// </summary>
+    internal class RetryAttempt
+    {
+        private static readonly ReadOnlyCollection<WebExceptionStatus> RetryableStatuses =
+            new ReadOnlyCollection<WebExceptionStatus>(
+                new[]
+                {
+                    WebExceptionStatus.ConnectFailure,
+                    WebExceptionStatus.NameResolutionFailure,
+                    WebExceptionStatus.ProxyNameResolutionFailure,
+                    WebExceptionStatus.SendFailure,
+                    WebExceptionStatus.PipelineFailure,
+                    WebExceptionStatus.ConnectionClosed,
+                    WebExceptionStatus.KeepAliveFailure,
+                    WebExceptionStatus.UnknownError,
+                    WebExceptionStatus.ReceiveFailure,
+                    WebExceptionStatus.RequestCanceled,
+                    WebExceptionStatus.Timeout,
+                });
+
+        internal Exception Error { get; }
+        private readonly int _count;
+        private readonly WriteOptions _writeOptions;
+
+        internal RetryAttempt(Exception error, int count, WriteOptions writeOptions)
+        {
+            Error = error;
+            _count = count;
+            _writeOptions = writeOptions;
+        }
+
+        /// <summary>
+        /// Is this request retryable?
+        /// </summary>
+        /// <returns>true if its retryable otherwise false</returns>
+        internal bool IsRetry()
+        {
+            //
+            // Max retries exceeded.
+            //
+            if (_count > _writeOptions.MaxRetries)
+            {
+                Trace.TraceWarning($"Max write retries exceeded. Response: '{Error.Message}'.");
+
+                return false;
+            }
+
+            if (Error is HttpException httpException && httpException.Status > 0)
+            {
+                //
+                // Retry HTTP error codes >= 429
+                //
+                return httpException.Status >= 429;
+            }
+
+            var webException = GetWebException(Error);
+
+            if (webException != null)
+            {
+                if (RetryableStatuses.Contains(webException.Status))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Get current retry interval.
+        /// </summary>
+        /// <returns>retry interval to sleep</returns>
+        internal long GetRetryInterval()
+        {
+            long retryInterval;
+
+            // from header
+            if (Error is HttpException httpException && httpException.RetryAfter.HasValue)
+            {
+                retryInterval = httpException.RetryAfter.Value * 1000;
+            }
+            // from configuration
+            else
+            {
+                retryInterval = _writeOptions.RetryInterval
+                                * (long) (Math.Pow(_writeOptions.ExponentialBase, _count - 1));
+                retryInterval = Math.Min(retryInterval, _writeOptions.MaxRetryDelay);
+
+                Trace.WriteLine($"The InfluxDB does not specify \"Retry-After\". " +
+                                $"Use the default retryInterval: {retryInterval}");
+            }
+
+            retryInterval += JitterDelay(_writeOptions);
+
+            return retryInterval;
+        }
+
+        internal static int JitterDelay(WriteOptions writeOptions)
+        {
+            return (int) (new Random().NextDouble() * writeOptions.JitterInterval);
+        }
+
+        private WebException GetWebException(Exception exception)
+        {
+            switch (exception)
+            {
+                case null:
+                    return null;
+                case WebException webException:
+                    return webException;
+                default:
+                    return GetWebException(exception.InnerException);
+            }
+        }
+    }
+}

--- a/Client/README.md
+++ b/Client/README.md
@@ -320,7 +320,10 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | **BatchSize** | the number of data point to collect in batch | 1000 |
 | **FlushInterval** | the number of milliseconds before the batch is written | 1000 |
 | **JitterInterval** | the number of milliseconds to increase the batch flush interval by a random amount| 0 |
-| **RetryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
+| **RetryInterval** | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 5000 |
+| **MaxRetries** | the number of max retries when write fails | 3 |
+| **MaxRetryDelay** | the maximum delay between each retry attempt in milliseconds | 180_000 |
+| **ExponentialBase** |  the base for the exponential retry delay, the next delay is computed as `RetryInterval * ExponentialBase^(attempts-1) + random(JitterInterval)` | 5 |
 
 ### Writing data
 


### PR DESCRIPTION
## Proposed Changes

1. default value for `RetryInterval` is 5_000
1. added exponential backoff strategy for batch writes
   1. added `MaxRetries` - the number of max retries when write fails - `3`
   1. added `MaxRetryDelay` -  the maximum delay between each retry attempt in milliseconds - `180_000`
   1. added `ExponentialBase` -  the base for the exponential retry delay, the next delay is computed as `RetryInterval * ExponentialBase^(attempts-1) + random(JitterInterval)` 
   1. retry also network strategy
1. other http request doesn't have retry strategy

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
