### PR TITLE
fix: added supports for unsigned numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#143](https://github.com/influxdata/influxdb-client-csharp/pull/143): Added validation that a configuration is present when is client configured via file
+1. [#150](https://github.com/influxdata/influxdb-client-csharp/pull/150): The unsigned numbers are serialized with `u` postfix
 
 ### Dependencies
 1. [#145](https://github.com/influxdata/influxdb-client-csharp/pull/145): Updated RestSharp to 106.11.7

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -147,7 +147,7 @@ namespace InfluxDB.Client.Test
 
             var expected =
                 "h2o,location=europe boolean=false,byte=9i,decimal=25.6,double=250.69,float=35,integer=7i,long=1i," +
-                "point=13.3,sbyte=12i,short=8i,string=\"string value\",uint=11i,ulong=10i,ushort=13i";
+                "point=13.3,sbyte=12i,short=8i,string=\"string value\",uint=11u,ulong=10u,ushort=13u";
 
             Assert.AreEqual(expected, point.ToLineProtocol());
         }
@@ -416,5 +416,7 @@ namespace InfluxDB.Client.Test
 
             Assert.AreEqual("", point.ToLineProtocol());
         }
+        
+        
     }
 }

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -95,6 +95,17 @@ namespace InfluxDB.Client.Writes
         }
 
         /// <summary>
+        /// Add a field with a <see cref="byte"/> value.
+        /// </summary>
+        /// <param name="name">the field name</param>
+        /// <param name="value">the field value</param>
+        /// <returns>this</returns>
+        public PointData Field(string name, byte value)
+        {
+            return PutField(name, value);
+        }
+
+        /// <summary>
         /// Add a field with a <see cref="float"/> value.
         /// </summary>
         /// <param name="name">the field name</param>
@@ -145,6 +156,17 @@ namespace InfluxDB.Client.Writes
         /// <param name="value">the field value</param>
         /// <returns>this</returns>
         public PointData Field(string name, ulong value)
+        {
+            return PutField(name, value);
+        }
+
+        /// <summary>
+        /// Add a field with a <see cref="uint"/> value.
+        /// </summary>
+        /// <param name="name">the field name</param>
+        /// <param name="value">the field value</param>
+        /// <returns>this</returns>
+        public PointData Field(string name, uint value)
         {
             return PutField(name, value);
         }
@@ -410,12 +432,16 @@ namespace InfluxDB.Client.Writes
 
                 if (value is double || value is float)
                 {
-                    sb.Append(((IConvertible)value).ToString(CultureInfo.InvariantCulture));
+                    sb.Append(((IConvertible) value).ToString(CultureInfo.InvariantCulture));
                 }
-                else if (value is byte || value is int || value is long || value is sbyte || value is short ||
-                         value is uint || value is ulong || value is ushort)
+                else if (value is uint || value is ulong || value is ushort)
                 {
-                    sb.Append(((IConvertible)value).ToString(CultureInfo.InvariantCulture));
+                    sb.Append(((IConvertible) value).ToString(CultureInfo.InvariantCulture));
+                    sb.Append('u');
+                }
+                else if (value is byte || value is int || value is long || value is sbyte || value is short)
+                {
+                    sb.Append(((IConvertible) value).ToString(CultureInfo.InvariantCulture));
                     sb.Append('i');
                 }
                 else if (value is bool b)


### PR DESCRIPTION
Closes #149

## Proposed Changes

The unsigned numbers are serialized with `u` postfix.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
