### PR TITLE
feat: improved logging message for retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#121](https://github.com/influxdata/influxdb-client-csharp/pull/121): Added IAsyncEnumerable&lt;T&gt; query overloads to QueryAPI
 1. [#127](https://github.com/influxdata/influxdb-client-csharp/pull/127): Added exponential backoff strategy for batching writes. Default value for `RetryInterval` is 5_000 milliseconds.
+1. [#128](https://github.com/influxdata/influxdb-client-csharp/pull/128): Improved logging message for retries
 
 ## 1.12.0 [2020-10-02]
 

--- a/Client.Test/AbstractItClientTest.cs
+++ b/Client.Test/AbstractItClientTest.cs
@@ -46,7 +46,7 @@ namespace InfluxDB.Client.Test
 
         protected async Task<Organization> FindMyOrg()
         {
-            var org = (await Client.GetOrganizationsApi().FindOrganizationsAsync())
+            var org = (await Client.GetOrganizationsApi().FindOrganizationsAsync(100))
                 .FirstOrDefault(organization => organization.Name.Equals("my-org"));
 
             Assert.IsNotNull(org, "my-org is required for integration tests");

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -367,7 +367,7 @@ namespace InfluxDB.Client.Test
 
             const string message = "The retriable error occurred during writing of data. " +
                                    "Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. " +
-                                   "Retry in: 5000ms.";
+                                   "Retry in: 5s.";
             StringAssert.Contains(message, writer.ToString());
         }
 

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -319,6 +319,58 @@ namespace InfluxDB.Client.Test
             listener.Get<WriteRetriableErrorEvent>();
         }
 
+
+        [Test]
+        public void RetryContainsMessage()
+        {
+            MockServer.Reset();
+            _writeApi.Dispose();
+
+            const string json = "{\"code\":\"too many requests\"," +
+                                "\"message\":\"org 04014de4ed590000 has exceeded limited_write plan limit\"}";
+            var response = CreateResponse(
+                    json,
+                    "application/json")
+                .WithHeader("Retry-After", "5")
+                .WithStatusCode(429);
+
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+                .InScenario("RetryWithRetryAfter")
+                .WillSetStateTo("RetryWithRetryAfter Started")
+                .RespondWith(response);
+
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+                .InScenario("RetryWithRetryAfter")
+                .WhenStateIs("RetryWithRetryAfter Started")
+                .WillSetStateTo("RetryWithRetryAfter Finished")
+                .RespondWith(CreateResponse("{}"));
+            
+            var options = WriteOptions.CreateNew()
+                .BatchSize(1)
+                .RetryInterval(100)
+                .MaxRetries(1)
+                .Build();
+            _writeApi = _influxDbClient.GetWriteApi(options);
+            
+            var listener = new EventListener(_writeApi);
+            
+            var writer = new StringWriter();
+            Trace.Listeners.Add(new TextWriterTraceListener(writer));
+            
+            _writeApi.WriteRecord("b1", "org1", WritePrecision.Ns,
+                "h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1");
+            
+            // One attempt
+            listener.Get<WriteRetriableErrorEvent>();
+
+            const string message = "The retriable error occurred during writing of data. " +
+                                   "Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. " +
+                                   "Retry in: 5000ms.";
+            StringAssert.Contains(message, writer.ToString());
+        }
+
         [Test]
         public void TwiceDispose()
         {

--- a/Client/OrganizationsApi.cs
+++ b/Client/OrganizationsApi.cs
@@ -126,10 +126,11 @@ namespace InfluxDB.Client
         /// <summary>
         /// List all organizations.
         /// </summary>
+        /// <param name="limit"> (optional, default to 20)</param>
         /// <returns>List all organizations</returns>
-        public async Task<List<Organization>> FindOrganizationsAsync()
+        public async Task<List<Organization>> FindOrganizationsAsync(int? limit = null)
         {
-            return (await _service.GetOrgsAsync()).Orgs;
+            return (await _service.GetOrgsAsync(limit: limit)).Orgs;
         }
 
         /// <summary>

--- a/Client/Writes/Events.cs
+++ b/Client/Writes/Events.cs
@@ -66,9 +66,9 @@ namespace InfluxDB.Client.Writes
         {
             var message = "The retriable error occurred during writing of data. " +
                           $"Reason: '{Exception.Message}'. " +
-                          $"Retry in: {RetryInterval}ms.";
+                          $"Retry in: {(double) RetryInterval / 1000}s.";
             
-            Trace.TraceError(message);
+            Trace.TraceWarning(message);
         }
     }
 

--- a/Client/Writes/Events.cs
+++ b/Client/Writes/Events.cs
@@ -64,7 +64,11 @@ namespace InfluxDB.Client.Writes
         
         internal override void LogEvent()
         {
-            Trace.TraceError($"The retriable error occurred during writing of data. Retry in: {RetryInterval} [ms]");
+            var message = "The retriable error occurred during writing of data. " +
+                          $"Reason: '{Exception.Message}'. " +
+                          $"Retry in: {RetryInterval}ms.";
+            
+            Trace.TraceError(message);
         }
     }
 


### PR DESCRIPTION
## Proposed Changes

The message looks like:

 _The retriable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in 5000ms._


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
