### PR TITLE
fix: validate configuration when is client configured via file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.15.0 [unreleased]
 
+### Bug Fixes
+1. [#143](https://github.com/influxdata/influxdb-client-csharp/pull/143): Added validation that a configuration is present when is client configured via file
+
 ### CI
  1. [#140](https://github.com/influxdata/influxdb-client-csharp/pull/140): Updated default docker image to v2.0.3
 

--- a/Client.Test/App.config
+++ b/Client.Test/App.config
@@ -2,6 +2,7 @@
 <configuration>
     <configSections>
         <section name="influx2" type="InfluxDB.Client.Configurations.Influx2, InfluxDB.Client" />
+        <section name="influx2-without-url" type="InfluxDB.Client.Configurations.Influx2, InfluxDB.Client" />
     </configSections>
     <appSettings>
         <add key="SensorVersion" value="v1.00"/>
@@ -20,4 +21,10 @@
             <tag name="version" value="${SensorVersion}"/>
         </tags>
     </influx2>
+    <influx2-without-url org="my-org"
+                         bucket="my-bucket"
+                         token="my-token"
+                         logLevel="BODY"
+                         readWriteTimeout="5s"
+                         timeout="10s" />
 </configuration>

--- a/Client.Test/ItWriteApiRaceTest.cs
+++ b/Client.Test/ItWriteApiRaceTest.cs
@@ -1,16 +1,9 @@
-using System;
 using System.Collections.Generic;
-using System.Configuration;
-using System.Diagnostics;
-using System.Linq;
 using System.Threading;
+using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
-using InfluxDB.Client.Core;
 using InfluxDB.Client.Writes;
-using NodaTime;
 using NUnit.Framework;
-using Duration = NodaTime.Duration;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {
@@ -58,11 +51,6 @@ namespace InfluxDB.Client.Test
         [Test]
         public void Race()
         {
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
-                .LoadConfig()
-                .Url(InfluxDbUrl)
-                .AuthenticateToken(_token)
-                .Build();
             var point = PointData.Measurement("race-test")
                                  .Tag("test", "stress")
                                  .Field("value", 1);

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -79,7 +79,8 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
+            var options = new InfluxDBClientOptions.Builder()
+                .LoadConfig()
                 .Url(InfluxDbUrl)
                 .AuthenticateToken(_token)
                 .Build();

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -80,7 +80,6 @@ namespace InfluxDB.Client.Test
             Client.Dispose();
 
             var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
-                .LoadConfig()
                 .Url(InfluxDbUrl)
                 .AuthenticateToken(_token)
                 .Build();

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -248,20 +248,30 @@ namespace InfluxDB.Client
             /// <summary>
             /// Configure Builder via App.config.
             /// </summary>
+            /// <param name="sectionName">Name of configuration section. Useful for tests.</param>
             /// <returns><see cref="Builder"/></returns>
-            internal Builder LoadConfig()
+            internal Builder LoadConfig(string sectionName = "influx2")
             {
-                var config = (Influx2) ConfigurationManager.GetSection("influx2");
+                var config = (Influx2) ConfigurationManager.GetSection(sectionName);
+                if (config == null)
+                {
+                    const string message = "The configuration doesn't contains a 'influx2' section. " +
+                                           "The minimal configuration should contains an url of InfluxDB. " +
+                                           "For more details see: " +
+                                           "https://github.com/influxdata/influxdb-client-csharp/blob/master/Client/README.md#client-configuration-file";
+                    
+                    throw new ConfigurationErrorsException(message);
+                }
 
-                var url = config?.Url;
-                var org = config?.Org;
-                var bucket = config?.Bucket;
-                var token = config?.Token;
-                var logLevel = config?.LogLevel;
-                var timeout = config?.Timeout;
-                var readWriteTimeout = config?.ReadWriteTimeout;
+                var url = config.Url;
+                var org = config.Org;
+                var bucket = config.Bucket;
+                var token = config.Token;
+                var logLevel = config.LogLevel;
+                var timeout = config.Timeout;
+                var readWriteTimeout = config.ReadWriteTimeout;
 
-                var tags = config?.Tags;
+                var tags = config.Tags;
                 if (tags != null)
                 {
                     foreach (Influx2.TagElement o in tags)


### PR DESCRIPTION
Closes #142 

## Proposed Changes

Added validation that a configuration is present when is client configured via file.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
