### PR TITLE
chore: update of csvhelper to v18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Dependencies
 1. [#145](https://github.com/influxdata/influxdb-client-csharp/pull/145): Updated RestSharp to 106.11.7
+1. [#148](https://github.com/influxdata/influxdb-client-csharp/pull/148): Updated CsvHelper to 18.0.0
 
 ### CI
 1. [#140](https://github.com/influxdata/influxdb-client-csharp/pull/140): Updated default docker image to v2.0.3

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -32,7 +32,7 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="[15.0.4,16.0)" />
+      <PackageReference Include="CsvHelper" Version="18.0.0" />
       <PackageReference Include="Newtonsoft.Json" Version="	11.0.2" />
       <PackageReference Include="NodaTime" Version="2.4.1" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.0.0" />


### PR DESCRIPTION
## Proposed Changes

In order to avoid warnings with our code base we would like to update the csvhelper library to a more recent version which nonetheless doesn't introduce breaking changes

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] `dotnet test` completes successfully
I would have liked but it is not quite clear how to set up the dependencies for a successful test run. A windows download for influx db v2 doesn't seem to be available?
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
