### PR TITLE
chore: update RestSharp to 106.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,11 @@
 ### Bug Fixes
 1. [#143](https://github.com/influxdata/influxdb-client-csharp/pull/143): Added validation that a configuration is present when is client configured via file
 
+### Dependencies
+1. [#145](https://github.com/influxdata/influxdb-client-csharp/pull/145): Updated RestSharp to 106.11.7
+
 ### CI
- 1. [#140](https://github.com/influxdata/influxdb-client-csharp/pull/140): Updated default docker image to v2.0.3
+1. [#140](https://github.com/influxdata/influxdb-client-csharp/pull/140): Updated default docker image to v2.0.3
 
 ## 1.14.0 [2020-12-04]
 

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="	11.0.2" />
       <PackageReference Include="NodaTime" Version="2.4.1" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.0.0" />
-      <PackageReference Include="RestSharp" Version="106.6.10" />
+      <PackageReference Include="RestSharp" Version="106.11.7" />
       <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -23,7 +23,7 @@ sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<
 #
 # Install testing tools
 #
-dotnet tool install --tool-path="./Coverlet/" coverlet.console
+dotnet tool install --tool-path="./Coverlet/" coverlet.console --version 1.7.2
 dotnet tool install --tool-path="./trx2junit/" trx2junit --version 1.3.2
 
 #


### PR DESCRIPTION
Probably closes #141

## Proposed Changes

- Update RestSharp to 106.11.7 to avoid https://github.com/restsharp/RestSharp/issues/1321

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
