### PR TITLE
fix: always use ConfigureAwait(false), avoid unnecessary await overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.16.0 [unreleased]
 
+### Bug Fixes
+1. [#154](https://github.com/influxdata/influxdb-client-csharp/pull/154): Always use `ConfigureAwait(false)` to avoid unnecessary context switching and potential dead-locks. Avoid unnecessary await overhead.
+
 ## 1.15.0 [2021-01-29]
 
 ### Bug Fixes

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -112,7 +112,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
             using var csv = new CsvReader(reader, CultureInfo.InvariantCulture);
             var state = new ParseFluxResponseState { csv = csv };
 
-            while (await csv.ReadAsync() && !cancellationToken.IsCancellationRequested)
+            while (await csv.ReadAsync().ConfigureAwait(false) && !cancellationToken.IsCancellationRequested)
             {
                 foreach (var response in ParseNextFluxResponse(state))
                     yield return response;   

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -32,7 +32,7 @@ namespace InfluxDB.Client.Core.Internal
             RestClient = restClient;
         }
 
-        protected async Task Query(RestRequest query, FluxCsvParser.IFluxResponseConsumer responseConsumer,
+        protected Task Query(RestRequest query, FluxCsvParser.IFluxResponseConsumer responseConsumer,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -48,10 +48,10 @@ namespace InfluxDB.Client.Core.Internal
                 }
             }
 
-            await Query(query, Consumer, onError, onComplete);
+            return Query(query, Consumer, onError, onComplete);
         }
 
-        protected async Task QueryRaw(RestRequest query,
+        protected Task QueryRaw(RestRequest query,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
@@ -68,7 +68,7 @@ namespace InfluxDB.Client.Core.Internal
                 }
             }
 
-            await Query(query, Consumer, onError, onComplete);
+            return Query(query, Consumer, onError, onComplete);
         }
 
         protected async Task Query(RestRequest query, Action<ICancellable, Stream> consumer,

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -93,7 +93,7 @@ namespace InfluxDB.Client.Core.Internal
                     consumer(cancellable, responseStream);
                 };
 
-                await Task.Run(() => { RestClient.DownloadData(query, true); });
+                await Task.Run(() => { RestClient.DownloadData(query, true); }).ConfigureAwait(false);
                 if (!cancellable.IsCancelled())
                 {
                     onComplete();
@@ -111,13 +111,13 @@ namespace InfluxDB.Client.Core.Internal
 
             BeforeIntercept(query);
 
-            var response = await RestClient.ExecuteTaskAsync(query, cancellationToken);
+            var response = await RestClient.ExecuteTaskAsync(query, cancellationToken).ConfigureAwait(false);
 
             response.Content = AfterIntercept((int)response.StatusCode, () => LoggingHandler.ToHeaders(response.Headers), response.Content);
 
             RaiseForInfluxError(response, response.Content);
 
-            await foreach(var (_, record) in _csvParser.ParseFluxResponseAsync(new StringReader(response.Content), cancellationToken))
+            await foreach(var (_, record) in _csvParser.ParseFluxResponseAsync(new StringReader(response.Content), cancellationToken).ConfigureAwait(false))
             {
                 if (!(record is null))
                     yield return Mapper.ToPoco<T>(record);

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
-using System.Net.Mime;
 using System.Threading.Tasks;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Exceptions;

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -90,12 +90,12 @@ namespace InfluxDB.Client.Flux
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability to discontinue a streaming query</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onNext, "onNext");
 
-            await QueryAsync(query, onNext, ErrorConsumer);
+            return QueryAsync(query, onNext, ErrorConsumer);
         }
 
         /// <summary>
@@ -105,12 +105,12 @@ namespace InfluxDB.Client.Flux
         /// <param name="onNext">the callback to consume the FluxRecord result with capability to discontinue a streaming query</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onNext, "onNext");
 
-            await QueryAsync(query, onNext, ErrorConsumer);
+            return QueryAsync(query, onNext, ErrorConsumer);
         }
 
         /// <summary>
@@ -120,13 +120,13 @@ namespace InfluxDB.Client.Flux
         /// <param name="onNext">the callback to consume the FluxRecord result with capability to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext, Action<Exception> onError)
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext, Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onNext, "onNext");
             Arguments.CheckNotNull(onError, "onError");
 
-            await QueryAsync(query, onNext, onError, EmptyAction);
+            return QueryAsync(query, onNext, onError, EmptyAction);
         }
 
         /// <summary>
@@ -137,13 +137,13 @@ namespace InfluxDB.Client.Flux
         /// <param name="onError">the callback to consume any error notification</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext, Action<Exception> onError)
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext, Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onNext, "onNext");
             Arguments.CheckNotNull(onError, "onError");
 
-            await QueryAsync(query, onNext, onError, EmptyAction);
+            return QueryAsync(query, onNext, onError, EmptyAction);
         }
 
         /// <summary>
@@ -154,7 +154,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query,
+        public Task QueryAsync(string query,
             Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
             Action onComplete)
@@ -166,7 +166,7 @@ namespace InfluxDB.Client.Flux
 
             var consumer = new FluxResponseConsumerRecord(onNext);
 
-            await QueryAsync(query, GetDefaultDialect(), consumer, onError, onComplete);
+            return QueryAsync(query, GetDefaultDialect(), consumer, onError, onComplete);
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext, Action<Exception> onError,
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext, Action<Exception> onError,
             Action onComplete)
         {
             Arguments.CheckNonEmptyString(query, "query");
@@ -188,10 +188,10 @@ namespace InfluxDB.Client.Flux
 
             var consumer = new FluxResponseConsumerPoco<T>(onNext);
 
-            await QueryAsync(query, GetDefaultDialect(), consumer, onError, onComplete);
+            return QueryAsync(query, GetDefaultDialect(), consumer, onError, onComplete);
         }
 
-        private async Task QueryAsync(string query,
+        private Task QueryAsync(string query,
             string dialect,
             FluxCsvParser.IFluxResponseConsumer responseConsumer,
             Action<Exception> onError,
@@ -199,7 +199,7 @@ namespace InfluxDB.Client.Flux
         {
             var message = QueryRequest(CreateBody(dialect, query));
 
-            await Query(message, responseConsumer, onError, onComplete);
+            return Query(message, responseConsumer, onError, onComplete);
         }
 
         /// <summary>
@@ -211,11 +211,11 @@ namespace InfluxDB.Client.Flux
         /// </summary>
         /// <param name="query">the flux query to execute></param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(string query)
+        public Task<string> QueryRawAsync(string query)
         {
             Arguments.CheckNonEmptyString(query, "query");
 
-            return await QueryRawAsync(query, "");
+            return QueryRawAsync(query, "");
         }
 
         /// <summary>
@@ -248,13 +248,13 @@ namespace InfluxDB.Client.Flux
         /// <param name="query">the flux query to execute</param>
         /// <param name="onResponse">the callback to consume the response line by line with capability to discontinue a streaming query.</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             Action<ICancellable, string> onResponse)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onResponse, "onNext");
 
-            await QueryRawAsync(query, null, onResponse);
+            return QueryRawAsync(query, null, onResponse);
         }
 
         /// <summary>
@@ -265,14 +265,14 @@ namespace InfluxDB.Client.Flux
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
         /// <param name="onResponse">the callback to consume the response line by line with capability to discontinue a streaming query.</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             string dialect,
             Action<ICancellable, string> onResponse)
         {
             Arguments.CheckNonEmptyString(query, "query");
             Arguments.CheckNotNull(onResponse, "onNext");
 
-            await QueryRawAsync(query, dialect, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, dialect, onResponse, ErrorConsumer);
         }
 
         /// <summary>
@@ -282,7 +282,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onResponse">the callback to consume the response line by line with capability to discontinue a streaming query.</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
@@ -290,7 +290,7 @@ namespace InfluxDB.Client.Flux
             Arguments.CheckNotNull(onResponse, "onNext");
             Arguments.CheckNotNull(onError, "onError");
 
-            await QueryRawAsync(query, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, onResponse, onError, EmptyAction);
         }
 
         /// <summary>
@@ -302,7 +302,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onResponse">the callback to consume the response line by line with capability to discontinue a streaming query.</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             string dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError)
@@ -311,7 +311,7 @@ namespace InfluxDB.Client.Flux
             Arguments.CheckNotNull(onResponse, "onNext");
             Arguments.CheckNotNull(onError, "onError");
 
-            await QueryRawAsync(query, dialect, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, dialect, onResponse, onError, EmptyAction);
         }
 
         /// <summary>
@@ -322,7 +322,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
@@ -332,7 +332,7 @@ namespace InfluxDB.Client.Flux
             Arguments.CheckNotNull(onError, "onError");
             Arguments.CheckNotNull(onComplete, "onComplete");
 
-            await QueryRawAsync(query, null, onResponse, onError, onComplete);
+            return QueryRawAsync(query, null, onResponse, onError, onComplete);
         }
 
         /// <summary>
@@ -345,7 +345,7 @@ namespace InfluxDB.Client.Flux
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryRawAsync(string query,
+        public Task QueryRawAsync(string query,
             string dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
@@ -358,7 +358,7 @@ namespace InfluxDB.Client.Flux
 
             var message = QueryRequest(CreateBody(dialect, query));
 
-            await QueryRaw(message, onResponse, onError, onComplete);
+            return QueryRaw(message, onResponse, onError, onComplete);
         }
 
         /// <summary>

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -56,7 +56,7 @@ namespace InfluxDB.Client.Flux
 
             var consumer = new FluxCsvParser.FluxResponseConsumerTable();
 
-            await QueryAsync(query, GetDefaultDialect(), consumer, ErrorConsumer, EmptyAction);
+            await QueryAsync(query, GetDefaultDialect(), consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return consumer.Tables;
         }
@@ -78,7 +78,7 @@ namespace InfluxDB.Client.Flux
 
             var consumer = new FluxResponseConsumerPoco<T>((cancellable, poco) => { measurements.Add(poco); });
 
-            await QueryAsync(query, GetDefaultDialect(), consumer, ErrorConsumer, EmptyAction);
+            await QueryAsync(query, GetDefaultDialect(), consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return measurements;
         }
@@ -236,7 +236,7 @@ namespace InfluxDB.Client.Flux
 
             void Consumer(ICancellable cancellable, string row) => rows.Add(row);
 
-            await QueryRawAsync(query, dialect, Consumer, ErrorConsumer, EmptyAction);
+            await QueryRawAsync(query, dialect, Consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return string.Join("\n", rows);
         }
@@ -368,7 +368,7 @@ namespace InfluxDB.Client.Flux
         {
             try
             {
-                await ExecuteAsync(PingRequest());
+                await ExecuteAsync(PingRequest()).ConfigureAwait(false);
 
                 return true;
             }
@@ -388,7 +388,7 @@ namespace InfluxDB.Client.Flux
         {
             try
             {
-                var response = await ExecuteAsync(PingRequest());
+                var response = await ExecuteAsync(PingRequest()).ConfigureAwait(false);
 
                 return GetVersion(response);
             }
@@ -422,7 +422,7 @@ namespace InfluxDB.Client.Flux
         {
             BeforeIntercept(request);
 
-            var response = await Task.Run(() => RestClient.Execute(request));
+            var response = await Task.Run(() => RestClient.Execute(request)).ConfigureAwait(false);
 
             RaiseForInfluxError(response, response.Content);
 

--- a/Client.Test/ItAuthorizationsApiTest.cs
+++ b/Client.Test/ItAuthorizationsApiTest.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Exceptions;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {
@@ -207,11 +206,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneAuthorizationNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _authorizationsApi.CloneAuthorizationAsync("020f755c3c082000"));
 
-            Assert.AreEqual("authorization not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("authorization not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         private List<Permission> NewPermissions()

--- a/Client.Test/ItBucketsApiTest.cs
+++ b/Client.Test/ItBucketsApiTest.cs
@@ -1,11 +1,10 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Domain;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {
@@ -66,11 +65,10 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneBucketNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _bucketsApi.CloneBucketAsync(GenerateName("bucket"), "020f755c3c082000"));
 
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException?.GetType());
-            Assert.AreEqual("bucket not found", ioe.InnerException?.Message);
+            Assert.AreEqual("bucket not found", ioe.Message);
         }
 
         [Test]

--- a/Client.Test/ItLabelsApiTest.cs
+++ b/Client.Test/ItLabelsApiTest.cs
@@ -1,10 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Exceptions;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {
@@ -47,11 +46,11 @@ namespace InfluxDB.Client.Test
         public void CloneLabelNotFound()
         {
             var exception =
-                Assert.ThrowsAsync<AggregateException>(async () => await _labelsApi.CloneLabelAsync(GenerateName("bucket"), "020f755c3c082000"));
+                Assert.ThrowsAsync<HttpException>(async () => await _labelsApi.CloneLabelAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.IsNotNull(exception);
-            Assert.AreEqual(typeof(HttpException), exception.InnerException.GetType());
-            Assert.AreEqual("label not found", exception.InnerException.Message);
+            Assert.AreEqual(typeof(HttpException), exception.GetType());
+            Assert.AreEqual("label not found", exception.Message);
         }
 
         [Test]

--- a/Client.Test/ItNotificationEndpointsApiTest.cs
+++ b/Client.Test/ItNotificationEndpointsApiTest.cs
@@ -428,30 +428,30 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
                 .CloneSlackEndpointAsync("not-found-cloned", "token", "020f755c3c082000"));
 
-            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.InnerException?.Message);
+            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<AggregateException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
                 .ClonePagerDutyEndpointAsync("not-found-cloned", "token", "020f755c3c082000"));
 
-            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.InnerException?.Message);
+            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<AggregateException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointAsync("not-found-cloned", "020f755c3c082000"));
 
-            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.InnerException?.Message);
+            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<AggregateException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointBearerAsync("not-found-cloned", "token", "020f755c3c082000"));
 
-            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.InnerException?.Message);
+            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<AggregateException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointBasicAuthAsync("not-found-cloned", "username", "password", "020f755c3c082000"));
 
-            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.InnerException?.Message);
+            Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
         }
 
         [Test]

--- a/Client.Test/ItOrganizationsApiTest.cs
+++ b/Client.Test/ItOrganizationsApiTest.cs
@@ -25,7 +25,6 @@ namespace InfluxDB.Client.Test
         {
             var source = await _organizationsApi.CreateOrganizationAsync(GenerateName("Constant Pro"));
 
-            var properties = new Dictionary<string, string> {{"color", "green"}, {"location", "west"}};
             var name = GenerateName("cloned");
 
             var cloned = await _organizationsApi.CloneOrganizationAsync(name, source);
@@ -37,11 +36,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneOrganizationNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _organizationsApi.CloneOrganizationAsync(GenerateName("bucket"), "020f755c3c082000"));
 
-            Assert.AreEqual("organization not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("organization not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]

--- a/Client.Test/ItScraperTargetsApiTest.cs
+++ b/Client.Test/ItScraperTargetsApiTest.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Exceptions;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {
@@ -56,11 +55,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneScraperNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _scraperTargetsApi.CloneScraperTargetAsync(GenerateName("bucket"), "020f755c3c082000"));
 
-            Assert.AreEqual("scraper target is not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("scraper target is not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]

--- a/Client.Test/ItSourcesApiTest.cs
+++ b/Client.Test/ItSourcesApiTest.cs
@@ -58,11 +58,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneSourceNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _sourcesApi.CloneSourceAsync(GenerateName("bucket"), "020f755c3d082000"));
 
-            Assert.AreEqual("source not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("source not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -123,10 +123,9 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneTaskNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () => await _tasksApi.CloneTaskAsync("020f755c3c082000"));
+            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.CloneTaskAsync("020f755c3c082000"));
 
-            Assert.NotNull(ioe.InnerException, "ioe.InnerException != null");
-            Assert.AreEqual("failed to find task: task not found", ioe.InnerException.Message);
+            Assert.AreEqual("failed to find task: task not found", ioe.Message);
         }
 
         [Test]

--- a/Client.Test/ItTelegrafsApiTest.cs
+++ b/Client.Test/ItTelegrafsApiTest.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
@@ -82,13 +81,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneTelegrafNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _telegrafsApi.CloneTelegrafAsync(GenerateName("tc"), "020f755c3c082000"));
 
-            Assert.IsNotNull(ioe.InnerException);
-            Assert.IsNotNull(ioe.InnerException.InnerException);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.InnerException.GetType());
-            Assert.AreEqual("telegraf configuration not found", ioe.InnerException.InnerException.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual("telegraf configuration not found", ioe.Message);
         }
 
         [Test]
@@ -154,12 +151,11 @@ namespace InfluxDB.Client.Test
             // delete source
             await _telegrafsApi.DeleteTelegrafAsync(createdConfig);
 
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _telegrafsApi.FindTelegrafByIdAsync(createdConfig.Id));
 
-            Assert.IsNotNull(ioe.InnerException);
-            Assert.AreEqual("telegraf configuration not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("telegraf configuration not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]
@@ -196,12 +192,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindTelegrafByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _telegrafsApi.FindTelegrafByIdAsync("020f755c3d082000"));
 
-            Assert.IsNotNull(ioe.InnerException);
-            Assert.AreEqual("telegraf configuration not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("telegraf configuration not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]

--- a/Client.Test/ItUsersApiTest.cs
+++ b/Client.Test/ItUsersApiTest.cs
@@ -122,12 +122,12 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _usersApi.MeUpdatePasswordAsync("my-password-wrong", "my-password"));
 
             Assert.IsNotNull(ioe);
-            Assert.AreEqual("unauthorized access", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("unauthorized access", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
 
         [Test]
@@ -191,11 +191,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneUserNotFound()
         {
-            var ioe = Assert.ThrowsAsync<AggregateException>(async () =>
+            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
                 await _usersApi.CloneUserAsync(GenerateName("bucket"), "020f755c3c082000"));
 
-            Assert.AreEqual("user not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual("user not found", ioe.Message);
+            Assert.AreEqual(typeof(HttpException), ioe.GetType());
         }
     }
 }

--- a/Client.Test/ItUsersApiTest.cs
+++ b/Client.Test/ItUsersApiTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using InfluxDB.Client.Core.Exceptions;
 using NUnit.Framework;
@@ -9,9 +10,12 @@ namespace InfluxDB.Client.Test
     public class ItUsersApiTest : AbstractItClientTest
     {
         [SetUp]
-        public new void SetUp()
+        public new async Task SetUp()
         {
             _usersApi = Client.GetUsersApi();
+            
+            foreach (var user in (await _usersApi.FindUsersAsync()).Where(user => user.Name.EndsWith("-IT")))
+                await _usersApi.DeleteUserAsync(user);
         }
 
         private UsersApi _usersApi;

--- a/Client/AuthorizationsApi.cs
+++ b/Client/AuthorizationsApi.cs
@@ -108,8 +108,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            var authorization = await FindAuthorizationByIdAsync(authorizationId);
-            return await CloneAuthorizationAsync(authorization);
+            var authorization = await FindAuthorizationByIdAsync(authorizationId).ConfigureAwait(false);
+            return await CloneAuthorizationAsync(authorization).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -186,7 +186,7 @@ namespace InfluxDB.Client
 
         private async Task<List<Authorization>> FindAuthorizationsByAsync(string userId, string userName)
         {
-            var response = await _service.GetAuthorizationsAsync(null, userId, userName);
+            var response = await _service.GetAuthorizationsAsync(null, userId, userName).ConfigureAwait(false);
             return response._Authorizations;
         }
     }

--- a/Client/AuthorizationsApi.cs
+++ b/Client/AuthorizationsApi.cs
@@ -24,12 +24,12 @@ namespace InfluxDB.Client
         /// <param name="organization">the owner of the authorization</param>
         /// <param name="permissions">the permissions for the authorization</param>
         /// <returns>the created authorization</returns>
-        public async Task<Authorization> CreateAuthorizationAsync(Organization organization, List<Permission> permissions)
+        public Task<Authorization> CreateAuthorizationAsync(Organization organization, List<Permission> permissions)
         {
             Arguments.CheckNotNull(organization, "organization");
             Arguments.CheckNotNull(permissions, "permissions");
 
-            return await CreateAuthorizationAsync(organization.Id, permissions);
+            return CreateAuthorizationAsync(organization.Id, permissions);
         }
 
         /// <summary>
@@ -38,7 +38,7 @@ namespace InfluxDB.Client
         /// <param name="orgId">the owner id of the authorization</param>
         /// <param name="permissions">the permissions for the authorization</param>
         /// <returns>the created authorization</returns>
-        public async Task<Authorization> CreateAuthorizationAsync(string orgId, List<Permission> permissions)
+        public Task<Authorization> CreateAuthorizationAsync(string orgId, List<Permission> permissions)
         {
             Arguments.CheckNonEmptyString(orgId, "orgId");
             Arguments.CheckNotNull(permissions, "permissions");
@@ -46,7 +46,7 @@ namespace InfluxDB.Client
             var authorization =
                 new Authorization(orgId, permissions, null, AuthorizationUpdateRequest.StatusEnum.Active);
 
-            return await CreateAuthorizationAsync(authorization);
+            return CreateAuthorizationAsync(authorization);
         }
 
         /// <summary>
@@ -54,11 +54,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorization">authorization to create</param>
         /// <returns>the created authorization</returns>
-        public async Task<Authorization> CreateAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> CreateAuthorizationAsync(Authorization authorization)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
-            return await _service.PostAuthorizationsAsync(authorization);
+            return _service.PostAuthorizationsAsync(authorization);
         }
 
         /// <summary>
@@ -66,13 +66,13 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorization">the authorization with updated status</param>
         /// <returns>the updated authorization</returns>
-        public async Task<Authorization> UpdateAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> UpdateAuthorizationAsync(Authorization authorization)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
             var request = new AuthorizationUpdateRequest(authorization.Status, authorization.Description);
 
-            return await _service.PatchAuthorizationsIDAsync(authorization.Id, request);
+            return _service.PatchAuthorizationsIDAsync(authorization.Id, request);
         }
 
         /// <summary>
@@ -80,11 +80,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorization">authorization to delete</param>
         /// <returns>authorization deleted</returns>
-        public async Task DeleteAuthorizationAsync(Authorization authorization)
+        public Task DeleteAuthorizationAsync(Authorization authorization)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
-            await DeleteAuthorizationAsync(authorization.Id);
+            return DeleteAuthorizationAsync(authorization.Id);
         }
 
         /// <summary>
@@ -92,11 +92,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorizationId">ID of authorization to delete</param>
         /// <returns>authorization deleted</returns>
-        public async Task DeleteAuthorizationAsync(string authorizationId)
+        public Task DeleteAuthorizationAsync(string authorizationId)
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            await _service.DeleteAuthorizationsIDAsync(authorizationId);
+            return _service.DeleteAuthorizationsIDAsync(authorizationId);
         }
 
         /// <summary>
@@ -108,8 +108,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            return await FindAuthorizationByIdAsync(authorizationId).ContinueWith(t => CloneAuthorizationAsync(t.Result))
-                .Unwrap();
+            var authorization = await FindAuthorizationByIdAsync(authorizationId);
+            return await CloneAuthorizationAsync(authorization);
         }
 
         /// <summary>
@@ -117,14 +117,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorization">authorization to clone</param>
         /// <returns>cloned authorization</returns>
-        public async Task<Authorization> CloneAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> CloneAuthorizationAsync(Authorization authorization)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
             var cloned = new Authorization(authorization.OrgID, authorization.Permissions, authorization.Links,
                 authorization.Status, authorization.Description);
 
-            return await CreateAuthorizationAsync(cloned);
+            return CreateAuthorizationAsync(cloned);
         }
 
         /// <summary>
@@ -132,20 +132,20 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="authorizationId">ID of authorization to get</param>
         /// <returns>authorization details</returns>
-        public async Task<Authorization> FindAuthorizationByIdAsync(string authorizationId)
+        public Task<Authorization> FindAuthorizationByIdAsync(string authorizationId)
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            return await _service.GetAuthorizationsIDAsync(authorizationId);
+            return _service.GetAuthorizationsIDAsync(authorizationId);
         }
 
         /// <summary>
         /// List all authorizations.
         /// </summary>
         /// <returns>List all authorizations.</returns>
-        public async Task<List<Authorization>> FindAuthorizationsAsync()
+        public Task<List<Authorization>> FindAuthorizationsAsync()
         {
-            return await FindAuthorizationsByAsync(null, null);
+            return FindAuthorizationsByAsync(null, null);
         }
 
         /// <summary>
@@ -153,11 +153,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="user">user</param>
         /// <returns>A list of authorizations</returns>
-        public async Task<List<Authorization>> FindAuthorizationsByUserAsync(User user)
+        public Task<List<Authorization>> FindAuthorizationsByUserAsync(User user)
         {
             Arguments.CheckNotNull(user, "user");
 
-            return await FindAuthorizationsByUserIdAsync(user.Id);
+            return FindAuthorizationsByUserIdAsync(user.Id);
         }
 
         /// <summary>
@@ -165,11 +165,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="userId">ID of user</param>
         /// <returns>A list of authorizations</returns>
-        public async Task<List<Authorization>> FindAuthorizationsByUserIdAsync(string userId)
+        public Task<List<Authorization>> FindAuthorizationsByUserIdAsync(string userId)
         {
             Arguments.CheckNonEmptyString(userId, "User ID");
 
-            return await FindAuthorizationsByAsync(userId, null);
+            return FindAuthorizationsByAsync(userId, null);
         }
 
         /// <summary>
@@ -177,16 +177,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="userName">Name of User</param>
         /// <returns>A list of authorizations</returns>
-        public async Task<List<Authorization>> FindAuthorizationsByUserNameAsync(string userName)
+        public Task<List<Authorization>> FindAuthorizationsByUserNameAsync(string userName)
         {
             Arguments.CheckNonEmptyString(userName, "User name");
 
-            return await FindAuthorizationsByAsync(null, userName);
+            return FindAuthorizationsByAsync(null, userName);
         }
 
         private async Task<List<Authorization>> FindAuthorizationsByAsync(string userId, string userName)
         {
-            return (await _service.GetAuthorizationsAsync(null, userId, userName))._Authorizations;
+            var response = await _service.GetAuthorizationsAsync(null, userId, userName);
+            return response._Authorizations;
         }
     }
 }

--- a/Client/BucketsApi.cs
+++ b/Client/BucketsApi.cs
@@ -155,8 +155,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var bucket = await FindBucketByIdAsync(bucketId);
-            return await CloneBucketAsync(clonedName, bucket);
+            var bucket = await FindBucketByIdAsync(bucketId).ConfigureAwait(false);
+            return await CloneBucketAsync(clonedName, bucket).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -172,12 +172,12 @@ namespace InfluxDB.Client
 
             var cloned = new Bucket(null, clonedName, null, bucket.OrgID, bucket.Rp, bucket.RetentionRules);
 
-            var created = await CreateBucketAsync(cloned);
+            var created = await CreateBucketAsync(cloned).ConfigureAwait(false);
 
-            var labels = await GetLabelsAsync(bucket);
+            var labels = await GetLabelsAsync(bucket).ConfigureAwait(false);
             foreach (var label in labels)
             {
-                await AddLabelAsync(label, created);
+                await AddLabelAsync(label, created).ConfigureAwait(false);
             }
             
             return created;
@@ -205,7 +205,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(bucketName, nameof(bucketName));
 
             var buckets = await _service
-                .GetBucketsAsync(null, null, null, null, null, null, bucketName);
+                .GetBucketsAsync(null, null, null, null, null, null, bucketName).ConfigureAwait(false);
             
             return buckets._Buckets.FirstOrDefault();
         }
@@ -229,7 +229,7 @@ namespace InfluxDB.Client
         /// <returns>A list of buckets</returns>
         public async Task<List<Bucket>> FindBucketsByOrgNameAsync(string orgName)
         {
-            var buckets = await FindBucketsAsync(orgName, new FindOptions());
+            var buckets = await FindBucketsAsync(orgName, new FindOptions()).ConfigureAwait(false);
             return buckets._Buckets;
         }
 
@@ -275,7 +275,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var members = await _service.GetBucketsIDMembersAsync(bucketId);
+            var members = await _service.GetBucketsIDMembersAsync(bucketId).ConfigureAwait(false);
             return members.Users;
         }
 
@@ -358,7 +358,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var members = await _service.GetBucketsIDOwnersAsync(bucketId);
+            var members = await _service.GetBucketsIDOwnersAsync(bucketId).ConfigureAwait(false);
             return members.Users;
         }
 
@@ -441,7 +441,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var response = await _service.GetBucketsIDLabelsAsync(bucketId);
+            var response = await _service.GetBucketsIDLabelsAsync(bucketId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -472,7 +472,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostBucketsIDLabelsAsync(bucketId, mapping);
+            var response = await _service.PostBucketsIDLabelsAsync(bucketId, mapping).ConfigureAwait(false);
             return response.Label;
         }
 

--- a/Client/BucketsApi.cs
+++ b/Client/BucketsApi.cs
@@ -24,14 +24,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket to create</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(Bucket bucket)
+        public Task<Bucket> CreateBucketAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
             var postBucket = new PostBucketRequest(orgID: bucket.OrgID, name: bucket.Name, description: bucket.Description,
                 rp: bucket.Rp, retentionRules: bucket.RetentionRules);
 
-            return await _service.PostBucketsAsync(postBucket);
+            return _service.PostBucketsAsync(postBucket);
         }
         
         /// <summary>
@@ -39,11 +39,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket to create</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(PostBucketRequest bucket)
+        public Task<Bucket> CreateBucketAsync(PostBucketRequest bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return await _service.PostBucketsAsync(bucket);
+            return _service.PostBucketsAsync(bucket);
         }
 
         /// <summary>
@@ -52,12 +52,12 @@ namespace InfluxDB.Client
         /// <param name="name">name of the bucket</param>
         /// <param name="organization">owner of the bucket</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(string name, Organization organization)
+        public Task<Bucket> CreateBucketAsync(string name, Organization organization)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await CreateBucketAsync(name, organization.Id);
+            return CreateBucketAsync(name, organization.Id);
         }
 
         /// <summary>
@@ -67,13 +67,13 @@ namespace InfluxDB.Client
         /// <param name="bucketRetentionRules">retention rule of the bucket</param>
         /// <param name="organization">owner of the bucket</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules,
+        public Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules,
             Organization organization)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await CreateBucketAsync(name, bucketRetentionRules, organization.Id);
+            return CreateBucketAsync(name, bucketRetentionRules, organization.Id);
         }
 
         /// <summary>
@@ -82,12 +82,12 @@ namespace InfluxDB.Client
         /// <param name="name">name of the bucket</param>
         /// <param name="orgId">owner of the bucket</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(string name, string orgId)
+        public Task<Bucket> CreateBucketAsync(string name, string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return await CreateBucketAsync(name, default(BucketRetentionRules), orgId);
+            return CreateBucketAsync(name, default(BucketRetentionRules), orgId);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace InfluxDB.Client
         /// <param name="bucketRetentionRules">retention rule of the bucket</param>
         /// <param name="orgId">owner of the bucket</param>
         /// <returns>created Bucket</returns>
-        public async Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules, string orgId)
+        public Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules, string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
@@ -105,7 +105,7 @@ namespace InfluxDB.Client
             var bucket = new Bucket(null, name, null, orgId, null, new List<BucketRetentionRules>());
             if (bucketRetentionRules != null) bucket.RetentionRules.Add(bucketRetentionRules);
 
-            return await CreateBucketAsync(bucket);
+            return CreateBucketAsync(bucket);
         }
 
         /// <summary>
@@ -113,11 +113,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket update to apply</param>
         /// <returns>bucket updated</returns>
-        public async Task<Bucket> UpdateBucketAsync(Bucket bucket)
+        public Task<Bucket> UpdateBucketAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return await _service.PatchBucketsIDAsync(bucket.Id, bucket);
+            return _service.PatchBucketsIDAsync(bucket.Id, bucket);
         }
 
         /// <summary>
@@ -125,11 +125,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucketId">ID of bucket to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteBucketAsync(string bucketId)
+        public Task DeleteBucketAsync(string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            await _service.DeleteBucketsIDAsync(bucketId);
+            return _service.DeleteBucketsIDAsync(bucketId);
         }
 
         /// <summary>
@@ -137,11 +137,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteBucketAsync(Bucket bucket)
+        public Task DeleteBucketAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            await DeleteBucketAsync(bucket.Id);
+            return DeleteBucketAsync(bucket.Id);
         }
 
         /// <summary>
@@ -155,8 +155,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return await FindBucketByIdAsync(bucketId)
-                .ContinueWith(t => CloneBucketAsync(clonedName, t.Result)).Unwrap();
+            var bucket = await FindBucketByIdAsync(bucketId);
+            return await CloneBucketAsync(clonedName, bucket);
         }
 
         /// <summary>
@@ -172,20 +172,15 @@ namespace InfluxDB.Client
 
             var cloned = new Bucket(null, clonedName, null, bucket.OrgID, bucket.Rp, bucket.RetentionRules);
 
-            return await CreateBucketAsync(cloned).ContinueWith(created =>
+            var created = await CreateBucketAsync(cloned);
+
+            var labels = await GetLabelsAsync(bucket);
+            foreach (var label in labels)
             {
-                //
-                // Add labels
-                //
-                return GetLabelsAsync(bucket)
-                    .ContinueWith(labels => { return labels.Result.Select(label => AddLabelAsync(label, created.Result)); })
-                    .ContinueWith(async tasks =>
-                    {
-                        await Task.WhenAll(tasks.Result);
-                        return created.Result;
-                    })
-                    .Unwrap();
-            }).Unwrap();
+                await AddLabelAsync(label, created);
+            }
+            
+            return created;
         }
 
         /// <summary>
@@ -193,11 +188,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucketId">ID of bucket to get</param>
         /// <returns>Bucket Details</returns>
-        public async Task<Bucket> FindBucketByIdAsync(string bucketId)
+        public Task<Bucket> FindBucketByIdAsync(string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return await _service.GetBucketsIDAsync(bucketId);
+            return _service.GetBucketsIDAsync(bucketId);
         }
 
         /// <summary>
@@ -209,8 +204,10 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketName, nameof(bucketName));
 
-            return (await _service.GetBucketsAsync(null, null, null, null, null, null, bucketName))
-                ._Buckets.FirstOrDefault();
+            var buckets = await _service
+                .GetBucketsAsync(null, null, null, null, null, null, bucketName);
+            
+            return buckets._Buckets.FirstOrDefault();
         }
 
         /// <summary>
@@ -218,11 +215,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">filter buckets to a specific organization</param>
         /// <returns>A list of buckets</returns>
-        public async Task<List<Bucket>> FindBucketsByOrganizationAsync(Organization organization)
+        public Task<List<Bucket>> FindBucketsByOrganizationAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await FindBucketsByOrgNameAsync(organization.Name);
+            return FindBucketsByOrgNameAsync(organization.Name);
         }
 
         /// <summary>
@@ -232,16 +229,17 @@ namespace InfluxDB.Client
         /// <returns>A list of buckets</returns>
         public async Task<List<Bucket>> FindBucketsByOrgNameAsync(string orgName)
         {
-            return (await FindBucketsAsync(orgName, new FindOptions()))._Buckets;
+            var buckets = await FindBucketsAsync(orgName, new FindOptions());
+            return buckets._Buckets;
         }
 
         /// <summary>
         /// List all buckets.
         /// </summary>
         /// <returns>List all buckets</returns>
-        public async Task<List<Bucket>> FindBucketsAsync()
+        public Task<List<Bucket>> FindBucketsAsync()
         {
-            return await FindBucketsByOrgNameAsync(null);
+            return FindBucketsByOrgNameAsync(null);
         }
 
         /// <summary>
@@ -249,11 +247,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="findOptions">the find options</param>
         /// <returns>List all buckets</returns>
-        public async Task<Buckets> FindBucketsAsync(FindOptions findOptions)
+        public Task<Buckets> FindBucketsAsync(FindOptions findOptions)
         {
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
-            return await FindBucketsAsync(null, findOptions);
+            return FindBucketsAsync(null, findOptions);
         }
 
         /// <summary>
@@ -261,11 +259,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket of the members</param>
         /// <returns>the List all members of a bucket</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(Bucket bucket)
+        public Task<List<ResourceMember>> GetMembersAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return await GetMembersAsync(bucket.Id);
+            return GetMembersAsync(bucket.Id);
         }
 
         /// <summary>
@@ -277,7 +275,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return (await _service.GetBucketsIDMembersAsync(bucketId)).Users;
+            var members = await _service.GetBucketsIDMembersAsync(bucketId);
+            return members.Users;
         }
 
         /// <summary>
@@ -286,12 +285,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of a bucket</param>
         /// <param name="bucket">the bucket of a member</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(User member, Bucket bucket)
+        public Task<ResourceMember> AddMemberAsync(User member, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return await AddMemberAsync(member.Id, bucket.Id);
+            return AddMemberAsync(member.Id, bucket.Id);
         }
 
         /// <summary>
@@ -300,14 +299,14 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="bucketId">the ID of a bucket</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(string memberId, string bucketId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
             var mapping = new AddResourceMemberRequestBody(memberId);
 
-            return await _service.PostBucketsIDMembersAsync(bucketId, mapping);
+            return _service.PostBucketsIDMembersAsync(bucketId, mapping);
         }
 
         /// <summary>
@@ -316,12 +315,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of a bucket</param>
         /// <param name="bucket">the bucket of a member</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(User member, Bucket bucket)
+        public Task DeleteMemberAsync(User member, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(member, nameof(member));
 
-            await DeleteMemberAsync(member.Id, bucket.Id);
+            return DeleteMemberAsync(member.Id, bucket.Id);
         }
 
         /// <summary>
@@ -330,12 +329,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="bucketId">the ID of a bucket</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(string memberId, string bucketId)
+        public Task DeleteMemberAsync(string memberId, string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            await _service.DeleteBucketsIDMembersIDAsync(memberId, bucketId);
+            return _service.DeleteBucketsIDMembersIDAsync(memberId, bucketId);
         }
 
         /// <summary>
@@ -343,11 +342,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket of the owners</param>
         /// <returns>the List all owners of a bucket</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(Bucket bucket)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return await GetOwnersAsync(bucket.Id);
+            return GetOwnersAsync(bucket.Id);
         }
 
         /// <summary>
@@ -359,7 +358,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return (await _service.GetBucketsIDOwnersAsync(bucketId)).Users;
+            var members = await _service.GetBucketsIDOwnersAsync(bucketId);
+            return members.Users;
         }
 
         /// <summary>
@@ -368,12 +368,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(User owner, Bucket bucket)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return await AddOwnerAsync(owner.Id, bucket.Id);
+            return AddOwnerAsync(owner.Id, bucket.Id);
         }
 
         /// <summary>
@@ -382,14 +382,14 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="bucketId">the ID of a bucket</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(string ownerId, string bucketId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
             var mapping = new AddResourceMemberRequestBody(ownerId);
 
-            return await _service.PostBucketsIDOwnersAsync(bucketId, mapping);
+            return _service.PostBucketsIDOwnersAsync(bucketId, mapping);
         }
 
         /// <summary>
@@ -398,12 +398,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(User owner, Bucket bucket)
+        public Task DeleteOwnerAsync(User owner, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            await DeleteOwnerAsync(owner.Id, bucket.Id);
+            return DeleteOwnerAsync(owner.Id, bucket.Id);
         }
 
         /// <summary>
@@ -412,12 +412,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="bucketId">the ID of a bucket</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(string ownerId, string bucketId)
+        public Task DeleteOwnerAsync(string ownerId, string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            await _service.DeleteBucketsIDOwnersIDAsync(ownerId, bucketId);
+            return _service.DeleteBucketsIDOwnersIDAsync(ownerId, bucketId);
         }
 
         /// <summary>
@@ -425,11 +425,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="bucket">bucket of the labels</param>
         /// <returns>the List all labels of a bucket</returns>
-        public async Task<List<Label>> GetLabelsAsync(Bucket bucket)
+        public Task<List<Label>> GetLabelsAsync(Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return await GetLabelsAsync(bucket.Id);
+            return GetLabelsAsync(bucket.Id);
         }
 
         /// <summary>
@@ -441,7 +441,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return (await _service.GetBucketsIDLabelsAsync(bucketId)).Labels;
+            var response = await _service.GetBucketsIDLabelsAsync(bucketId);
+            return response.Labels;
         }
 
         /// <summary>
@@ -450,12 +451,12 @@ namespace InfluxDB.Client
         /// <param name="label">the label of a bucket</param>
         /// <param name="bucket">the bucket of a label</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(Label label, Bucket bucket)
+        public Task<Label> AddLabelAsync(Label label, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return await AddLabelAsync(label.Id, bucket.Id);
+            return AddLabelAsync(label.Id, bucket.Id);
         }
 
         /// <summary>
@@ -471,7 +472,8 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            return (await _service.PostBucketsIDLabelsAsync(bucketId, mapping)).Label;
+            var response = await _service.PostBucketsIDLabelsAsync(bucketId, mapping);
+            return response.Label;
         }
 
         /// <summary>
@@ -480,12 +482,12 @@ namespace InfluxDB.Client
         /// <param name="label">the label of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(Label label, Bucket bucket)
+        public Task DeleteLabelAsync(Label label, Bucket bucket)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id, bucket.Id);
+            return DeleteLabelAsync(label.Id, bucket.Id);
         }
 
         /// <summary>
@@ -494,19 +496,19 @@ namespace InfluxDB.Client
         /// <param name="labelId">the ID of a label</param>
         /// <param name="bucketId">the ID of a bucket</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(string labelId, string bucketId)
+        public Task DeleteLabelAsync(string labelId, string bucketId)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteBucketsIDLabelsIDAsync(bucketId, labelId);
+            return _service.DeleteBucketsIDLabelsIDAsync(bucketId, labelId);
         }
 
-        private async Task<Buckets> FindBucketsAsync(string orgName, FindOptions findOptions)
+        private Task<Buckets> FindBucketsAsync(string orgName, FindOptions findOptions)
         {
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
-            return await _service.GetBucketsAsync(null, findOptions.Offset, findOptions.Limit, after: findOptions.After,org: orgName);
+            return _service.GetBucketsAsync(null, findOptions.Offset, findOptions.Limit, after: findOptions.After,org: orgName);
         }
     }
 }

--- a/Client/ChecksApi.cs
+++ b/Client/ChecksApi.cs
@@ -67,7 +67,7 @@ namespace InfluxDB.Client
                 orgID: orgId, every: every, statusMessageTemplate: messageTemplate, status: TaskStatusType.Active,
                 query: CreateDashboardQuery(query));
 
-            return (ThresholdCheck) await CreateCheckAsync(check);
+            return (ThresholdCheck) await CreateCheckAsync(check).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -99,7 +99,7 @@ namespace InfluxDB.Client
                 orgID: orgId, query: CreateDashboardQuery(query), statusMessageTemplate: messageTemplate,
                 status: TaskStatusType.Active);
 
-            return (DeadmanCheck) await CreateCheckAsync(check);
+            return (DeadmanCheck) await CreateCheckAsync(check).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -187,7 +187,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var checks = await FindChecksAsync(orgId, new FindOptions());
+            var checks = await FindChecksAsync(orgId, new FindOptions()).ConfigureAwait(false);
             return checks._Checks;
         }
 
@@ -227,7 +227,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            var labels = await _service.GetChecksIDLabelsAsync(checkId);
+            var labels = await _service.GetChecksIDLabelsAsync(checkId).ConfigureAwait(false);
             return labels.Labels;
         }
 
@@ -258,7 +258,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var labels = await _service.PostChecksIDLabelsAsync(checkId, mapping);
+            var labels = await _service.PostChecksIDLabelsAsync(checkId, mapping).ConfigureAwait(false);
             return labels.Label;
         }
 

--- a/Client/ChecksApi.cs
+++ b/Client/ChecksApi.cs
@@ -32,14 +32,14 @@ namespace InfluxDB.Client
         /// <param name="threshold">condition for that specific status</param>
         /// <param name="orgId">the organization that owns this check</param>
         /// <returns>ThresholdCheck created</returns>
-        public async Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query,
+        public Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query,
             string every, string messageTemplate, Threshold threshold, string orgId)
         {
             Arguments.CheckNotNull(threshold, nameof(threshold));
 
             var thresholds = new List<Threshold> {threshold};
 
-            return await CreateThresholdCheckAsync(name, query, every, messageTemplate, thresholds, orgId);
+            return CreateThresholdCheckAsync(name, query, every, messageTemplate, thresholds, orgId);
         }
 
         /// <summary>
@@ -107,9 +107,9 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="check">check to create</param>
         /// <returns>Check created</returns>
-        public async Task<Check> CreateCheckAsync(Check check)
+        public Task<Check> CreateCheckAsync(Check check)
         {
-            return await _service.CreateCheckAsync(check);
+            return _service.CreateCheckAsync(check);
         }
 
         /// <summary>
@@ -117,14 +117,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="check">check update to apply</param>
         /// <returns>An updated check</returns>
-        public async Task<Check> UpdateCheckAsync(Check check)
+        public Task<Check> UpdateCheckAsync(Check check)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
             Enum.TryParse(check.Status.ToString(), true,
                 out CheckPatch.StatusEnum status);
 
-            return await UpdateCheckAsync(check.Id,
+            return UpdateCheckAsync(check.Id,
                 new CheckPatch(check.Name, check.Description, status));
         }
 
@@ -134,12 +134,12 @@ namespace InfluxDB.Client
         /// <param name="checkId">ID of check</param>
         /// <param name="patch">update to apply</param>
         /// <returns>An updated check</returns>
-        public async Task<Check> UpdateCheckAsync(string checkId, CheckPatch patch)
+        public Task<Check> UpdateCheckAsync(string checkId, CheckPatch patch)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
             Arguments.CheckNotNull(patch, nameof(patch));
 
-            return await _service.PatchChecksIDAsync(checkId, patch);
+            return _service.PatchChecksIDAsync(checkId, patch);
         }
 
         /// <summary>
@@ -147,11 +147,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="check">the check to delete</param>
         /// <returns></returns>
-        public async Task DeleteCheckAsync(Check check)
+        public Task DeleteCheckAsync(Check check)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
-            await DeleteCheckAsync(check.Id);
+            return DeleteCheckAsync(check.Id);
         }
 
         /// <summary>
@@ -159,11 +159,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="checkId">checkID the ID of check to delete</param>
         /// <returns></returns>
-        public async Task DeleteCheckAsync(string checkId)
+        public Task DeleteCheckAsync(string checkId)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            await _service.DeleteChecksIDAsync(checkId);
+            return _service.DeleteChecksIDAsync(checkId);
         }
 
         /// <summary>
@@ -171,11 +171,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="checkId">ID of check</param>
         /// <returns>the check requested</returns>
-        public async Task<Check> FindCheckByIdAsync(string checkId)
+        public Task<Check> FindCheckByIdAsync(string checkId)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            return await _service.GetChecksIDAsync(checkId);
+            return _service.GetChecksIDAsync(checkId);
         }
 
         /// <summary>
@@ -187,7 +187,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await FindChecksAsync(orgId, new FindOptions()))._Checks;
+            var checks = await FindChecksAsync(orgId, new FindOptions());
+            return checks._Checks;
         }
 
         /// <summary>
@@ -196,12 +197,12 @@ namespace InfluxDB.Client
         /// <param name="orgId">only show checks belonging to specified organization</param>
         /// <param name="findOptions">find options</param>
         /// <returns>A list of checks</returns>
-        public async Task<Checks> FindChecksAsync(string orgId, FindOptions findOptions)
+        public Task<Checks> FindChecksAsync(string orgId, FindOptions findOptions)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
-            return await _service.GetChecksAsync(orgId, offset: findOptions.Offset,
+            return _service.GetChecksAsync(orgId, offset: findOptions.Offset,
                 limit: findOptions.Limit);
         }
 
@@ -210,11 +211,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="check"> the check</param>
         /// <returns>a list of all labels for a check</returns>
-        public async Task<List<Label>> GetLabelsAsync(Check check)
+        public Task<List<Label>> GetLabelsAsync(Check check)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
-            return await GetLabelsAsync(check.Id);
+            return GetLabelsAsync(check.Id);
         }
 
         /// <summary>
@@ -226,7 +227,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            return (await _service.GetChecksIDLabelsAsync(checkId)).Labels;
+            var labels = await _service.GetChecksIDLabelsAsync(checkId);
+            return labels.Labels;
         }
 
         /// <summary>
@@ -235,12 +237,12 @@ namespace InfluxDB.Client
         /// <param name="label">label to add</param>
         /// <param name="check">the check</param>
         /// <returns>the label was added to the check</returns>
-        public async Task<Label> AddLabelAsync(Label label, Check check)
+        public Task<Label> AddLabelAsync(Label label, Check check)
         {
             Arguments.CheckNotNull(check, nameof(check));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return await AddLabelAsync(label.Id, check.Id);
+            return AddLabelAsync(label.Id, check.Id);
         }
 
         /// <summary>
@@ -256,7 +258,8 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            return (await _service.PostChecksIDLabelsAsync(checkId, mapping)).Label;
+            var labels = await _service.PostChecksIDLabelsAsync(checkId, mapping);
+            return labels.Label;
         }
 
         /// <summary>
@@ -265,12 +268,12 @@ namespace InfluxDB.Client
         /// <param name="label">the label to delete</param>
         /// <param name="check">the check</param>
         /// <returns></returns>
-        public async Task DeleteLabelAsync(Label label, Check check)
+        public Task DeleteLabelAsync(Label label, Check check)
         {
             Arguments.CheckNotNull(check, nameof(check));
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id, check.Id);
+            return DeleteLabelAsync(label.Id, check.Id);
         }
 
         /// <summary>
@@ -279,12 +282,12 @@ namespace InfluxDB.Client
         /// <param name="labelId">labelID the label id to delete</param>
         /// <param name="checkId">checkID ID of the check</param>
         /// <returns></returns>
-        public async Task DeleteLabelAsync(string labelId, string checkId)
+        public Task DeleteLabelAsync(string labelId, string checkId)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteChecksIDLabelsIDAsync(checkId, labelId);
+            return _service.DeleteChecksIDLabelsIDAsync(checkId, labelId);
         }
 
         private DashboardQuery CreateDashboardQuery(string query)

--- a/Client/DeleteApi.cs
+++ b/Client/DeleteApi.cs
@@ -27,7 +27,7 @@ namespace InfluxDB.Client
         /// <param name="predicate">Sql where like delete statement</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public async Task Delete(DateTime start, DateTime stop, string predicate, Bucket bucket, Organization org)
+        public Task Delete(DateTime start, DateTime stop, string predicate, Bucket bucket, Organization org)
         {
             Arguments.CheckNotNull(start, "Start is required");
             Arguments.CheckNotNull(stop, "Stop is required");
@@ -35,7 +35,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(bucket, "Bucket is required");
             Arguments.CheckNotNull(org, "Organization is required");
             
-            await Delete(start, stop, predicate, bucket.Id, org.Id);
+            return Delete(start, stop, predicate, bucket.Id, org.Id);
         }
         
         /// <summary>
@@ -46,7 +46,7 @@ namespace InfluxDB.Client
         /// <param name="predicate">Sql where like delete statement</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public async Task Delete(DateTime start, DateTime stop, string predicate, string bucket, string org)
+        public Task Delete(DateTime start, DateTime stop, string predicate, string bucket, string org)
         {
             Arguments.CheckNotNull(start, "Start is required");
             Arguments.CheckNotNull(stop, "Stop is required");
@@ -56,7 +56,7 @@ namespace InfluxDB.Client
             
             var predicateRequest = new DeletePredicateRequest(start, stop, predicate);
 
-            await Delete(predicateRequest, bucket, org);
+            return Delete(predicateRequest, bucket, org);
         }
 
         /// <summary>
@@ -65,13 +65,13 @@ namespace InfluxDB.Client
         /// <param name="predicate">Predicate delete request</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public async Task Delete(DeletePredicateRequest predicate, string bucket, string org)
+        public Task Delete(DeletePredicateRequest predicate, string bucket, string org)
         {
             Arguments.CheckNotNull(predicate, "Predicate is required");
             Arguments.CheckNonEmptyString(bucket, "Bucket is required");
             Arguments.CheckNonEmptyString(org, "Organization is required");
             
-            await _service.DeletePostAsync(predicate, null, org, bucket, null, null);
+            return _service.DeletePostAsync(predicate, null, org, bucket, null, null);
         }
     }
 }

--- a/Client/InfluxDB.Client.Api/Client/ApiClient.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiClient.cs
@@ -205,7 +205,7 @@ namespace InfluxDB.Client.Api.Client
                 path, method, queryParams, postBody, headerParams, formParams, fileParams,
                 pathParams, contentType);
             InterceptRequest(request);
-            var response = await RestClient.ExecuteTaskAsync(request);
+            var response = await RestClient.ExecuteTaskAsync(request).ConfigureAwait(false);
             InterceptResponse(request, response);
             return (Object)response;
         }

--- a/Client/InfluxDB.Client.Api/Service/AuthorizationsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/AuthorizationsService.cs
@@ -602,9 +602,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="authID">The ID of the authorization to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteAuthorizationsIDAsync (string authID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteAuthorizationsIDAsync (string authID, string zapTraceSpan = null)
         {
-             await DeleteAuthorizationsIDAsyncWithHttpInfo(authID, zapTraceSpan);
+             return DeleteAuthorizationsIDAsyncWithHttpInfo(authID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/AuthorizationsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/AuthorizationsService.cs
@@ -483,7 +483,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -618,7 +618,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteAuthorizationsIDAsyncWithHttpInfo (string authID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteAuthorizationsIDAsyncWithIRestResponse(authID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteAuthorizationsIDAsyncWithIRestResponse(authID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -675,7 +675,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -807,7 +807,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -937,7 +937,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Authorizations</returns>
         public async System.Threading.Tasks.Task<Authorizations> GetAuthorizationsAsync (string zapTraceSpan = null, string userID = null, string user = null, string orgID = null, string org = null)
         {
-             ApiResponse<Authorizations> localVarResponse = await GetAuthorizationsAsyncWithHttpInfo(zapTraceSpan, userID, user, orgID, org);
+             ApiResponse<Authorizations> localVarResponse = await GetAuthorizationsAsyncWithHttpInfo(zapTraceSpan, userID, user, orgID, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -955,7 +955,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Authorizations>> GetAuthorizationsAsyncWithHttpInfo (string zapTraceSpan = null, string userID = null, string user = null, string orgID = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetAuthorizationsAsyncWithIRestResponse(zapTraceSpan, userID, user, orgID, org);
+            IRestResponse localVarResponse = await GetAuthorizationsAsyncWithIRestResponse(zapTraceSpan, userID, user, orgID, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1015,7 +1015,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1138,7 +1138,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1259,7 +1259,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Authorization</returns>
         public async System.Threading.Tasks.Task<Authorization> GetAuthorizationsIDAsync (string authID, string zapTraceSpan = null)
         {
-             ApiResponse<Authorization> localVarResponse = await GetAuthorizationsIDAsyncWithHttpInfo(authID, zapTraceSpan);
+             ApiResponse<Authorization> localVarResponse = await GetAuthorizationsIDAsyncWithHttpInfo(authID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1274,7 +1274,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Authorization>> GetAuthorizationsIDAsyncWithHttpInfo (string authID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetAuthorizationsIDAsyncWithIRestResponse(authID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetAuthorizationsIDAsyncWithIRestResponse(authID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1331,7 +1331,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1481,7 +1481,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1629,7 +1629,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Authorization</returns>
         public async System.Threading.Tasks.Task<Authorization> PatchAuthorizationsIDAsync (string authID, AuthorizationUpdateRequest authorizationUpdateRequest, string zapTraceSpan = null)
         {
-             ApiResponse<Authorization> localVarResponse = await PatchAuthorizationsIDAsyncWithHttpInfo(authID, authorizationUpdateRequest, zapTraceSpan);
+             ApiResponse<Authorization> localVarResponse = await PatchAuthorizationsIDAsyncWithHttpInfo(authID, authorizationUpdateRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1645,7 +1645,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Authorization>> PatchAuthorizationsIDAsyncWithHttpInfo (string authID, AuthorizationUpdateRequest authorizationUpdateRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchAuthorizationsIDAsyncWithIRestResponse(authID, authorizationUpdateRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchAuthorizationsIDAsyncWithIRestResponse(authID, authorizationUpdateRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1715,7 +1715,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1854,7 +1854,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1991,7 +1991,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Authorization</returns>
         public async System.Threading.Tasks.Task<Authorization> PostAuthorizationsAsync (Authorization authorization, string zapTraceSpan = null)
         {
-             ApiResponse<Authorization> localVarResponse = await PostAuthorizationsAsyncWithHttpInfo(authorization, zapTraceSpan);
+             ApiResponse<Authorization> localVarResponse = await PostAuthorizationsAsyncWithHttpInfo(authorization, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2006,7 +2006,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Authorization>> PostAuthorizationsAsyncWithHttpInfo (Authorization authorization, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostAuthorizationsAsyncWithIRestResponse(authorization, zapTraceSpan);
+            IRestResponse localVarResponse = await PostAuthorizationsAsyncWithIRestResponse(authorization, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2071,7 +2071,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/BucketsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/BucketsService.cs
@@ -132,7 +132,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -149,7 +149,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -505,7 +505,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -522,7 +522,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -1098,9 +1098,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="bucketID">The ID of the bucket to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDAsync (string bucketID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDAsync (string bucketID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             return DeleteBucketsIDAsyncWithHttpInfo(bucketID, zapTraceSpan);
 
         }
 
@@ -1434,9 +1434,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDLabelsIDAsync (string bucketID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDLabelsIDAsync (string bucketID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDLabelsIDAsyncWithHttpInfo(bucketID, labelID, zapTraceSpan);
+             return DeleteBucketsIDLabelsIDAsyncWithHttpInfo(bucketID, labelID, zapTraceSpan);
 
         }
 
@@ -1776,9 +1776,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="bucketID">The bucket ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDMembersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDMembersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDMembersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
+             return DeleteBucketsIDMembersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
 
         }
 
@@ -2118,9 +2118,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="bucketID">The bucket ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDOwnersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDOwnersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDOwnersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
+             return DeleteBucketsIDOwnersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
 
         }
 
@@ -2215,7 +2215,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2233,7 +2233,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2297,7 +2297,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2359,7 +2359,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2421,7 +2421,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2472,7 +2472,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2491,7 +2491,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
@@ -2521,7 +2521,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="offset"> (optional)</param>
         /// <param name="limit"> (optional, default to 20)</param>
-        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;.  (optional)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="org">The organization name. (optional)</param>
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>

--- a/Client/InfluxDB.Client.Api/Service/BucketsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/BucketsService.cs
@@ -979,7 +979,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1114,7 +1114,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1171,7 +1171,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1304,7 +1304,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1451,7 +1451,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDLabelsIDAsyncWithHttpInfo (string bucketID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDLabelsIDAsyncWithIRestResponse(bucketID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDLabelsIDAsyncWithIRestResponse(bucketID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1513,7 +1513,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1646,7 +1646,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1793,7 +1793,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDMembersIDAsyncWithHttpInfo (string userID, string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDMembersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDMembersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1855,7 +1855,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1988,7 +1988,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2135,7 +2135,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDOwnersIDAsyncWithHttpInfo (string userID, string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDOwnersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDOwnersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2197,7 +2197,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2339,7 +2339,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2479,7 +2479,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Buckets</returns>
         public async System.Threading.Tasks.Task<Buckets> GetBucketsAsync (string zapTraceSpan = null, int? offset = null, int? limit = null, string after = null, string org = null, string orgID = null, string name = null)
         {
-             ApiResponse<Buckets> localVarResponse = await GetBucketsAsyncWithHttpInfo(zapTraceSpan, offset, limit, after, org, orgID, name);
+             ApiResponse<Buckets> localVarResponse = await GetBucketsAsyncWithHttpInfo(zapTraceSpan, offset, limit, after, org, orgID, name).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2499,7 +2499,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Buckets>> GetBucketsAsyncWithHttpInfo (string zapTraceSpan = null, int? offset = null, int? limit = null, string after = null, string org = null, string orgID = null, string name = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsAsyncWithIRestResponse(zapTraceSpan, offset, limit, after, org, orgID, name);
+            IRestResponse localVarResponse = await GetBucketsAsyncWithIRestResponse(zapTraceSpan, offset, limit, after, org, orgID, name).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2563,7 +2563,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2686,7 +2686,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2807,7 +2807,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Bucket</returns>
         public async System.Threading.Tasks.Task<Bucket> GetBucketsIDAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<Bucket> localVarResponse = await GetBucketsIDAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<Bucket> localVarResponse = await GetBucketsIDAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2822,7 +2822,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Bucket>> GetBucketsIDAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2879,7 +2879,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3002,7 +3002,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3123,7 +3123,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetBucketsIDLabelsAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetBucketsIDLabelsAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetBucketsIDLabelsAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3138,7 +3138,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetBucketsIDLabelsAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDLabelsAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDLabelsAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3195,7 +3195,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3318,7 +3318,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3439,7 +3439,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetBucketsIDMembersAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetBucketsIDMembersAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetBucketsIDMembersAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3454,7 +3454,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetBucketsIDMembersAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDMembersAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDMembersAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3511,7 +3511,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3634,7 +3634,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3755,7 +3755,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetBucketsIDOwnersAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetBucketsIDOwnersAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetBucketsIDOwnersAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3770,7 +3770,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetBucketsIDOwnersAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDOwnersAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDOwnersAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3827,7 +3827,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3955,7 +3955,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4081,7 +4081,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Buckets</returns>
         public async System.Threading.Tasks.Task<Buckets> GetSourcesIDBucketsAsync (string sourceID, string zapTraceSpan = null, string org = null)
         {
-             ApiResponse<Buckets> localVarResponse = await GetSourcesIDBucketsAsyncWithHttpInfo(sourceID, zapTraceSpan, org);
+             ApiResponse<Buckets> localVarResponse = await GetSourcesIDBucketsAsyncWithHttpInfo(sourceID, zapTraceSpan, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4097,7 +4097,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Buckets>> GetSourcesIDBucketsAsyncWithHttpInfo (string sourceID, string zapTraceSpan = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSourcesIDBucketsAsyncWithIRestResponse(sourceID, zapTraceSpan, org);
+            IRestResponse localVarResponse = await GetSourcesIDBucketsAsyncWithIRestResponse(sourceID, zapTraceSpan, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4156,7 +4156,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4306,7 +4306,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4454,7 +4454,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Bucket</returns>
         public async System.Threading.Tasks.Task<Bucket> PatchBucketsIDAsync (string bucketID, Bucket bucket, string zapTraceSpan = null)
         {
-             ApiResponse<Bucket> localVarResponse = await PatchBucketsIDAsyncWithHttpInfo(bucketID, bucket, zapTraceSpan);
+             ApiResponse<Bucket> localVarResponse = await PatchBucketsIDAsyncWithHttpInfo(bucketID, bucket, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4470,7 +4470,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Bucket>> PatchBucketsIDAsyncWithHttpInfo (string bucketID, Bucket bucket, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchBucketsIDAsyncWithIRestResponse(bucketID, bucket, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchBucketsIDAsyncWithIRestResponse(bucketID, bucket, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4540,7 +4540,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4679,7 +4679,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4816,7 +4816,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Bucket</returns>
         public async System.Threading.Tasks.Task<Bucket> PostBucketsAsync (PostBucketRequest postBucketRequest, string zapTraceSpan = null)
         {
-             ApiResponse<Bucket> localVarResponse = await PostBucketsAsyncWithHttpInfo(postBucketRequest, zapTraceSpan);
+             ApiResponse<Bucket> localVarResponse = await PostBucketsAsyncWithHttpInfo(postBucketRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4831,7 +4831,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Bucket>> PostBucketsAsyncWithHttpInfo (PostBucketRequest postBucketRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsAsyncWithIRestResponse(postBucketRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsAsyncWithIRestResponse(postBucketRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4896,7 +4896,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5046,7 +5046,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5194,7 +5194,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostBucketsIDLabelsAsync (string bucketID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostBucketsIDLabelsAsyncWithHttpInfo(bucketID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostBucketsIDLabelsAsyncWithHttpInfo(bucketID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5210,7 +5210,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostBucketsIDLabelsAsyncWithHttpInfo (string bucketID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsIDLabelsAsyncWithIRestResponse(bucketID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsIDLabelsAsyncWithIRestResponse(bucketID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5280,7 +5280,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5430,7 +5430,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5578,7 +5578,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostBucketsIDMembersAsync (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostBucketsIDMembersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostBucketsIDMembersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5594,7 +5594,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostBucketsIDMembersAsyncWithHttpInfo (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsIDMembersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsIDMembersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5664,7 +5664,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5814,7 +5814,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5962,7 +5962,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostBucketsIDOwnersAsync (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostBucketsIDOwnersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostBucketsIDOwnersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5978,7 +5978,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostBucketsIDOwnersAsyncWithHttpInfo (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsIDOwnersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsIDOwnersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6048,7 +6048,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/CellsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/CellsService.cs
@@ -556,7 +556,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -703,7 +703,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDCellsIDAsyncWithHttpInfo (string dashboardID, string cellID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -765,7 +765,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -899,7 +899,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1031,7 +1031,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> GetDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1047,7 +1047,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> GetDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1109,7 +1109,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1270,7 +1270,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1429,7 +1429,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Cell</returns>
         public async System.Threading.Tasks.Task<Cell> PatchDashboardsIDCellsIDAsync (string dashboardID, string cellID, CellUpdate cellUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<Cell> localVarResponse = await PatchDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, cellUpdate, zapTraceSpan);
+             ApiResponse<Cell> localVarResponse = await PatchDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, cellUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1446,7 +1446,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Cell>> PatchDashboardsIDCellsIDAsyncWithHttpInfo (string dashboardID, string cellID, CellUpdate cellUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, cellUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, cellUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1521,7 +1521,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1682,7 +1682,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1841,7 +1841,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> PatchDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1858,7 +1858,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> PatchDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1933,7 +1933,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2083,7 +2083,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2231,7 +2231,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Cell</returns>
         public async System.Threading.Tasks.Task<Cell> PostDashboardsIDCellsAsync (string dashboardID, CreateCell createCell, string zapTraceSpan = null)
         {
-             ApiResponse<Cell> localVarResponse = await PostDashboardsIDCellsAsyncWithHttpInfo(dashboardID, createCell, zapTraceSpan);
+             ApiResponse<Cell> localVarResponse = await PostDashboardsIDCellsAsyncWithHttpInfo(dashboardID, createCell, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2247,7 +2247,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Cell>> PostDashboardsIDCellsAsyncWithHttpInfo (string dashboardID, CreateCell createCell, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDCellsAsyncWithIRestResponse(dashboardID, createCell, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDCellsAsyncWithIRestResponse(dashboardID, createCell, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2317,7 +2317,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2467,7 +2467,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2615,7 +2615,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboard</returns>
         public async System.Threading.Tasks.Task<Dashboard> PutDashboardsIDCellsAsync (string dashboardID, List<Cell> cell, string zapTraceSpan = null)
         {
-             ApiResponse<Dashboard> localVarResponse = await PutDashboardsIDCellsAsyncWithHttpInfo(dashboardID, cell, zapTraceSpan);
+             ApiResponse<Dashboard> localVarResponse = await PutDashboardsIDCellsAsyncWithHttpInfo(dashboardID, cell, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2631,7 +2631,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboard>> PutDashboardsIDCellsAsyncWithHttpInfo (string dashboardID, List<Cell> cell, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutDashboardsIDCellsAsyncWithIRestResponse(dashboardID, cell, zapTraceSpan);
+            IRestResponse localVarResponse = await PutDashboardsIDCellsAsyncWithIRestResponse(dashboardID, cell, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2701,7 +2701,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/CellsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/CellsService.cs
@@ -686,9 +686,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="cellID">The ID of the cell to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDCellsIDAsync (string dashboardID, string cellID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDCellsIDAsync (string dashboardID, string cellID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
+             return DeleteDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/ChecksService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ChecksService.cs
@@ -1179,9 +1179,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="checkID">The check ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteChecksIDAsync (string checkID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteChecksIDAsync (string checkID, string zapTraceSpan = null)
         {
-             await DeleteChecksIDAsyncWithHttpInfo(checkID, zapTraceSpan);
+             return DeleteChecksIDAsyncWithHttpInfo(checkID, zapTraceSpan);
 
         }
 
@@ -1515,9 +1515,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteChecksIDLabelsIDAsync (string checkID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteChecksIDLabelsIDAsync (string checkID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteChecksIDLabelsIDAsyncWithHttpInfo(checkID, labelID, zapTraceSpan);
+             return DeleteChecksIDLabelsIDAsyncWithHttpInfo(checkID, labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/ChecksService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ChecksService.cs
@@ -729,7 +729,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -861,7 +861,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Check</returns>
         public async System.Threading.Tasks.Task<Check> CreateCheckAsync (PostCheck postCheck)
         {
-             ApiResponse<Check> localVarResponse = await CreateCheckAsyncWithHttpInfo(postCheck);
+             ApiResponse<Check> localVarResponse = await CreateCheckAsyncWithHttpInfo(postCheck).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -875,7 +875,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Check>> CreateCheckAsyncWithHttpInfo (PostCheck postCheck)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await CreateCheckAsyncWithIRestResponse(postCheck);
+            IRestResponse localVarResponse = await CreateCheckAsyncWithIRestResponse(postCheck).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -938,7 +938,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1060,7 +1060,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1195,7 +1195,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteChecksIDAsyncWithHttpInfo (string checkID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteChecksIDAsyncWithIRestResponse(checkID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteChecksIDAsyncWithIRestResponse(checkID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1252,7 +1252,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1385,7 +1385,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1532,7 +1532,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteChecksIDLabelsIDAsyncWithHttpInfo (string checkID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteChecksIDLabelsIDAsyncWithIRestResponse(checkID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteChecksIDLabelsIDAsyncWithIRestResponse(checkID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1594,7 +1594,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1727,7 +1727,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1858,7 +1858,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Checks</returns>
         public async System.Threading.Tasks.Task<Checks> GetChecksAsync (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null)
         {
-             ApiResponse<Checks> localVarResponse = await GetChecksAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit);
+             ApiResponse<Checks> localVarResponse = await GetChecksAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1875,7 +1875,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Checks>> GetChecksAsyncWithHttpInfo (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetChecksAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit);
+            IRestResponse localVarResponse = await GetChecksAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1936,7 +1936,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2059,7 +2059,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2180,7 +2180,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Check</returns>
         public async System.Threading.Tasks.Task<Check> GetChecksIDAsync (string checkID, string zapTraceSpan = null)
         {
-             ApiResponse<Check> localVarResponse = await GetChecksIDAsyncWithHttpInfo(checkID, zapTraceSpan);
+             ApiResponse<Check> localVarResponse = await GetChecksIDAsyncWithHttpInfo(checkID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2195,7 +2195,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Check>> GetChecksIDAsyncWithHttpInfo (string checkID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetChecksIDAsyncWithIRestResponse(checkID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetChecksIDAsyncWithIRestResponse(checkID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2252,7 +2252,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2375,7 +2375,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2496,7 +2496,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetChecksIDLabelsAsync (string checkID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetChecksIDLabelsAsyncWithHttpInfo(checkID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetChecksIDLabelsAsyncWithHttpInfo(checkID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2511,7 +2511,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetChecksIDLabelsAsyncWithHttpInfo (string checkID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetChecksIDLabelsAsyncWithIRestResponse(checkID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetChecksIDLabelsAsyncWithIRestResponse(checkID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2568,7 +2568,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2691,7 +2691,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2812,7 +2812,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of FluxResponse</returns>
         public async System.Threading.Tasks.Task<FluxResponse> GetChecksIDQueryAsync (string checkID, string zapTraceSpan = null)
         {
-             ApiResponse<FluxResponse> localVarResponse = await GetChecksIDQueryAsyncWithHttpInfo(checkID, zapTraceSpan);
+             ApiResponse<FluxResponse> localVarResponse = await GetChecksIDQueryAsyncWithHttpInfo(checkID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2827,7 +2827,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<FluxResponse>> GetChecksIDQueryAsyncWithHttpInfo (string checkID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetChecksIDQueryAsyncWithIRestResponse(checkID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetChecksIDQueryAsyncWithIRestResponse(checkID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2884,7 +2884,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3034,7 +3034,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3182,7 +3182,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Check</returns>
         public async System.Threading.Tasks.Task<Check> PatchChecksIDAsync (string checkID, CheckPatch checkPatch, string zapTraceSpan = null)
         {
-             ApiResponse<Check> localVarResponse = await PatchChecksIDAsyncWithHttpInfo(checkID, checkPatch, zapTraceSpan);
+             ApiResponse<Check> localVarResponse = await PatchChecksIDAsyncWithHttpInfo(checkID, checkPatch, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3198,7 +3198,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Check>> PatchChecksIDAsyncWithHttpInfo (string checkID, CheckPatch checkPatch, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchChecksIDAsyncWithIRestResponse(checkID, checkPatch, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchChecksIDAsyncWithIRestResponse(checkID, checkPatch, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3268,7 +3268,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3418,7 +3418,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3566,7 +3566,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostChecksIDLabelsAsync (string checkID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostChecksIDLabelsAsyncWithHttpInfo(checkID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostChecksIDLabelsAsyncWithHttpInfo(checkID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3582,7 +3582,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostChecksIDLabelsAsyncWithHttpInfo (string checkID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostChecksIDLabelsAsyncWithIRestResponse(checkID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostChecksIDLabelsAsyncWithIRestResponse(checkID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3652,7 +3652,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3802,7 +3802,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3950,7 +3950,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Check</returns>
         public async System.Threading.Tasks.Task<Check> PutChecksIDAsync (string checkID, Check check, string zapTraceSpan = null)
         {
-             ApiResponse<Check> localVarResponse = await PutChecksIDAsyncWithHttpInfo(checkID, check, zapTraceSpan);
+             ApiResponse<Check> localVarResponse = await PutChecksIDAsyncWithHttpInfo(checkID, check, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3966,7 +3966,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Check>> PutChecksIDAsyncWithHttpInfo (string checkID, Check check, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutChecksIDAsyncWithIRestResponse(checkID, check, zapTraceSpan);
+            IRestResponse localVarResponse = await PutChecksIDAsyncWithIRestResponse(checkID, check, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4036,7 +4036,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/DBRPsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DBRPsService.cs
@@ -514,7 +514,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -661,7 +661,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDBRPIDAsyncWithHttpInfo (string orgID, string dbrpID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDBRPIDAsyncWithIRestResponse(orgID, dbrpID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDBRPIDAsyncWithIRestResponse(orgID, dbrpID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -723,7 +723,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -871,7 +871,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1017,7 +1017,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of DBRPs</returns>
         public async System.Threading.Tasks.Task<DBRPs> GetDBRPsAsync (string orgID, string zapTraceSpan = null, string id = null, string bucketID = null, bool? _default = null, string db = null, string rp = null)
         {
-             ApiResponse<DBRPs> localVarResponse = await GetDBRPsAsyncWithHttpInfo(orgID, zapTraceSpan, id, bucketID, _default, db, rp);
+             ApiResponse<DBRPs> localVarResponse = await GetDBRPsAsyncWithHttpInfo(orgID, zapTraceSpan, id, bucketID, _default, db, rp).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1037,7 +1037,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<DBRPs>> GetDBRPsAsyncWithHttpInfo (string orgID, string zapTraceSpan = null, string id = null, string bucketID = null, bool? _default = null, string db = null, string rp = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDBRPsAsyncWithIRestResponse(orgID, zapTraceSpan, id, bucketID, _default, db, rp);
+            IRestResponse localVarResponse = await GetDBRPsAsyncWithIRestResponse(orgID, zapTraceSpan, id, bucketID, _default, db, rp).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1104,7 +1104,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1238,7 +1238,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1370,7 +1370,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of DBRP</returns>
         public async System.Threading.Tasks.Task<DBRP> GetDBRPsIDAsync (string orgID, string dbrpID, string zapTraceSpan = null)
         {
-             ApiResponse<DBRP> localVarResponse = await GetDBRPsIDAsyncWithHttpInfo(orgID, dbrpID, zapTraceSpan);
+             ApiResponse<DBRP> localVarResponse = await GetDBRPsIDAsyncWithHttpInfo(orgID, dbrpID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1386,7 +1386,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<DBRP>> GetDBRPsIDAsyncWithHttpInfo (string orgID, string dbrpID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDBRPsIDAsyncWithIRestResponse(orgID, dbrpID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDBRPsIDAsyncWithIRestResponse(orgID, dbrpID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1448,7 +1448,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1609,7 +1609,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1768,7 +1768,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of DBRP</returns>
         public async System.Threading.Tasks.Task<DBRP> PatchDBRPIDAsync (string orgID, string dbrpID, DBRPUpdate dBRPUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<DBRP> localVarResponse = await PatchDBRPIDAsyncWithHttpInfo(orgID, dbrpID, dBRPUpdate, zapTraceSpan);
+             ApiResponse<DBRP> localVarResponse = await PatchDBRPIDAsyncWithHttpInfo(orgID, dbrpID, dBRPUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1785,7 +1785,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<DBRP>> PatchDBRPIDAsyncWithHttpInfo (string orgID, string dbrpID, DBRPUpdate dBRPUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDBRPIDAsyncWithIRestResponse(orgID, dbrpID, dBRPUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDBRPIDAsyncWithIRestResponse(orgID, dbrpID, dBRPUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1860,7 +1860,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1999,7 +1999,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2136,7 +2136,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of DBRP</returns>
         public async System.Threading.Tasks.Task<DBRP> PostDBRPAsync (DBRP DBRP, string zapTraceSpan = null)
         {
-             ApiResponse<DBRP> localVarResponse = await PostDBRPAsyncWithHttpInfo(DBRP, zapTraceSpan);
+             ApiResponse<DBRP> localVarResponse = await PostDBRPAsyncWithHttpInfo(DBRP, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2151,7 +2151,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<DBRP>> PostDBRPAsyncWithHttpInfo (DBRP DBRP, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDBRPAsyncWithIRestResponse(DBRP, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDBRPAsyncWithIRestResponse(DBRP, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2216,7 +2216,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/DBRPsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DBRPsService.cs
@@ -644,9 +644,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dbrpID">The database retention policy mapping</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDBRPIDAsync (string orgID, string dbrpID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDBRPIDAsync (string orgID, string dbrpID, string zapTraceSpan = null)
         {
-             await DeleteDBRPIDAsyncWithHttpInfo(orgID, dbrpID, zapTraceSpan);
+             return DeleteDBRPIDAsyncWithHttpInfo(orgID, dbrpID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/DashboardsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DashboardsService.cs
@@ -1237,7 +1237,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1372,7 +1372,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1429,7 +1429,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1562,7 +1562,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1709,7 +1709,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDCellsIDAsyncWithHttpInfo (string dashboardID, string cellID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1771,7 +1771,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1904,7 +1904,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2051,7 +2051,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDLabelsIDAsyncWithHttpInfo (string dashboardID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDLabelsIDAsyncWithIRestResponse(dashboardID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDLabelsIDAsyncWithIRestResponse(dashboardID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2113,7 +2113,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2246,7 +2246,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2393,7 +2393,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDMembersIDAsyncWithHttpInfo (string userID, string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDMembersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDMembersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2455,7 +2455,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2588,7 +2588,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2735,7 +2735,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDOwnersIDAsyncWithHttpInfo (string userID, string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDOwnersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDOwnersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2797,7 +2797,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2934,7 +2934,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3069,7 +3069,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboards</returns>
         public async System.Threading.Tasks.Task<Dashboards> GetDashboardsAsync (string zapTraceSpan = null, string owner = null, string sortBy = null, List<string> id = null, string orgID = null, string org = null)
         {
-             ApiResponse<Dashboards> localVarResponse = await GetDashboardsAsyncWithHttpInfo(zapTraceSpan, owner, sortBy, id, orgID, org);
+             ApiResponse<Dashboards> localVarResponse = await GetDashboardsAsyncWithHttpInfo(zapTraceSpan, owner, sortBy, id, orgID, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3088,7 +3088,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboards>> GetDashboardsAsyncWithHttpInfo (string zapTraceSpan = null, string owner = null, string sortBy = null, List<string> id = null, string orgID = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsAsyncWithIRestResponse(zapTraceSpan, owner, sortBy, id, orgID, org);
+            IRestResponse localVarResponse = await GetDashboardsAsyncWithIRestResponse(zapTraceSpan, owner, sortBy, id, orgID, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3150,7 +3150,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3278,7 +3278,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3404,7 +3404,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboard</returns>
         public async System.Threading.Tasks.Task<Dashboard> GetDashboardsIDAsync (string dashboardID, string zapTraceSpan = null, string include = null)
         {
-             ApiResponse<Dashboard> localVarResponse = await GetDashboardsIDAsyncWithHttpInfo(dashboardID, zapTraceSpan, include);
+             ApiResponse<Dashboard> localVarResponse = await GetDashboardsIDAsyncWithHttpInfo(dashboardID, zapTraceSpan, include).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3420,7 +3420,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboard>> GetDashboardsIDAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null, string include = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDAsyncWithIRestResponse(dashboardID, zapTraceSpan, include);
+            IRestResponse localVarResponse = await GetDashboardsIDAsyncWithIRestResponse(dashboardID, zapTraceSpan, include).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3479,7 +3479,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3613,7 +3613,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3745,7 +3745,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> GetDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3761,7 +3761,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> GetDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3823,7 +3823,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3946,7 +3946,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4067,7 +4067,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetDashboardsIDLabelsAsync (string dashboardID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetDashboardsIDLabelsAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetDashboardsIDLabelsAsyncWithHttpInfo(dashboardID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4082,7 +4082,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetDashboardsIDLabelsAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDLabelsAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDLabelsAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4139,7 +4139,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4262,7 +4262,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4383,7 +4383,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetDashboardsIDMembersAsync (string dashboardID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetDashboardsIDMembersAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetDashboardsIDMembersAsyncWithHttpInfo(dashboardID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4398,7 +4398,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetDashboardsIDMembersAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDMembersAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDMembersAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4455,7 +4455,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4578,7 +4578,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4699,7 +4699,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetDashboardsIDOwnersAsync (string dashboardID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4714,7 +4714,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetDashboardsIDOwnersAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4771,7 +4771,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4921,7 +4921,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5069,7 +5069,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboard</returns>
         public async System.Threading.Tasks.Task<Dashboard> PatchDashboardsIDAsync (string dashboardID, Dashboard dashboard, string zapTraceSpan = null)
         {
-             ApiResponse<Dashboard> localVarResponse = await PatchDashboardsIDAsyncWithHttpInfo(dashboardID, dashboard, zapTraceSpan);
+             ApiResponse<Dashboard> localVarResponse = await PatchDashboardsIDAsyncWithHttpInfo(dashboardID, dashboard, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5085,7 +5085,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboard>> PatchDashboardsIDAsyncWithHttpInfo (string dashboardID, Dashboard dashboard, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDAsyncWithIRestResponse(dashboardID, dashboard, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDAsyncWithIRestResponse(dashboardID, dashboard, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5155,7 +5155,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5316,7 +5316,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5475,7 +5475,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Cell</returns>
         public async System.Threading.Tasks.Task<Cell> PatchDashboardsIDCellsIDAsync (string dashboardID, string cellID, CellUpdate cellUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<Cell> localVarResponse = await PatchDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, cellUpdate, zapTraceSpan);
+             ApiResponse<Cell> localVarResponse = await PatchDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, cellUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5492,7 +5492,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Cell>> PatchDashboardsIDCellsIDAsyncWithHttpInfo (string dashboardID, string cellID, CellUpdate cellUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, cellUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDAsyncWithIRestResponse(dashboardID, cellID, cellUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5567,7 +5567,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5728,7 +5728,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5887,7 +5887,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> PatchDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5904,7 +5904,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> PatchDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5979,7 +5979,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6118,7 +6118,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6255,7 +6255,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboard</returns>
         public async System.Threading.Tasks.Task<Dashboard> PostDashboardsAsync (CreateDashboardRequest createDashboardRequest, string zapTraceSpan = null)
         {
-             ApiResponse<Dashboard> localVarResponse = await PostDashboardsAsyncWithHttpInfo(createDashboardRequest, zapTraceSpan);
+             ApiResponse<Dashboard> localVarResponse = await PostDashboardsAsyncWithHttpInfo(createDashboardRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6270,7 +6270,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboard>> PostDashboardsAsyncWithHttpInfo (CreateDashboardRequest createDashboardRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsAsyncWithIRestResponse(createDashboardRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsAsyncWithIRestResponse(createDashboardRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6335,7 +6335,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6485,7 +6485,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6633,7 +6633,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Cell</returns>
         public async System.Threading.Tasks.Task<Cell> PostDashboardsIDCellsAsync (string dashboardID, CreateCell createCell, string zapTraceSpan = null)
         {
-             ApiResponse<Cell> localVarResponse = await PostDashboardsIDCellsAsyncWithHttpInfo(dashboardID, createCell, zapTraceSpan);
+             ApiResponse<Cell> localVarResponse = await PostDashboardsIDCellsAsyncWithHttpInfo(dashboardID, createCell, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6649,7 +6649,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Cell>> PostDashboardsIDCellsAsyncWithHttpInfo (string dashboardID, CreateCell createCell, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDCellsAsyncWithIRestResponse(dashboardID, createCell, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDCellsAsyncWithIRestResponse(dashboardID, createCell, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6719,7 +6719,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6869,7 +6869,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7017,7 +7017,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostDashboardsIDLabelsAsync (string dashboardID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostDashboardsIDLabelsAsyncWithHttpInfo(dashboardID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostDashboardsIDLabelsAsyncWithHttpInfo(dashboardID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7033,7 +7033,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostDashboardsIDLabelsAsyncWithHttpInfo (string dashboardID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDLabelsAsyncWithIRestResponse(dashboardID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDLabelsAsyncWithIRestResponse(dashboardID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7103,7 +7103,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7253,7 +7253,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7401,7 +7401,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostDashboardsIDMembersAsync (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostDashboardsIDMembersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostDashboardsIDMembersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7417,7 +7417,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostDashboardsIDMembersAsyncWithHttpInfo (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDMembersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDMembersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7487,7 +7487,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7637,7 +7637,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7785,7 +7785,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostDashboardsIDOwnersAsync (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7801,7 +7801,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostDashboardsIDOwnersAsyncWithHttpInfo (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7871,7 +7871,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8021,7 +8021,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8169,7 +8169,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Dashboard</returns>
         public async System.Threading.Tasks.Task<Dashboard> PutDashboardsIDCellsAsync (string dashboardID, List<Cell> cell, string zapTraceSpan = null)
         {
-             ApiResponse<Dashboard> localVarResponse = await PutDashboardsIDCellsAsyncWithHttpInfo(dashboardID, cell, zapTraceSpan);
+             ApiResponse<Dashboard> localVarResponse = await PutDashboardsIDCellsAsyncWithHttpInfo(dashboardID, cell, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8185,7 +8185,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Dashboard>> PutDashboardsIDCellsAsyncWithHttpInfo (string dashboardID, List<Cell> cell, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutDashboardsIDCellsAsyncWithIRestResponse(dashboardID, cell, zapTraceSpan);
+            IRestResponse localVarResponse = await PutDashboardsIDCellsAsyncWithIRestResponse(dashboardID, cell, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8255,7 +8255,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/DashboardsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DashboardsService.cs
@@ -1356,9 +1356,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dashboardID">The ID of the dashboard to update.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDAsync (string dashboardID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDAsync (string dashboardID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             return DeleteDashboardsIDAsyncWithHttpInfo(dashboardID, zapTraceSpan);
 
         }
 
@@ -1692,9 +1692,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="cellID">The ID of the cell to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDCellsIDAsync (string dashboardID, string cellID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDCellsIDAsync (string dashboardID, string cellID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
+             return DeleteDashboardsIDCellsIDAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
 
         }
 
@@ -2034,9 +2034,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDLabelsIDAsync (string dashboardID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDLabelsIDAsync (string dashboardID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDLabelsIDAsyncWithHttpInfo(dashboardID, labelID, zapTraceSpan);
+             return DeleteDashboardsIDLabelsIDAsyncWithHttpInfo(dashboardID, labelID, zapTraceSpan);
 
         }
 
@@ -2376,9 +2376,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dashboardID">The dashboard ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDMembersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDMembersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDMembersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
+             return DeleteDashboardsIDMembersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
 
         }
 
@@ -2718,9 +2718,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dashboardID">The dashboard ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDOwnersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDOwnersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDOwnersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
+             return DeleteDashboardsIDOwnersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/DefaultService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DefaultService.cs
@@ -465,7 +465,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -640,7 +640,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeletePostAsyncWithHttpInfo (DeletePredicateRequest deletePredicateRequest, string zapTraceSpan = null, string org = null, string bucket = null, string orgID = null, string bucketID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeletePostAsyncWithIRestResponse(deletePredicateRequest, zapTraceSpan, org, bucket, orgID, bucketID);
+            IRestResponse localVarResponse = await DeletePostAsyncWithIRestResponse(deletePredicateRequest, zapTraceSpan, org, bucket, orgID, bucketID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -713,7 +713,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -825,7 +825,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -935,7 +935,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Routes</returns>
         public async System.Threading.Tasks.Task<Routes> GetRoutesAsync (string zapTraceSpan = null)
         {
-             ApiResponse<Routes> localVarResponse = await GetRoutesAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<Routes> localVarResponse = await GetRoutesAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -949,7 +949,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Routes>> GetRoutesAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetRoutesAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetRoutesAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1001,7 +1001,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1129,7 +1129,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1270,7 +1270,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostSigninAsyncWithHttpInfo (string zapTraceSpan = null, String authorization = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostSigninAsyncWithIRestResponse(zapTraceSpan, authorization);
+            IRestResponse localVarResponse = await PostSigninAsyncWithIRestResponse(zapTraceSpan, authorization).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1330,7 +1330,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1441,7 +1441,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1564,7 +1564,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostSignoutAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostSignoutAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await PostSignoutAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1616,7 +1616,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/DefaultService.cs
+++ b/Client/InfluxDB.Client.Api/Service/DefaultService.cs
@@ -620,9 +620,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">Specifies the organization ID of the resource. (optional)</param>
         /// <param name="bucketID">Specifies the bucket ID to delete data from. (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeletePostAsync (DeletePredicateRequest deletePredicateRequest, string zapTraceSpan = null, string org = null, string bucket = null, string orgID = null, string bucketID = null)
+        public System.Threading.Tasks.Task DeletePostAsync (DeletePredicateRequest deletePredicateRequest, string zapTraceSpan = null, string org = null, string bucket = null, string orgID = null, string bucketID = null)
         {
-             await DeletePostAsyncWithHttpInfo(deletePredicateRequest, zapTraceSpan, org, bucket, orgID, bucketID);
+             return DeletePostAsyncWithHttpInfo(deletePredicateRequest, zapTraceSpan, org, bucket, orgID, bucketID);
 
         }
 
@@ -1254,9 +1254,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="authorization">An auth credential for the Basic scheme (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostSigninAsync (string zapTraceSpan = null, String authorization = null)
+        public System.Threading.Tasks.Task PostSigninAsync (string zapTraceSpan = null, String authorization = null)
         {
-             await PostSigninAsyncWithHttpInfo(zapTraceSpan, authorization);
+             return PostSigninAsyncWithHttpInfo(zapTraceSpan, authorization);
 
         }
 
@@ -1549,9 +1549,9 @@ namespace InfluxDB.Client.Api.Service
         /// <exception cref="InfluxDB.Client.Api.Client.ApiException">Thrown when fails to make API call</exception>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostSignoutAsync (string zapTraceSpan = null)
+        public System.Threading.Tasks.Task PostSignoutAsync (string zapTraceSpan = null)
         {
-             await PostSignoutAsyncWithHttpInfo(zapTraceSpan);
+             return PostSignoutAsyncWithHttpInfo(zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/HealthService.cs
+++ b/Client/InfluxDB.Client.Api/Service/HealthService.cs
@@ -269,7 +269,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -379,7 +379,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of HealthCheck</returns>
         public async System.Threading.Tasks.Task<HealthCheck> GetHealthAsync (string zapTraceSpan = null)
         {
-             ApiResponse<HealthCheck> localVarResponse = await GetHealthAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<HealthCheck> localVarResponse = await GetHealthAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -393,7 +393,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<HealthCheck>> GetHealthAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetHealthAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetHealthAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -445,7 +445,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/LabelsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/LabelsService.cs
@@ -467,7 +467,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -602,7 +602,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteLabelsIDAsyncWithHttpInfo (string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteLabelsIDAsyncWithIRestResponse(labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteLabelsIDAsyncWithIRestResponse(labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -659,7 +659,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -776,7 +776,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -891,7 +891,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetLabelsAsync (string zapTraceSpan = null, string orgID = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetLabelsAsyncWithHttpInfo(zapTraceSpan, orgID);
+             ApiResponse<LabelsResponse> localVarResponse = await GetLabelsAsyncWithHttpInfo(zapTraceSpan, orgID).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -906,7 +906,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetLabelsAsyncWithHttpInfo (string zapTraceSpan = null, string orgID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetLabelsAsyncWithIRestResponse(zapTraceSpan, orgID);
+            IRestResponse localVarResponse = await GetLabelsAsyncWithIRestResponse(zapTraceSpan, orgID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -960,7 +960,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1083,7 +1083,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1204,7 +1204,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> GetLabelsIDAsync (string labelID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await GetLabelsIDAsyncWithHttpInfo(labelID, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await GetLabelsIDAsyncWithHttpInfo(labelID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1219,7 +1219,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> GetLabelsIDAsyncWithHttpInfo (string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetLabelsIDAsyncWithIRestResponse(labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetLabelsIDAsyncWithIRestResponse(labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1276,7 +1276,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1426,7 +1426,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1574,7 +1574,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PatchLabelsIDAsync (string labelID, LabelUpdate labelUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PatchLabelsIDAsyncWithHttpInfo(labelID, labelUpdate, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PatchLabelsIDAsyncWithHttpInfo(labelID, labelUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1590,7 +1590,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PatchLabelsIDAsyncWithHttpInfo (string labelID, LabelUpdate labelUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchLabelsIDAsyncWithIRestResponse(labelID, labelUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchLabelsIDAsyncWithIRestResponse(labelID, labelUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1660,7 +1660,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1794,7 +1794,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1926,7 +1926,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostLabelsAsync (LabelCreateRequest labelCreateRequest)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostLabelsAsyncWithHttpInfo(labelCreateRequest);
+             ApiResponse<LabelResponse> localVarResponse = await PostLabelsAsyncWithHttpInfo(labelCreateRequest).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1940,7 +1940,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostLabelsAsyncWithHttpInfo (LabelCreateRequest labelCreateRequest)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostLabelsAsyncWithIRestResponse(labelCreateRequest);
+            IRestResponse localVarResponse = await PostLabelsAsyncWithIRestResponse(labelCreateRequest).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2003,7 +2003,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/LabelsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/LabelsService.cs
@@ -586,9 +586,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteLabelsIDAsync (string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteLabelsIDAsync (string labelID, string zapTraceSpan = null)
         {
-             await DeleteLabelsIDAsyncWithHttpInfo(labelID, zapTraceSpan);
+             return DeleteLabelsIDAsyncWithHttpInfo(labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/NotificationEndpointsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/NotificationEndpointsService.cs
@@ -683,7 +683,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -815,7 +815,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationEndpoint</returns>
         public async System.Threading.Tasks.Task<NotificationEndpoint> CreateNotificationEndpointAsync (PostNotificationEndpoint postNotificationEndpoint)
         {
-             ApiResponse<NotificationEndpoint> localVarResponse = await CreateNotificationEndpointAsyncWithHttpInfo(postNotificationEndpoint);
+             ApiResponse<NotificationEndpoint> localVarResponse = await CreateNotificationEndpointAsyncWithHttpInfo(postNotificationEndpoint).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -829,7 +829,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationEndpoint>> CreateNotificationEndpointAsyncWithHttpInfo (PostNotificationEndpoint postNotificationEndpoint)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await CreateNotificationEndpointAsyncWithIRestResponse(postNotificationEndpoint);
+            IRestResponse localVarResponse = await CreateNotificationEndpointAsyncWithIRestResponse(postNotificationEndpoint).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -892,7 +892,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1014,7 +1014,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1149,7 +1149,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteNotificationEndpointsIDAsyncWithHttpInfo (string endpointID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteNotificationEndpointsIDAsyncWithIRestResponse(endpointID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteNotificationEndpointsIDAsyncWithIRestResponse(endpointID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1206,7 +1206,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1339,7 +1339,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1486,7 +1486,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteNotificationEndpointsIDLabelsIDAsyncWithHttpInfo (string endpointID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteNotificationEndpointsIDLabelsIDAsyncWithIRestResponse(endpointID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteNotificationEndpointsIDLabelsIDAsyncWithIRestResponse(endpointID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1548,7 +1548,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1681,7 +1681,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1812,7 +1812,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationEndpoints</returns>
         public async System.Threading.Tasks.Task<NotificationEndpoints> GetNotificationEndpointsAsync (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null)
         {
-             ApiResponse<NotificationEndpoints> localVarResponse = await GetNotificationEndpointsAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit);
+             ApiResponse<NotificationEndpoints> localVarResponse = await GetNotificationEndpointsAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1829,7 +1829,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationEndpoints>> GetNotificationEndpointsAsyncWithHttpInfo (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationEndpointsAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit);
+            IRestResponse localVarResponse = await GetNotificationEndpointsAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1890,7 +1890,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2013,7 +2013,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2134,7 +2134,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationEndpoint</returns>
         public async System.Threading.Tasks.Task<NotificationEndpoint> GetNotificationEndpointsIDAsync (string endpointID, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationEndpoint> localVarResponse = await GetNotificationEndpointsIDAsyncWithHttpInfo(endpointID, zapTraceSpan);
+             ApiResponse<NotificationEndpoint> localVarResponse = await GetNotificationEndpointsIDAsyncWithHttpInfo(endpointID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2149,7 +2149,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationEndpoint>> GetNotificationEndpointsIDAsyncWithHttpInfo (string endpointID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationEndpointsIDAsyncWithIRestResponse(endpointID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetNotificationEndpointsIDAsyncWithIRestResponse(endpointID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2206,7 +2206,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2329,7 +2329,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2450,7 +2450,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetNotificationEndpointsIDLabelsAsync (string endpointID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetNotificationEndpointsIDLabelsAsyncWithHttpInfo(endpointID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetNotificationEndpointsIDLabelsAsyncWithHttpInfo(endpointID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2465,7 +2465,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetNotificationEndpointsIDLabelsAsyncWithHttpInfo (string endpointID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationEndpointsIDLabelsAsyncWithIRestResponse(endpointID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetNotificationEndpointsIDLabelsAsyncWithIRestResponse(endpointID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2522,7 +2522,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2672,7 +2672,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2820,7 +2820,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationEndpoint</returns>
         public async System.Threading.Tasks.Task<NotificationEndpoint> PatchNotificationEndpointsIDAsync (string endpointID, NotificationEndpointUpdate notificationEndpointUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationEndpoint> localVarResponse = await PatchNotificationEndpointsIDAsyncWithHttpInfo(endpointID, notificationEndpointUpdate, zapTraceSpan);
+             ApiResponse<NotificationEndpoint> localVarResponse = await PatchNotificationEndpointsIDAsyncWithHttpInfo(endpointID, notificationEndpointUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2836,7 +2836,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationEndpoint>> PatchNotificationEndpointsIDAsyncWithHttpInfo (string endpointID, NotificationEndpointUpdate notificationEndpointUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchNotificationEndpointsIDAsyncWithIRestResponse(endpointID, notificationEndpointUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchNotificationEndpointsIDAsyncWithIRestResponse(endpointID, notificationEndpointUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2906,7 +2906,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3056,7 +3056,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3204,7 +3204,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostNotificationEndpointIDLabelsAsync (string endpointID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostNotificationEndpointIDLabelsAsyncWithHttpInfo(endpointID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostNotificationEndpointIDLabelsAsyncWithHttpInfo(endpointID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3220,7 +3220,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostNotificationEndpointIDLabelsAsyncWithHttpInfo (string endpointID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostNotificationEndpointIDLabelsAsyncWithIRestResponse(endpointID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostNotificationEndpointIDLabelsAsyncWithIRestResponse(endpointID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3290,7 +3290,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3440,7 +3440,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3588,7 +3588,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationEndpoint</returns>
         public async System.Threading.Tasks.Task<NotificationEndpoint> PutNotificationEndpointsIDAsync (string endpointID, NotificationEndpoint notificationEndpoint, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationEndpoint> localVarResponse = await PutNotificationEndpointsIDAsyncWithHttpInfo(endpointID, notificationEndpoint, zapTraceSpan);
+             ApiResponse<NotificationEndpoint> localVarResponse = await PutNotificationEndpointsIDAsyncWithHttpInfo(endpointID, notificationEndpoint, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3604,7 +3604,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationEndpoint>> PutNotificationEndpointsIDAsyncWithHttpInfo (string endpointID, NotificationEndpoint notificationEndpoint, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutNotificationEndpointsIDAsyncWithIRestResponse(endpointID, notificationEndpoint, zapTraceSpan);
+            IRestResponse localVarResponse = await PutNotificationEndpointsIDAsyncWithIRestResponse(endpointID, notificationEndpoint, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3674,7 +3674,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/NotificationEndpointsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/NotificationEndpointsService.cs
@@ -1133,9 +1133,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="endpointID">The notification endpoint ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteNotificationEndpointsIDAsync (string endpointID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteNotificationEndpointsIDAsync (string endpointID, string zapTraceSpan = null)
         {
-             await DeleteNotificationEndpointsIDAsyncWithHttpInfo(endpointID, zapTraceSpan);
+             return DeleteNotificationEndpointsIDAsyncWithHttpInfo(endpointID, zapTraceSpan);
 
         }
 
@@ -1469,9 +1469,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteNotificationEndpointsIDLabelsIDAsync (string endpointID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteNotificationEndpointsIDLabelsIDAsync (string endpointID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteNotificationEndpointsIDLabelsIDAsyncWithHttpInfo(endpointID, labelID, zapTraceSpan);
+             return DeleteNotificationEndpointsIDLabelsIDAsyncWithHttpInfo(endpointID, labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/NotificationRulesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/NotificationRulesService.cs
@@ -691,7 +691,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -823,7 +823,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationRule</returns>
         public async System.Threading.Tasks.Task<NotificationRule> CreateNotificationRuleAsync (PostNotificationRule postNotificationRule)
         {
-             ApiResponse<NotificationRule> localVarResponse = await CreateNotificationRuleAsyncWithHttpInfo(postNotificationRule);
+             ApiResponse<NotificationRule> localVarResponse = await CreateNotificationRuleAsyncWithHttpInfo(postNotificationRule).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -837,7 +837,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationRule>> CreateNotificationRuleAsyncWithHttpInfo (PostNotificationRule postNotificationRule)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await CreateNotificationRuleAsyncWithIRestResponse(postNotificationRule);
+            IRestResponse localVarResponse = await CreateNotificationRuleAsyncWithIRestResponse(postNotificationRule).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -900,7 +900,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1022,7 +1022,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1157,7 +1157,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteNotificationRulesIDAsyncWithHttpInfo (string ruleID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteNotificationRulesIDAsyncWithIRestResponse(ruleID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteNotificationRulesIDAsyncWithIRestResponse(ruleID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1214,7 +1214,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1347,7 +1347,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1494,7 +1494,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteNotificationRulesIDLabelsIDAsyncWithHttpInfo (string ruleID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteNotificationRulesIDLabelsIDAsyncWithIRestResponse(ruleID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteNotificationRulesIDLabelsIDAsyncWithIRestResponse(ruleID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1556,7 +1556,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1699,7 +1699,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1840,7 +1840,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationRules</returns>
         public async System.Threading.Tasks.Task<NotificationRules> GetNotificationRulesAsync (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null, string checkID = null, string tag = null)
         {
-             ApiResponse<NotificationRules> localVarResponse = await GetNotificationRulesAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit, checkID, tag);
+             ApiResponse<NotificationRules> localVarResponse = await GetNotificationRulesAsyncWithHttpInfo(orgID, zapTraceSpan, offset, limit, checkID, tag).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1859,7 +1859,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationRules>> GetNotificationRulesAsyncWithHttpInfo (string orgID, string zapTraceSpan = null, int? offset = null, int? limit = null, string checkID = null, string tag = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationRulesAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit, checkID, tag);
+            IRestResponse localVarResponse = await GetNotificationRulesAsyncWithIRestResponse(orgID, zapTraceSpan, offset, limit, checkID, tag).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1924,7 +1924,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2047,7 +2047,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2168,7 +2168,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationRule</returns>
         public async System.Threading.Tasks.Task<NotificationRule> GetNotificationRulesIDAsync (string ruleID, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationRule> localVarResponse = await GetNotificationRulesIDAsyncWithHttpInfo(ruleID, zapTraceSpan);
+             ApiResponse<NotificationRule> localVarResponse = await GetNotificationRulesIDAsyncWithHttpInfo(ruleID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2183,7 +2183,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationRule>> GetNotificationRulesIDAsyncWithHttpInfo (string ruleID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationRulesIDAsyncWithIRestResponse(ruleID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetNotificationRulesIDAsyncWithIRestResponse(ruleID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2240,7 +2240,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2363,7 +2363,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2484,7 +2484,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetNotificationRulesIDLabelsAsync (string ruleID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetNotificationRulesIDLabelsAsyncWithHttpInfo(ruleID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetNotificationRulesIDLabelsAsyncWithHttpInfo(ruleID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2499,7 +2499,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetNotificationRulesIDLabelsAsyncWithHttpInfo (string ruleID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationRulesIDLabelsAsyncWithIRestResponse(ruleID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetNotificationRulesIDLabelsAsyncWithIRestResponse(ruleID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2556,7 +2556,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2706,7 +2706,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2854,7 +2854,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationRule</returns>
         public async System.Threading.Tasks.Task<NotificationRule> PatchNotificationRulesIDAsync (string ruleID, NotificationRuleUpdate notificationRuleUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationRule> localVarResponse = await PatchNotificationRulesIDAsyncWithHttpInfo(ruleID, notificationRuleUpdate, zapTraceSpan);
+             ApiResponse<NotificationRule> localVarResponse = await PatchNotificationRulesIDAsyncWithHttpInfo(ruleID, notificationRuleUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2870,7 +2870,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationRule>> PatchNotificationRulesIDAsyncWithHttpInfo (string ruleID, NotificationRuleUpdate notificationRuleUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchNotificationRulesIDAsyncWithIRestResponse(ruleID, notificationRuleUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchNotificationRulesIDAsyncWithIRestResponse(ruleID, notificationRuleUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2940,7 +2940,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3090,7 +3090,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3238,7 +3238,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostNotificationRuleIDLabelsAsync (string ruleID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostNotificationRuleIDLabelsAsyncWithHttpInfo(ruleID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostNotificationRuleIDLabelsAsyncWithHttpInfo(ruleID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3254,7 +3254,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostNotificationRuleIDLabelsAsyncWithHttpInfo (string ruleID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostNotificationRuleIDLabelsAsyncWithIRestResponse(ruleID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostNotificationRuleIDLabelsAsyncWithIRestResponse(ruleID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3324,7 +3324,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3474,7 +3474,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3622,7 +3622,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of NotificationRule</returns>
         public async System.Threading.Tasks.Task<NotificationRule> PutNotificationRulesIDAsync (string ruleID, NotificationRule notificationRule, string zapTraceSpan = null)
         {
-             ApiResponse<NotificationRule> localVarResponse = await PutNotificationRulesIDAsyncWithHttpInfo(ruleID, notificationRule, zapTraceSpan);
+             ApiResponse<NotificationRule> localVarResponse = await PutNotificationRulesIDAsyncWithHttpInfo(ruleID, notificationRule, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3638,7 +3638,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<NotificationRule>> PutNotificationRulesIDAsyncWithHttpInfo (string ruleID, NotificationRule notificationRule, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutNotificationRulesIDAsyncWithIRestResponse(ruleID, notificationRule, zapTraceSpan);
+            IRestResponse localVarResponse = await PutNotificationRulesIDAsyncWithIRestResponse(ruleID, notificationRule, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3708,7 +3708,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/NotificationRulesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/NotificationRulesService.cs
@@ -1141,9 +1141,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="ruleID">The notification rule ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteNotificationRulesIDAsync (string ruleID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteNotificationRulesIDAsync (string ruleID, string zapTraceSpan = null)
         {
-             await DeleteNotificationRulesIDAsyncWithHttpInfo(ruleID, zapTraceSpan);
+             return DeleteNotificationRulesIDAsyncWithHttpInfo(ruleID, zapTraceSpan);
 
         }
 
@@ -1477,9 +1477,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The ID of the label to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteNotificationRulesIDLabelsIDAsync (string ruleID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteNotificationRulesIDLabelsIDAsync (string ruleID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteNotificationRulesIDLabelsIDAsyncWithHttpInfo(ruleID, labelID, zapTraceSpan);
+             return DeleteNotificationRulesIDLabelsIDAsyncWithHttpInfo(ruleID, labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/OrganizationsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/OrganizationsService.cs
@@ -929,7 +929,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1064,7 +1064,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteOrgsIDAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteOrgsIDAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteOrgsIDAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1121,7 +1121,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1254,7 +1254,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1401,7 +1401,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteOrgsIDMembersIDAsyncWithHttpInfo (string userID, string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteOrgsIDMembersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteOrgsIDMembersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1463,7 +1463,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1596,7 +1596,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1743,7 +1743,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteOrgsIDOwnersIDAsyncWithHttpInfo (string userID, string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteOrgsIDOwnersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteOrgsIDOwnersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1805,7 +1805,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1947,7 +1947,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2087,7 +2087,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Organizations</returns>
         public async System.Threading.Tasks.Task<Organizations> GetOrgsAsync (string zapTraceSpan = null, int? offset = null, int? limit = null, bool? descending = null, string org = null, string orgID = null, string userID = null)
         {
-             ApiResponse<Organizations> localVarResponse = await GetOrgsAsyncWithHttpInfo(zapTraceSpan, offset, limit, descending, org, orgID, userID);
+             ApiResponse<Organizations> localVarResponse = await GetOrgsAsyncWithHttpInfo(zapTraceSpan, offset, limit, descending, org, orgID, userID).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2107,7 +2107,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Organizations>> GetOrgsAsyncWithHttpInfo (string zapTraceSpan = null, int? offset = null, int? limit = null, bool? descending = null, string org = null, string orgID = null, string userID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsAsyncWithIRestResponse(zapTraceSpan, offset, limit, descending, org, orgID, userID);
+            IRestResponse localVarResponse = await GetOrgsAsyncWithIRestResponse(zapTraceSpan, offset, limit, descending, org, orgID, userID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2171,7 +2171,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2294,7 +2294,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2415,7 +2415,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Organization</returns>
         public async System.Threading.Tasks.Task<Organization> GetOrgsIDAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<Organization> localVarResponse = await GetOrgsIDAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<Organization> localVarResponse = await GetOrgsIDAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2430,7 +2430,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Organization>> GetOrgsIDAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2487,7 +2487,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2610,7 +2610,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2731,7 +2731,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetOrgsIDMembersAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetOrgsIDMembersAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetOrgsIDMembersAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2746,7 +2746,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetOrgsIDMembersAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDMembersAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDMembersAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2803,7 +2803,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2926,7 +2926,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3047,7 +3047,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetOrgsIDOwnersAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetOrgsIDOwnersAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetOrgsIDOwnersAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3062,7 +3062,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetOrgsIDOwnersAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDOwnersAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDOwnersAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3119,7 +3119,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3242,7 +3242,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3363,7 +3363,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of SecretKeysResponse</returns>
         public async System.Threading.Tasks.Task<SecretKeysResponse> GetOrgsIDSecretsAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<SecretKeysResponse> localVarResponse = await GetOrgsIDSecretsAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<SecretKeysResponse> localVarResponse = await GetOrgsIDSecretsAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3378,7 +3378,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<SecretKeysResponse>> GetOrgsIDSecretsAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDSecretsAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDSecretsAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3435,7 +3435,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3585,7 +3585,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3733,7 +3733,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Organization</returns>
         public async System.Threading.Tasks.Task<Organization> PatchOrgsIDAsync (string orgID, Organization organization, string zapTraceSpan = null)
         {
-             ApiResponse<Organization> localVarResponse = await PatchOrgsIDAsyncWithHttpInfo(orgID, organization, zapTraceSpan);
+             ApiResponse<Organization> localVarResponse = await PatchOrgsIDAsyncWithHttpInfo(orgID, organization, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3749,7 +3749,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Organization>> PatchOrgsIDAsyncWithHttpInfo (string orgID, Organization organization, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchOrgsIDAsyncWithIRestResponse(orgID, organization, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchOrgsIDAsyncWithIRestResponse(orgID, organization, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3819,7 +3819,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3968,7 +3968,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4131,7 +4131,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PatchOrgsIDSecretsAsyncWithHttpInfo (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchOrgsIDSecretsAsyncWithIRestResponse(orgID, requestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchOrgsIDSecretsAsyncWithIRestResponse(orgID, requestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4201,7 +4201,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4340,7 +4340,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4477,7 +4477,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Organization</returns>
         public async System.Threading.Tasks.Task<Organization> PostOrgsAsync (Organization organization, string zapTraceSpan = null)
         {
-             ApiResponse<Organization> localVarResponse = await PostOrgsAsyncWithHttpInfo(organization, zapTraceSpan);
+             ApiResponse<Organization> localVarResponse = await PostOrgsAsyncWithHttpInfo(organization, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4492,7 +4492,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Organization>> PostOrgsAsyncWithHttpInfo (Organization organization, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsAsyncWithIRestResponse(organization, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsAsyncWithIRestResponse(organization, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4557,7 +4557,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4707,7 +4707,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4855,7 +4855,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostOrgsIDMembersAsync (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostOrgsIDMembersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostOrgsIDMembersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4871,7 +4871,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostOrgsIDMembersAsyncWithHttpInfo (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDMembersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDMembersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4941,7 +4941,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5091,7 +5091,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5239,7 +5239,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostOrgsIDOwnersAsync (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostOrgsIDOwnersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostOrgsIDOwnersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5255,7 +5255,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostOrgsIDOwnersAsyncWithHttpInfo (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDOwnersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDOwnersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5325,7 +5325,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5474,7 +5474,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5637,7 +5637,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostOrgsIDSecretsAsyncWithHttpInfo (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDSecretsAsyncWithIRestResponse(orgID, secretKeys, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDSecretsAsyncWithIRestResponse(orgID, secretKeys, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5707,7 +5707,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/OrganizationsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/OrganizationsService.cs
@@ -1048,9 +1048,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">The ID of the organization to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteOrgsIDAsync (string orgID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteOrgsIDAsync (string orgID, string zapTraceSpan = null)
         {
-             await DeleteOrgsIDAsyncWithHttpInfo(orgID, zapTraceSpan);
+             return DeleteOrgsIDAsyncWithHttpInfo(orgID, zapTraceSpan);
 
         }
 
@@ -1384,9 +1384,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">The organization ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteOrgsIDMembersIDAsync (string userID, string orgID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteOrgsIDMembersIDAsync (string userID, string orgID, string zapTraceSpan = null)
         {
-             await DeleteOrgsIDMembersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
+             return DeleteOrgsIDMembersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
 
         }
 
@@ -1726,9 +1726,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">The organization ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteOrgsIDOwnersIDAsync (string userID, string orgID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteOrgsIDOwnersIDAsync (string userID, string orgID, string zapTraceSpan = null)
         {
-             await DeleteOrgsIDOwnersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
+             return DeleteOrgsIDOwnersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
 
         }
 
@@ -4114,9 +4114,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="requestBody">Secret key value pairs to update/add</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PatchOrgsIDSecretsAsync (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task PatchOrgsIDSecretsAsync (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
         {
-             await PatchOrgsIDSecretsAsyncWithHttpInfo(orgID, requestBody, zapTraceSpan);
+             return PatchOrgsIDSecretsAsyncWithHttpInfo(orgID, requestBody, zapTraceSpan);
 
         }
 
@@ -5620,9 +5620,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="secretKeys">Secret key to delete</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostOrgsIDSecretsAsync (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task PostOrgsIDSecretsAsync (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
         {
-             await PostOrgsIDSecretsAsyncWithHttpInfo(orgID, secretKeys, zapTraceSpan);
+             return PostOrgsIDSecretsAsyncWithHttpInfo(orgID, secretKeys, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/QueryService.cs
+++ b/Client/InfluxDB.Client.Api/Service/QueryService.cs
@@ -539,7 +539,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -649,7 +649,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of FluxSuggestions</returns>
         public async System.Threading.Tasks.Task<FluxSuggestions> GetQuerySuggestionsAsync (string zapTraceSpan = null)
         {
-             ApiResponse<FluxSuggestions> localVarResponse = await GetQuerySuggestionsAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<FluxSuggestions> localVarResponse = await GetQuerySuggestionsAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -663,7 +663,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<FluxSuggestions>> GetQuerySuggestionsAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetQuerySuggestionsAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetQuerySuggestionsAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -715,7 +715,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -838,7 +838,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -959,7 +959,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of FluxSuggestion</returns>
         public async System.Threading.Tasks.Task<FluxSuggestion> GetQuerySuggestionsNameAsync (string name, string zapTraceSpan = null)
         {
-             ApiResponse<FluxSuggestion> localVarResponse = await GetQuerySuggestionsNameAsyncWithHttpInfo(name, zapTraceSpan);
+             ApiResponse<FluxSuggestion> localVarResponse = await GetQuerySuggestionsNameAsyncWithHttpInfo(name, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -974,7 +974,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<FluxSuggestion>> GetQuerySuggestionsNameAsyncWithHttpInfo (string name, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetQuerySuggestionsNameAsyncWithIRestResponse(name, zapTraceSpan);
+            IRestResponse localVarResponse = await GetQuerySuggestionsNameAsyncWithIRestResponse(name, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1031,7 +1031,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1190,7 +1190,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1347,7 +1347,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of string</returns>
         public async System.Threading.Tasks.Task<string> PostQueryAsync (string zapTraceSpan = null, string acceptEncoding = null, string contentType = null, string org = null, string orgID = null, Query query = null)
         {
-             ApiResponse<string> localVarResponse = await PostQueryAsyncWithHttpInfo(zapTraceSpan, acceptEncoding, contentType, org, orgID, query);
+             ApiResponse<string> localVarResponse = await PostQueryAsyncWithHttpInfo(zapTraceSpan, acceptEncoding, contentType, org, orgID, query).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1366,7 +1366,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<string>> PostQueryAsyncWithHttpInfo (string zapTraceSpan = null, string acceptEncoding = null, string contentType = null, string org = null, string orgID = null, Query query = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostQueryAsyncWithIRestResponse(zapTraceSpan, acceptEncoding, contentType, org, orgID, query);
+            IRestResponse localVarResponse = await PostQueryAsyncWithIRestResponse(zapTraceSpan, acceptEncoding, contentType, org, orgID, query).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1439,7 +1439,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1568,7 +1568,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1695,7 +1695,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of string</returns>
         public async System.Threading.Tasks.Task<string> PostQuerystringAsync (string zapTraceSpan = null, string acceptEncoding = null, string contentType = null, string org = null, string orgID = null, Query query = null)
         {
-             ApiResponse<string> localVarResponse = await PostQuerystringAsyncWithHttpInfo(zapTraceSpan, acceptEncoding, contentType, org, orgID, query);
+             ApiResponse<string> localVarResponse = await PostQuerystringAsyncWithHttpInfo(zapTraceSpan, acceptEncoding, contentType, org, orgID, query).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1714,7 +1714,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<string>> PostQuerystringAsyncWithHttpInfo (string zapTraceSpan = null, string acceptEncoding = null, string contentType = null, string org = null, string orgID = null, Query query = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostQuerystringAsyncWithIRestResponse(zapTraceSpan, acceptEncoding, contentType, org, orgID, query);
+            IRestResponse localVarResponse = await PostQuerystringAsyncWithIRestResponse(zapTraceSpan, acceptEncoding, contentType, org, orgID, query).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1772,7 +1772,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1910,7 +1910,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2046,7 +2046,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of AnalyzeQueryResponse</returns>
         public async System.Threading.Tasks.Task<AnalyzeQueryResponse> PostQueryAnalyzeAsync (string zapTraceSpan = null, string contentType = null, Query query = null)
         {
-             ApiResponse<AnalyzeQueryResponse> localVarResponse = await PostQueryAnalyzeAsyncWithHttpInfo(zapTraceSpan, contentType, query);
+             ApiResponse<AnalyzeQueryResponse> localVarResponse = await PostQueryAnalyzeAsyncWithHttpInfo(zapTraceSpan, contentType, query).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2062,7 +2062,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<AnalyzeQueryResponse>> PostQueryAnalyzeAsyncWithHttpInfo (string zapTraceSpan = null, string contentType = null, Query query = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostQueryAnalyzeAsyncWithIRestResponse(zapTraceSpan, contentType, query);
+            IRestResponse localVarResponse = await PostQueryAnalyzeAsyncWithIRestResponse(zapTraceSpan, contentType, query).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2126,7 +2126,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2264,7 +2264,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2400,7 +2400,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ASTResponse</returns>
         public async System.Threading.Tasks.Task<ASTResponse> PostQueryAstAsync (string zapTraceSpan = null, string contentType = null, LanguageRequest languageRequest = null)
         {
-             ApiResponse<ASTResponse> localVarResponse = await PostQueryAstAsyncWithHttpInfo(zapTraceSpan, contentType, languageRequest);
+             ApiResponse<ASTResponse> localVarResponse = await PostQueryAstAsyncWithHttpInfo(zapTraceSpan, contentType, languageRequest).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2416,7 +2416,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ASTResponse>> PostQueryAstAsyncWithHttpInfo (string zapTraceSpan = null, string contentType = null, LanguageRequest languageRequest = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostQueryAstAsyncWithIRestResponse(zapTraceSpan, contentType, languageRequest);
+            IRestResponse localVarResponse = await PostQueryAstAsyncWithIRestResponse(zapTraceSpan, contentType, languageRequest).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2480,7 +2480,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/ReadyService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ReadyService.cs
@@ -269,7 +269,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -379,7 +379,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Ready</returns>
         public async System.Threading.Tasks.Task<Ready> GetReadyAsync (string zapTraceSpan = null)
         {
-             ApiResponse<Ready> localVarResponse = await GetReadyAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<Ready> localVarResponse = await GetReadyAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -393,7 +393,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Ready>> GetReadyAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetReadyAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetReadyAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -445,7 +445,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/RulesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/RulesService.cs
@@ -284,7 +284,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -405,7 +405,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of FluxResponse</returns>
         public async System.Threading.Tasks.Task<FluxResponse> GetNotificationRulesIDQueryAsync (string ruleID, string zapTraceSpan = null)
         {
-             ApiResponse<FluxResponse> localVarResponse = await GetNotificationRulesIDQueryAsyncWithHttpInfo(ruleID, zapTraceSpan);
+             ApiResponse<FluxResponse> localVarResponse = await GetNotificationRulesIDQueryAsyncWithHttpInfo(ruleID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -420,7 +420,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<FluxResponse>> GetNotificationRulesIDQueryAsyncWithHttpInfo (string ruleID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetNotificationRulesIDQueryAsyncWithIRestResponse(ruleID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetNotificationRulesIDQueryAsyncWithIRestResponse(ruleID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -477,7 +477,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/ScraperTargetsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ScraperTargetsService.cs
@@ -1040,9 +1040,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="scraperTargetID">The scraper target ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDAsync (string scraperTargetID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             return DeleteScrapersIDAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
 
         }
 
@@ -1376,9 +1376,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The label ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDLabelsIDAsync (string scraperTargetID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDLabelsIDAsync (string scraperTargetID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDLabelsIDAsyncWithHttpInfo(scraperTargetID, labelID, zapTraceSpan);
+             return DeleteScrapersIDLabelsIDAsyncWithHttpInfo(scraperTargetID, labelID, zapTraceSpan);
 
         }
 
@@ -1718,9 +1718,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="scraperTargetID">The scraper target ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDMembersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDMembersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDMembersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
+             return DeleteScrapersIDMembersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
 
         }
 
@@ -2060,9 +2060,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="scraperTargetID">The scraper target ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDOwnersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDOwnersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDOwnersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
+             return DeleteScrapersIDOwnersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/ScraperTargetsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ScraperTargetsService.cs
@@ -921,7 +921,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1056,7 +1056,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1113,7 +1113,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1246,7 +1246,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1393,7 +1393,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDLabelsIDAsyncWithHttpInfo (string scraperTargetID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDLabelsIDAsyncWithIRestResponse(scraperTargetID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDLabelsIDAsyncWithIRestResponse(scraperTargetID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1455,7 +1455,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1588,7 +1588,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1735,7 +1735,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDMembersIDAsyncWithHttpInfo (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDMembersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDMembersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1797,7 +1797,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1930,7 +1930,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2077,7 +2077,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDOwnersIDAsyncWithHttpInfo (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDOwnersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDOwnersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2139,7 +2139,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2271,7 +2271,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2401,7 +2401,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ScraperTargetResponses</returns>
         public async System.Threading.Tasks.Task<ScraperTargetResponses> GetScrapersAsync (string zapTraceSpan = null, string name = null, List<string> id = null, string orgID = null, string org = null)
         {
-             ApiResponse<ScraperTargetResponses> localVarResponse = await GetScrapersAsyncWithHttpInfo(zapTraceSpan, name, id, orgID, org);
+             ApiResponse<ScraperTargetResponses> localVarResponse = await GetScrapersAsyncWithHttpInfo(zapTraceSpan, name, id, orgID, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2419,7 +2419,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ScraperTargetResponses>> GetScrapersAsyncWithHttpInfo (string zapTraceSpan = null, string name = null, List<string> id = null, string orgID = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersAsyncWithIRestResponse(zapTraceSpan, name, id, orgID, org);
+            IRestResponse localVarResponse = await GetScrapersAsyncWithIRestResponse(zapTraceSpan, name, id, orgID, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2479,7 +2479,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2602,7 +2602,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2723,7 +2723,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ScraperTargetResponse</returns>
         public async System.Threading.Tasks.Task<ScraperTargetResponse> GetScrapersIDAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<ScraperTargetResponse> localVarResponse = await GetScrapersIDAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<ScraperTargetResponse> localVarResponse = await GetScrapersIDAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2738,7 +2738,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ScraperTargetResponse>> GetScrapersIDAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2795,7 +2795,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2918,7 +2918,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3039,7 +3039,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetScrapersIDLabelsAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetScrapersIDLabelsAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetScrapersIDLabelsAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3054,7 +3054,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetScrapersIDLabelsAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDLabelsAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDLabelsAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3111,7 +3111,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3234,7 +3234,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3355,7 +3355,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetScrapersIDMembersAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3370,7 +3370,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetScrapersIDMembersAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3427,7 +3427,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3550,7 +3550,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3671,7 +3671,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetScrapersIDOwnersAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3686,7 +3686,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetScrapersIDOwnersAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3743,7 +3743,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3893,7 +3893,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4041,7 +4041,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ScraperTargetResponse</returns>
         public async System.Threading.Tasks.Task<ScraperTargetResponse> PatchScrapersIDAsync (string scraperTargetID, ScraperTargetRequest scraperTargetRequest, string zapTraceSpan = null)
         {
-             ApiResponse<ScraperTargetResponse> localVarResponse = await PatchScrapersIDAsyncWithHttpInfo(scraperTargetID, scraperTargetRequest, zapTraceSpan);
+             ApiResponse<ScraperTargetResponse> localVarResponse = await PatchScrapersIDAsyncWithHttpInfo(scraperTargetID, scraperTargetRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4057,7 +4057,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ScraperTargetResponse>> PatchScrapersIDAsyncWithHttpInfo (string scraperTargetID, ScraperTargetRequest scraperTargetRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchScrapersIDAsyncWithIRestResponse(scraperTargetID, scraperTargetRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchScrapersIDAsyncWithIRestResponse(scraperTargetID, scraperTargetRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4127,7 +4127,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4266,7 +4266,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4403,7 +4403,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ScraperTargetResponse</returns>
         public async System.Threading.Tasks.Task<ScraperTargetResponse> PostScrapersAsync (ScraperTargetRequest scraperTargetRequest, string zapTraceSpan = null)
         {
-             ApiResponse<ScraperTargetResponse> localVarResponse = await PostScrapersAsyncWithHttpInfo(scraperTargetRequest, zapTraceSpan);
+             ApiResponse<ScraperTargetResponse> localVarResponse = await PostScrapersAsyncWithHttpInfo(scraperTargetRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4418,7 +4418,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ScraperTargetResponse>> PostScrapersAsyncWithHttpInfo (ScraperTargetRequest scraperTargetRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersAsyncWithIRestResponse(scraperTargetRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersAsyncWithIRestResponse(scraperTargetRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4483,7 +4483,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4633,7 +4633,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4781,7 +4781,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostScrapersIDLabelsAsync (string scraperTargetID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostScrapersIDLabelsAsyncWithHttpInfo(scraperTargetID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostScrapersIDLabelsAsyncWithHttpInfo(scraperTargetID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4797,7 +4797,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostScrapersIDLabelsAsyncWithHttpInfo (string scraperTargetID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersIDLabelsAsyncWithIRestResponse(scraperTargetID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersIDLabelsAsyncWithIRestResponse(scraperTargetID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4867,7 +4867,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5017,7 +5017,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5165,7 +5165,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostScrapersIDMembersAsync (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5181,7 +5181,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostScrapersIDMembersAsyncWithHttpInfo (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5251,7 +5251,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5401,7 +5401,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5549,7 +5549,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostScrapersIDOwnersAsync (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5565,7 +5565,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostScrapersIDOwnersAsyncWithHttpInfo (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5635,7 +5635,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/SecretsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/SecretsService.cs
@@ -872,9 +872,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="requestBody">Secret key value pairs to update/add</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PatchOrgsIDSecretsAsync (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task PatchOrgsIDSecretsAsync (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
         {
-             await PatchOrgsIDSecretsAsyncWithHttpInfo(orgID, requestBody, zapTraceSpan);
+             return PatchOrgsIDSecretsAsyncWithHttpInfo(orgID, requestBody, zapTraceSpan);
 
         }
 
@@ -1254,9 +1254,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="secretKeys">Secret key to delete</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostOrgsIDSecretsAsync (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task PostOrgsIDSecretsAsync (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
         {
-             await PostOrgsIDSecretsAsyncWithHttpInfo(orgID, secretKeys, zapTraceSpan);
+             return PostOrgsIDSecretsAsyncWithHttpInfo(orgID, secretKeys, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/SecretsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/SecretsService.cs
@@ -384,7 +384,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -505,7 +505,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of SecretKeysResponse</returns>
         public async System.Threading.Tasks.Task<SecretKeysResponse> GetOrgsIDSecretsAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<SecretKeysResponse> localVarResponse = await GetOrgsIDSecretsAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<SecretKeysResponse> localVarResponse = await GetOrgsIDSecretsAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -520,7 +520,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<SecretKeysResponse>> GetOrgsIDSecretsAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDSecretsAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDSecretsAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -577,7 +577,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -726,7 +726,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -889,7 +889,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PatchOrgsIDSecretsAsyncWithHttpInfo (string orgID, Dictionary<string, string> requestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchOrgsIDSecretsAsyncWithIRestResponse(orgID, requestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchOrgsIDSecretsAsyncWithIRestResponse(orgID, requestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -959,7 +959,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1108,7 +1108,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1271,7 +1271,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostOrgsIDSecretsAsyncWithHttpInfo (string orgID, SecretKeys secretKeys, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDSecretsAsyncWithIRestResponse(orgID, secretKeys, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDSecretsAsyncWithIRestResponse(orgID, secretKeys, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1341,7 +1341,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/SetupService.cs
+++ b/Client/InfluxDB.Client.Api/Service/SetupService.cs
@@ -361,7 +361,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -471,7 +471,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of IsOnboarding</returns>
         public async System.Threading.Tasks.Task<IsOnboarding> GetSetupAsync (string zapTraceSpan = null)
         {
-             ApiResponse<IsOnboarding> localVarResponse = await GetSetupAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<IsOnboarding> localVarResponse = await GetSetupAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -485,7 +485,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<IsOnboarding>> GetSetupAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSetupAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetSetupAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -537,7 +537,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -676,7 +676,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -813,7 +813,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of OnboardingResponse</returns>
         public async System.Threading.Tasks.Task<OnboardingResponse> PostSetupAsync (OnboardingRequest onboardingRequest, string zapTraceSpan = null)
         {
-             ApiResponse<OnboardingResponse> localVarResponse = await PostSetupAsyncWithHttpInfo(onboardingRequest, zapTraceSpan);
+             ApiResponse<OnboardingResponse> localVarResponse = await PostSetupAsyncWithHttpInfo(onboardingRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -828,7 +828,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<OnboardingResponse>> PostSetupAsyncWithHttpInfo (OnboardingRequest onboardingRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostSetupAsyncWithIRestResponse(onboardingRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostSetupAsyncWithIRestResponse(onboardingRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -893,7 +893,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1032,7 +1032,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1169,7 +1169,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of OnboardingResponse</returns>
         public async System.Threading.Tasks.Task<OnboardingResponse> PostSetupUserAsync (OnboardingRequest onboardingRequest, string zapTraceSpan = null)
         {
-             ApiResponse<OnboardingResponse> localVarResponse = await PostSetupUserAsyncWithHttpInfo(onboardingRequest, zapTraceSpan);
+             ApiResponse<OnboardingResponse> localVarResponse = await PostSetupUserAsyncWithHttpInfo(onboardingRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1184,7 +1184,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<OnboardingResponse>> PostSetupUserAsyncWithHttpInfo (OnboardingRequest onboardingRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostSetupUserAsyncWithIRestResponse(onboardingRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostSetupUserAsyncWithIRestResponse(onboardingRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1249,7 +1249,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/SourcesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/SourcesService.cs
@@ -567,7 +567,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -702,7 +702,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteSourcesIDAsyncWithHttpInfo (string sourceID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteSourcesIDAsyncWithIRestResponse(sourceID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteSourcesIDAsyncWithIRestResponse(sourceID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -759,7 +759,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -876,7 +876,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -991,7 +991,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Sources</returns>
         public async System.Threading.Tasks.Task<Sources> GetSourcesAsync (string zapTraceSpan = null, string org = null)
         {
-             ApiResponse<Sources> localVarResponse = await GetSourcesAsyncWithHttpInfo(zapTraceSpan, org);
+             ApiResponse<Sources> localVarResponse = await GetSourcesAsyncWithHttpInfo(zapTraceSpan, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1006,7 +1006,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Sources>> GetSourcesAsyncWithHttpInfo (string zapTraceSpan = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSourcesAsyncWithIRestResponse(zapTraceSpan, org);
+            IRestResponse localVarResponse = await GetSourcesAsyncWithIRestResponse(zapTraceSpan, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1060,7 +1060,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1183,7 +1183,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1304,7 +1304,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Source</returns>
         public async System.Threading.Tasks.Task<Source> GetSourcesIDAsync (string sourceID, string zapTraceSpan = null)
         {
-             ApiResponse<Source> localVarResponse = await GetSourcesIDAsyncWithHttpInfo(sourceID, zapTraceSpan);
+             ApiResponse<Source> localVarResponse = await GetSourcesIDAsyncWithHttpInfo(sourceID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1319,7 +1319,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Source>> GetSourcesIDAsyncWithHttpInfo (string sourceID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSourcesIDAsyncWithIRestResponse(sourceID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetSourcesIDAsyncWithIRestResponse(sourceID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1376,7 +1376,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1504,7 +1504,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1630,7 +1630,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Buckets</returns>
         public async System.Threading.Tasks.Task<Buckets> GetSourcesIDBucketsAsync (string sourceID, string zapTraceSpan = null, string org = null)
         {
-             ApiResponse<Buckets> localVarResponse = await GetSourcesIDBucketsAsyncWithHttpInfo(sourceID, zapTraceSpan, org);
+             ApiResponse<Buckets> localVarResponse = await GetSourcesIDBucketsAsyncWithHttpInfo(sourceID, zapTraceSpan, org).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1646,7 +1646,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Buckets>> GetSourcesIDBucketsAsyncWithHttpInfo (string sourceID, string zapTraceSpan = null, string org = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSourcesIDBucketsAsyncWithIRestResponse(sourceID, zapTraceSpan, org);
+            IRestResponse localVarResponse = await GetSourcesIDBucketsAsyncWithIRestResponse(sourceID, zapTraceSpan, org).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1705,7 +1705,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1828,7 +1828,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1949,7 +1949,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of HealthCheck</returns>
         public async System.Threading.Tasks.Task<HealthCheck> GetSourcesIDHealthAsync (string sourceID, string zapTraceSpan = null)
         {
-             ApiResponse<HealthCheck> localVarResponse = await GetSourcesIDHealthAsyncWithHttpInfo(sourceID, zapTraceSpan);
+             ApiResponse<HealthCheck> localVarResponse = await GetSourcesIDHealthAsyncWithHttpInfo(sourceID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1964,7 +1964,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<HealthCheck>> GetSourcesIDHealthAsyncWithHttpInfo (string sourceID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetSourcesIDHealthAsyncWithIRestResponse(sourceID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetSourcesIDHealthAsyncWithIRestResponse(sourceID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2021,7 +2021,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2171,7 +2171,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2319,7 +2319,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Source</returns>
         public async System.Threading.Tasks.Task<Source> PatchSourcesIDAsync (string sourceID, Source source, string zapTraceSpan = null)
         {
-             ApiResponse<Source> localVarResponse = await PatchSourcesIDAsyncWithHttpInfo(sourceID, source, zapTraceSpan);
+             ApiResponse<Source> localVarResponse = await PatchSourcesIDAsyncWithHttpInfo(sourceID, source, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2335,7 +2335,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Source>> PatchSourcesIDAsyncWithHttpInfo (string sourceID, Source source, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchSourcesIDAsyncWithIRestResponse(sourceID, source, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchSourcesIDAsyncWithIRestResponse(sourceID, source, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2405,7 +2405,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2544,7 +2544,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2681,7 +2681,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Source</returns>
         public async System.Threading.Tasks.Task<Source> PostSourcesAsync (Source source, string zapTraceSpan = null)
         {
-             ApiResponse<Source> localVarResponse = await PostSourcesAsyncWithHttpInfo(source, zapTraceSpan);
+             ApiResponse<Source> localVarResponse = await PostSourcesAsyncWithHttpInfo(source, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2696,7 +2696,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Source>> PostSourcesAsyncWithHttpInfo (Source source, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostSourcesAsyncWithIRestResponse(source, zapTraceSpan);
+            IRestResponse localVarResponse = await PostSourcesAsyncWithIRestResponse(source, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2761,7 +2761,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/SourcesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/SourcesService.cs
@@ -686,9 +686,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="sourceID">The source ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteSourcesIDAsync (string sourceID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteSourcesIDAsync (string sourceID, string zapTraceSpan = null)
         {
-             await DeleteSourcesIDAsyncWithHttpInfo(sourceID, zapTraceSpan);
+             return DeleteSourcesIDAsyncWithHttpInfo(sourceID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/TasksService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TasksService.cs
@@ -1291,7 +1291,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1426,7 +1426,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1483,7 +1483,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1616,7 +1616,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1763,7 +1763,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDLabelsIDAsyncWithHttpInfo (string taskID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDLabelsIDAsyncWithIRestResponse(taskID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDLabelsIDAsyncWithIRestResponse(taskID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1825,7 +1825,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1958,7 +1958,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2105,7 +2105,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDMembersIDAsyncWithHttpInfo (string userID, string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDMembersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDMembersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2167,7 +2167,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2300,7 +2300,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2447,7 +2447,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDOwnersIDAsyncWithHttpInfo (string userID, string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDOwnersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDOwnersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2509,7 +2509,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2642,7 +2642,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2789,7 +2789,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDRunsIDAsyncWithHttpInfo (string taskID, string runID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDRunsIDAsyncWithIRestResponse(taskID, runID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDRunsIDAsyncWithIRestResponse(taskID, runID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2851,7 +2851,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2998,7 +2998,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3143,7 +3143,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Tasks</returns>
         public async System.Threading.Tasks.Task<Tasks> GetTasksAsync (string zapTraceSpan = null, string name = null, string after = null, string user = null, string org = null, string orgID = null, string status = null, int? limit = null)
         {
-             ApiResponse<Tasks> localVarResponse = await GetTasksAsyncWithHttpInfo(zapTraceSpan, name, after, user, org, orgID, status, limit);
+             ApiResponse<Tasks> localVarResponse = await GetTasksAsyncWithHttpInfo(zapTraceSpan, name, after, user, org, orgID, status, limit).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3164,7 +3164,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Tasks>> GetTasksAsyncWithHttpInfo (string zapTraceSpan = null, string name = null, string after = null, string user = null, string org = null, string orgID = null, string status = null, int? limit = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksAsyncWithIRestResponse(zapTraceSpan, name, after, user, org, orgID, status, limit);
+            IRestResponse localVarResponse = await GetTasksAsyncWithIRestResponse(zapTraceSpan, name, after, user, org, orgID, status, limit).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3230,7 +3230,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3353,7 +3353,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3474,7 +3474,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of TaskType</returns>
         public async System.Threading.Tasks.Task<TaskType> GetTasksIDAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<TaskType> localVarResponse = await GetTasksIDAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<TaskType> localVarResponse = await GetTasksIDAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3489,7 +3489,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<TaskType>> GetTasksIDAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3546,7 +3546,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3669,7 +3669,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3790,7 +3790,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetTasksIDLabelsAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetTasksIDLabelsAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetTasksIDLabelsAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3805,7 +3805,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetTasksIDLabelsAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDLabelsAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDLabelsAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3862,7 +3862,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3985,7 +3985,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4106,7 +4106,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Logs</returns>
         public async System.Threading.Tasks.Task<Logs> GetTasksIDLogsAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<Logs> localVarResponse = await GetTasksIDLogsAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<Logs> localVarResponse = await GetTasksIDLogsAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4121,7 +4121,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Logs>> GetTasksIDLogsAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDLogsAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDLogsAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4178,7 +4178,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4301,7 +4301,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4422,7 +4422,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetTasksIDMembersAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetTasksIDMembersAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetTasksIDMembersAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4437,7 +4437,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetTasksIDMembersAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDMembersAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDMembersAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4494,7 +4494,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4617,7 +4617,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4738,7 +4738,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetTasksIDOwnersAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetTasksIDOwnersAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetTasksIDOwnersAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4753,7 +4753,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetTasksIDOwnersAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDOwnersAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDOwnersAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4810,7 +4810,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4953,7 +4953,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5094,7 +5094,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Runs</returns>
         public async System.Threading.Tasks.Task<Runs> GetTasksIDRunsAsync (string taskID, string zapTraceSpan = null, string after = null, int? limit = null, DateTime? afterTime = null, DateTime? beforeTime = null)
         {
-             ApiResponse<Runs> localVarResponse = await GetTasksIDRunsAsyncWithHttpInfo(taskID, zapTraceSpan, after, limit, afterTime, beforeTime);
+             ApiResponse<Runs> localVarResponse = await GetTasksIDRunsAsyncWithHttpInfo(taskID, zapTraceSpan, after, limit, afterTime, beforeTime).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5113,7 +5113,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Runs>> GetTasksIDRunsAsyncWithHttpInfo (string taskID, string zapTraceSpan = null, string after = null, int? limit = null, DateTime? afterTime = null, DateTime? beforeTime = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDRunsAsyncWithIRestResponse(taskID, zapTraceSpan, after, limit, afterTime, beforeTime);
+            IRestResponse localVarResponse = await GetTasksIDRunsAsyncWithIRestResponse(taskID, zapTraceSpan, after, limit, afterTime, beforeTime).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5178,7 +5178,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5312,7 +5312,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5444,7 +5444,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Run</returns>
         public async System.Threading.Tasks.Task<Run> GetTasksIDRunsIDAsync (string taskID, string runID, string zapTraceSpan = null)
         {
-             ApiResponse<Run> localVarResponse = await GetTasksIDRunsIDAsyncWithHttpInfo(taskID, runID, zapTraceSpan);
+             ApiResponse<Run> localVarResponse = await GetTasksIDRunsIDAsyncWithHttpInfo(taskID, runID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5460,7 +5460,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Run>> GetTasksIDRunsIDAsyncWithHttpInfo (string taskID, string runID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDRunsIDAsyncWithIRestResponse(taskID, runID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDRunsIDAsyncWithIRestResponse(taskID, runID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5522,7 +5522,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5656,7 +5656,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5788,7 +5788,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Logs</returns>
         public async System.Threading.Tasks.Task<Logs> GetTasksIDRunsIDLogsAsync (string taskID, string runID, string zapTraceSpan = null)
         {
-             ApiResponse<Logs> localVarResponse = await GetTasksIDRunsIDLogsAsyncWithHttpInfo(taskID, runID, zapTraceSpan);
+             ApiResponse<Logs> localVarResponse = await GetTasksIDRunsIDLogsAsyncWithHttpInfo(taskID, runID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5804,7 +5804,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Logs>> GetTasksIDRunsIDLogsAsyncWithHttpInfo (string taskID, string runID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDRunsIDLogsAsyncWithIRestResponse(taskID, runID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDRunsIDLogsAsyncWithIRestResponse(taskID, runID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5866,7 +5866,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6016,7 +6016,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6164,7 +6164,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of TaskType</returns>
         public async System.Threading.Tasks.Task<TaskType> PatchTasksIDAsync (string taskID, TaskUpdateRequest taskUpdateRequest, string zapTraceSpan = null)
         {
-             ApiResponse<TaskType> localVarResponse = await PatchTasksIDAsyncWithHttpInfo(taskID, taskUpdateRequest, zapTraceSpan);
+             ApiResponse<TaskType> localVarResponse = await PatchTasksIDAsyncWithHttpInfo(taskID, taskUpdateRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6180,7 +6180,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<TaskType>> PatchTasksIDAsyncWithHttpInfo (string taskID, TaskUpdateRequest taskUpdateRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchTasksIDAsyncWithIRestResponse(taskID, taskUpdateRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchTasksIDAsyncWithIRestResponse(taskID, taskUpdateRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6250,7 +6250,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6389,7 +6389,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6526,7 +6526,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of TaskType</returns>
         public async System.Threading.Tasks.Task<TaskType> PostTasksAsync (TaskCreateRequest taskCreateRequest, string zapTraceSpan = null)
         {
-             ApiResponse<TaskType> localVarResponse = await PostTasksAsyncWithHttpInfo(taskCreateRequest, zapTraceSpan);
+             ApiResponse<TaskType> localVarResponse = await PostTasksAsyncWithHttpInfo(taskCreateRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6541,7 +6541,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<TaskType>> PostTasksAsyncWithHttpInfo (TaskCreateRequest taskCreateRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksAsyncWithIRestResponse(taskCreateRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksAsyncWithIRestResponse(taskCreateRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6606,7 +6606,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6756,7 +6756,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6904,7 +6904,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostTasksIDLabelsAsync (string taskID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostTasksIDLabelsAsyncWithHttpInfo(taskID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostTasksIDLabelsAsyncWithHttpInfo(taskID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6920,7 +6920,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostTasksIDLabelsAsyncWithHttpInfo (string taskID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDLabelsAsyncWithIRestResponse(taskID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDLabelsAsyncWithIRestResponse(taskID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6990,7 +6990,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7140,7 +7140,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7288,7 +7288,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostTasksIDMembersAsync (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostTasksIDMembersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostTasksIDMembersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7304,7 +7304,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostTasksIDMembersAsyncWithHttpInfo (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDMembersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDMembersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7374,7 +7374,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7524,7 +7524,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7672,7 +7672,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostTasksIDOwnersAsync (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostTasksIDOwnersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostTasksIDOwnersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7688,7 +7688,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostTasksIDOwnersAsyncWithHttpInfo (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDOwnersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDOwnersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7758,7 +7758,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7902,7 +7902,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8044,7 +8044,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Run</returns>
         public async System.Threading.Tasks.Task<Run> PostTasksIDRunsAsync (string taskID, string zapTraceSpan = null, RunManually runManually = null)
         {
-             ApiResponse<Run> localVarResponse = await PostTasksIDRunsAsyncWithHttpInfo(taskID, zapTraceSpan, runManually);
+             ApiResponse<Run> localVarResponse = await PostTasksIDRunsAsyncWithHttpInfo(taskID, zapTraceSpan, runManually).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8060,7 +8060,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Run>> PostTasksIDRunsAsyncWithHttpInfo (string taskID, string zapTraceSpan = null, RunManually runManually = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDRunsAsyncWithIRestResponse(taskID, zapTraceSpan, runManually);
+            IRestResponse localVarResponse = await PostTasksIDRunsAsyncWithIRestResponse(taskID, zapTraceSpan, runManually).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8127,7 +8127,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8261,7 +8261,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8393,7 +8393,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Run</returns>
         public async System.Threading.Tasks.Task<Run> PostTasksIDRunsIDRetryAsync (string taskID, string runID, string zapTraceSpan = null)
         {
-             ApiResponse<Run> localVarResponse = await PostTasksIDRunsIDRetryAsyncWithHttpInfo(taskID, runID, zapTraceSpan);
+             ApiResponse<Run> localVarResponse = await PostTasksIDRunsIDRetryAsyncWithHttpInfo(taskID, runID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8409,7 +8409,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Run>> PostTasksIDRunsIDRetryAsyncWithHttpInfo (string taskID, string runID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDRunsIDRetryAsyncWithIRestResponse(taskID, runID, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDRunsIDRetryAsyncWithIRestResponse(taskID, runID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8471,7 +8471,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/TasksService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TasksService.cs
@@ -1410,9 +1410,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="taskID">The ID of the task to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDAsync (string taskID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDAsync (string taskID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDAsyncWithHttpInfo(taskID, zapTraceSpan);
+             return DeleteTasksIDAsyncWithHttpInfo(taskID, zapTraceSpan);
 
         }
 
@@ -1746,9 +1746,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The label ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDLabelsIDAsync (string taskID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDLabelsIDAsync (string taskID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDLabelsIDAsyncWithHttpInfo(taskID, labelID, zapTraceSpan);
+             return DeleteTasksIDLabelsIDAsyncWithHttpInfo(taskID, labelID, zapTraceSpan);
 
         }
 
@@ -2088,9 +2088,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="taskID">The task ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDMembersIDAsync (string userID, string taskID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDMembersIDAsync (string userID, string taskID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDMembersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
+             return DeleteTasksIDMembersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
 
         }
 
@@ -2430,9 +2430,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="taskID">The task ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDOwnersIDAsync (string userID, string taskID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDOwnersIDAsync (string userID, string taskID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDOwnersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
+             return DeleteTasksIDOwnersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
 
         }
 
@@ -2772,9 +2772,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="runID">The run ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDRunsIDAsync (string taskID, string runID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDRunsIDAsync (string taskID, string runID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDRunsIDAsyncWithHttpInfo(taskID, runID, zapTraceSpan);
+             return DeleteTasksIDRunsIDAsyncWithHttpInfo(taskID, runID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/TelegrafsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TelegrafsService.cs
@@ -963,7 +963,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1098,7 +1098,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1155,7 +1155,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1288,7 +1288,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1435,7 +1435,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDLabelsIDAsyncWithHttpInfo (string telegrafID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDLabelsIDAsyncWithIRestResponse(telegrafID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDLabelsIDAsyncWithIRestResponse(telegrafID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1497,7 +1497,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1630,7 +1630,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1777,7 +1777,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDMembersIDAsyncWithHttpInfo (string userID, string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDMembersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDMembersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1839,7 +1839,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1972,7 +1972,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2119,7 +2119,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo (string userID, string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDOwnersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDOwnersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2181,7 +2181,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2298,7 +2298,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2413,7 +2413,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Telegrafs</returns>
         public async System.Threading.Tasks.Task<Telegrafs> GetTelegrafsAsync (string zapTraceSpan = null, string orgID = null)
         {
-             ApiResponse<Telegrafs> localVarResponse = await GetTelegrafsAsyncWithHttpInfo(zapTraceSpan, orgID);
+             ApiResponse<Telegrafs> localVarResponse = await GetTelegrafsAsyncWithHttpInfo(zapTraceSpan, orgID).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2428,7 +2428,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Telegrafs>> GetTelegrafsAsyncWithHttpInfo (string zapTraceSpan = null, string orgID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsAsyncWithIRestResponse(zapTraceSpan, orgID);
+            IRestResponse localVarResponse = await GetTelegrafsAsyncWithIRestResponse(zapTraceSpan, orgID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2482,7 +2482,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2614,7 +2614,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2744,7 +2744,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of string</returns>
         public async System.Threading.Tasks.Task<string> GetTelegrafsIDAsync (string telegrafID, string zapTraceSpan = null, string accept = null)
         {
-             ApiResponse<string> localVarResponse = await GetTelegrafsIDAsyncWithHttpInfo(telegrafID, zapTraceSpan, accept);
+             ApiResponse<string> localVarResponse = await GetTelegrafsIDAsyncWithHttpInfo(telegrafID, zapTraceSpan, accept).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2760,7 +2760,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<string>> GetTelegrafsIDAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null, string accept = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDAsyncWithIRestResponse(telegrafID, zapTraceSpan, accept);
+            IRestResponse localVarResponse = await GetTelegrafsIDAsyncWithIRestResponse(telegrafID, zapTraceSpan, accept).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2821,7 +2821,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2945,7 +2945,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3067,7 +3067,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of string</returns>
         public async System.Threading.Tasks.Task<string> GetTelegrafsIDstringAsync (string telegrafID, string zapTraceSpan = null, string accept = null)
         {
-             ApiResponse<string> localVarResponse = await GetTelegrafsIDstringAsyncWithHttpInfo(telegrafID, zapTraceSpan, accept);
+             ApiResponse<string> localVarResponse = await GetTelegrafsIDstringAsyncWithHttpInfo(telegrafID, zapTraceSpan, accept).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3083,7 +3083,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<string>> GetTelegrafsIDstringAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null, string accept = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDstringAsyncWithIRestResponse(telegrafID, zapTraceSpan, accept);
+            IRestResponse localVarResponse = await GetTelegrafsIDstringAsyncWithIRestResponse(telegrafID, zapTraceSpan, accept).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3140,7 +3140,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3263,7 +3263,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3384,7 +3384,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetTelegrafsIDLabelsAsync (string telegrafID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetTelegrafsIDLabelsAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetTelegrafsIDLabelsAsyncWithHttpInfo(telegrafID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3399,7 +3399,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetTelegrafsIDLabelsAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDLabelsAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTelegrafsIDLabelsAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3456,7 +3456,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3579,7 +3579,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3700,7 +3700,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetTelegrafsIDMembersAsync (string telegrafID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3715,7 +3715,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetTelegrafsIDMembersAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3772,7 +3772,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3895,7 +3895,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4016,7 +4016,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetTelegrafsIDOwnersAsync (string telegrafID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4031,7 +4031,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetTelegrafsIDOwnersAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4088,7 +4088,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4227,7 +4227,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4364,7 +4364,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Telegraf</returns>
         public async System.Threading.Tasks.Task<Telegraf> PostTelegrafsAsync (TelegrafRequest telegrafRequest, string zapTraceSpan = null)
         {
-             ApiResponse<Telegraf> localVarResponse = await PostTelegrafsAsyncWithHttpInfo(telegrafRequest, zapTraceSpan);
+             ApiResponse<Telegraf> localVarResponse = await PostTelegrafsAsyncWithHttpInfo(telegrafRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4379,7 +4379,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Telegraf>> PostTelegrafsAsyncWithHttpInfo (TelegrafRequest telegrafRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsAsyncWithIRestResponse(telegrafRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsAsyncWithIRestResponse(telegrafRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4444,7 +4444,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4594,7 +4594,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4742,7 +4742,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostTelegrafsIDLabelsAsync (string telegrafID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostTelegrafsIDLabelsAsyncWithHttpInfo(telegrafID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostTelegrafsIDLabelsAsyncWithHttpInfo(telegrafID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -4758,7 +4758,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostTelegrafsIDLabelsAsyncWithHttpInfo (string telegrafID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsIDLabelsAsyncWithIRestResponse(telegrafID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsIDLabelsAsyncWithIRestResponse(telegrafID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4828,7 +4828,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4978,7 +4978,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5126,7 +5126,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostTelegrafsIDMembersAsync (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5142,7 +5142,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostTelegrafsIDMembersAsyncWithHttpInfo (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5212,7 +5212,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5362,7 +5362,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5510,7 +5510,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostTelegrafsIDOwnersAsync (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5526,7 +5526,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostTelegrafsIDOwnersAsyncWithHttpInfo (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5596,7 +5596,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5746,7 +5746,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5894,7 +5894,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Telegraf</returns>
         public async System.Threading.Tasks.Task<Telegraf> PutTelegrafsIDAsync (string telegrafID, TelegrafRequest telegrafRequest, string zapTraceSpan = null)
         {
-             ApiResponse<Telegraf> localVarResponse = await PutTelegrafsIDAsyncWithHttpInfo(telegrafID, telegrafRequest, zapTraceSpan);
+             ApiResponse<Telegraf> localVarResponse = await PutTelegrafsIDAsyncWithHttpInfo(telegrafID, telegrafRequest, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -5910,7 +5910,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Telegraf>> PutTelegrafsIDAsyncWithHttpInfo (string telegrafID, TelegrafRequest telegrafRequest, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutTelegrafsIDAsyncWithIRestResponse(telegrafID, telegrafRequest, zapTraceSpan);
+            IRestResponse localVarResponse = await PutTelegrafsIDAsyncWithIRestResponse(telegrafID, telegrafRequest, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5980,7 +5980,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/TelegrafsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TelegrafsService.cs
@@ -1082,9 +1082,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="telegrafID">The Telegraf config ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDAsync (string telegrafID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDAsync (string telegrafID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             return DeleteTelegrafsIDAsyncWithHttpInfo(telegrafID, zapTraceSpan);
 
         }
 
@@ -1418,9 +1418,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The label ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDLabelsIDAsync (string telegrafID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDLabelsIDAsync (string telegrafID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDLabelsIDAsyncWithHttpInfo(telegrafID, labelID, zapTraceSpan);
+             return DeleteTelegrafsIDLabelsIDAsyncWithHttpInfo(telegrafID, labelID, zapTraceSpan);
 
         }
 
@@ -1760,9 +1760,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="telegrafID">The Telegraf config ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDMembersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDMembersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDMembersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
+             return DeleteTelegrafsIDMembersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
 
         }
 
@@ -2102,9 +2102,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="telegrafID">The Telegraf config ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDOwnersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDOwnersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
+             return DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/TemplatesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TemplatesService.cs
@@ -621,7 +621,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -756,7 +756,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDocumentsTemplatesIDAsyncWithHttpInfo (string templateID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDocumentsTemplatesIDAsyncWithIRestResponse(templateID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDocumentsTemplatesIDAsyncWithIRestResponse(templateID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -813,7 +813,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -946,7 +946,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1093,7 +1093,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDocumentsTemplatesIDLabelsIDAsyncWithHttpInfo (string templateID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDocumentsTemplatesIDLabelsIDAsyncWithIRestResponse(templateID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDocumentsTemplatesIDLabelsIDAsyncWithIRestResponse(templateID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1155,7 +1155,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1277,7 +1277,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1397,7 +1397,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Documents</returns>
         public async System.Threading.Tasks.Task<Documents> GetDocumentsTemplatesAsync (string zapTraceSpan = null, string org = null, string orgID = null)
         {
-             ApiResponse<Documents> localVarResponse = await GetDocumentsTemplatesAsyncWithHttpInfo(zapTraceSpan, org, orgID);
+             ApiResponse<Documents> localVarResponse = await GetDocumentsTemplatesAsyncWithHttpInfo(zapTraceSpan, org, orgID).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1413,7 +1413,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Documents>> GetDocumentsTemplatesAsyncWithHttpInfo (string zapTraceSpan = null, string org = null, string orgID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDocumentsTemplatesAsyncWithIRestResponse(zapTraceSpan, org, orgID);
+            IRestResponse localVarResponse = await GetDocumentsTemplatesAsyncWithIRestResponse(zapTraceSpan, org, orgID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1469,7 +1469,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1592,7 +1592,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1713,7 +1713,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Document</returns>
         public async System.Threading.Tasks.Task<Document> GetDocumentsTemplatesIDAsync (string templateID, string zapTraceSpan = null)
         {
-             ApiResponse<Document> localVarResponse = await GetDocumentsTemplatesIDAsyncWithHttpInfo(templateID, zapTraceSpan);
+             ApiResponse<Document> localVarResponse = await GetDocumentsTemplatesIDAsyncWithHttpInfo(templateID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1728,7 +1728,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Document>> GetDocumentsTemplatesIDAsyncWithHttpInfo (string templateID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDocumentsTemplatesIDAsyncWithIRestResponse(templateID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDocumentsTemplatesIDAsyncWithIRestResponse(templateID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1785,7 +1785,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1908,7 +1908,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2029,7 +2029,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetDocumentsTemplatesIDLabelsAsync (string templateID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetDocumentsTemplatesIDLabelsAsyncWithHttpInfo(templateID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetDocumentsTemplatesIDLabelsAsyncWithHttpInfo(templateID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2044,7 +2044,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetDocumentsTemplatesIDLabelsAsyncWithHttpInfo (string templateID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDocumentsTemplatesIDLabelsAsyncWithIRestResponse(templateID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDocumentsTemplatesIDLabelsAsyncWithIRestResponse(templateID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2101,7 +2101,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2240,7 +2240,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2377,7 +2377,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Document</returns>
         public async System.Threading.Tasks.Task<Document> PostDocumentsTemplatesAsync (DocumentCreate documentCreate, string zapTraceSpan = null)
         {
-             ApiResponse<Document> localVarResponse = await PostDocumentsTemplatesAsyncWithHttpInfo(documentCreate, zapTraceSpan);
+             ApiResponse<Document> localVarResponse = await PostDocumentsTemplatesAsyncWithHttpInfo(documentCreate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2392,7 +2392,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Document>> PostDocumentsTemplatesAsyncWithHttpInfo (DocumentCreate documentCreate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDocumentsTemplatesAsyncWithIRestResponse(documentCreate, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDocumentsTemplatesAsyncWithIRestResponse(documentCreate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2457,7 +2457,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2607,7 +2607,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2755,7 +2755,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostDocumentsTemplatesIDLabelsAsync (string templateID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostDocumentsTemplatesIDLabelsAsyncWithHttpInfo(templateID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostDocumentsTemplatesIDLabelsAsyncWithHttpInfo(templateID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2771,7 +2771,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostDocumentsTemplatesIDLabelsAsyncWithHttpInfo (string templateID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDocumentsTemplatesIDLabelsAsyncWithIRestResponse(templateID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDocumentsTemplatesIDLabelsAsyncWithIRestResponse(templateID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2841,7 +2841,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2991,7 +2991,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3139,7 +3139,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Document</returns>
         public async System.Threading.Tasks.Task<Document> PutDocumentsTemplatesIDAsync (string templateID, DocumentUpdate documentUpdate, string zapTraceSpan = null)
         {
-             ApiResponse<Document> localVarResponse = await PutDocumentsTemplatesIDAsyncWithHttpInfo(templateID, documentUpdate, zapTraceSpan);
+             ApiResponse<Document> localVarResponse = await PutDocumentsTemplatesIDAsyncWithHttpInfo(templateID, documentUpdate, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3155,7 +3155,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Document>> PutDocumentsTemplatesIDAsyncWithHttpInfo (string templateID, DocumentUpdate documentUpdate, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutDocumentsTemplatesIDAsyncWithIRestResponse(templateID, documentUpdate, zapTraceSpan);
+            IRestResponse localVarResponse = await PutDocumentsTemplatesIDAsyncWithIRestResponse(templateID, documentUpdate, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3225,7 +3225,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/TemplatesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/TemplatesService.cs
@@ -740,9 +740,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="templateID">The template ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDocumentsTemplatesIDAsync (string templateID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDocumentsTemplatesIDAsync (string templateID, string zapTraceSpan = null)
         {
-             await DeleteDocumentsTemplatesIDAsyncWithHttpInfo(templateID, zapTraceSpan);
+             return DeleteDocumentsTemplatesIDAsyncWithHttpInfo(templateID, zapTraceSpan);
 
         }
 
@@ -1076,9 +1076,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The label ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDocumentsTemplatesIDLabelsIDAsync (string templateID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDocumentsTemplatesIDLabelsIDAsync (string templateID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteDocumentsTemplatesIDLabelsIDAsyncWithHttpInfo(templateID, labelID, zapTraceSpan);
+             return DeleteDocumentsTemplatesIDLabelsIDAsyncWithHttpInfo(templateID, labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/UsersService.cs
+++ b/Client/InfluxDB.Client.Api/Service/UsersService.cs
@@ -2506,9 +2506,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="bucketID">The bucket ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDMembersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDMembersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDMembersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
+             return DeleteBucketsIDMembersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
 
         }
 
@@ -2848,9 +2848,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="bucketID">The bucket ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteBucketsIDOwnersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteBucketsIDOwnersIDAsync (string userID, string bucketID, string zapTraceSpan = null)
         {
-             await DeleteBucketsIDOwnersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
+             return DeleteBucketsIDOwnersIDAsyncWithHttpInfo(userID, bucketID, zapTraceSpan);
 
         }
 
@@ -3190,9 +3190,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dashboardID">The dashboard ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDMembersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDMembersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDMembersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
+             return DeleteDashboardsIDMembersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
 
         }
 
@@ -3532,9 +3532,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="dashboardID">The dashboard ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteDashboardsIDOwnersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteDashboardsIDOwnersIDAsync (string userID, string dashboardID, string zapTraceSpan = null)
         {
-             await DeleteDashboardsIDOwnersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
+             return DeleteDashboardsIDOwnersIDAsyncWithHttpInfo(userID, dashboardID, zapTraceSpan);
 
         }
 
@@ -3874,9 +3874,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">The organization ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteOrgsIDMembersIDAsync (string userID, string orgID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteOrgsIDMembersIDAsync (string userID, string orgID, string zapTraceSpan = null)
         {
-             await DeleteOrgsIDMembersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
+             return DeleteOrgsIDMembersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
 
         }
 
@@ -4216,9 +4216,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">The organization ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteOrgsIDOwnersIDAsync (string userID, string orgID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteOrgsIDOwnersIDAsync (string userID, string orgID, string zapTraceSpan = null)
         {
-             await DeleteOrgsIDOwnersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
+             return DeleteOrgsIDOwnersIDAsyncWithHttpInfo(userID, orgID, zapTraceSpan);
 
         }
 
@@ -4558,9 +4558,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="scraperTargetID">The scraper target ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDMembersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDMembersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDMembersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
+             return DeleteScrapersIDMembersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
 
         }
 
@@ -4900,9 +4900,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="scraperTargetID">The scraper target ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteScrapersIDOwnersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteScrapersIDOwnersIDAsync (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
-             await DeleteScrapersIDOwnersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
+             return DeleteScrapersIDOwnersIDAsyncWithHttpInfo(userID, scraperTargetID, zapTraceSpan);
 
         }
 
@@ -5242,9 +5242,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="taskID">The task ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDMembersIDAsync (string userID, string taskID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDMembersIDAsync (string userID, string taskID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDMembersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
+             return DeleteTasksIDMembersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
 
         }
 
@@ -5584,9 +5584,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="taskID">The task ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTasksIDOwnersIDAsync (string userID, string taskID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTasksIDOwnersIDAsync (string userID, string taskID, string zapTraceSpan = null)
         {
-             await DeleteTasksIDOwnersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
+             return DeleteTasksIDOwnersIDAsyncWithHttpInfo(userID, taskID, zapTraceSpan);
 
         }
 
@@ -5926,9 +5926,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="telegrafID">The Telegraf config ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDMembersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDMembersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDMembersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
+             return DeleteTelegrafsIDMembersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
 
         }
 
@@ -6268,9 +6268,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="telegrafID">The Telegraf config ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteTelegrafsIDOwnersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteTelegrafsIDOwnersIDAsync (string userID, string telegrafID, string zapTraceSpan = null)
         {
-             await DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
+             return DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo(userID, telegrafID, zapTraceSpan);
 
         }
 
@@ -6588,9 +6588,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="userID">The ID of the user to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteUsersIDAsync (string userID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteUsersIDAsync (string userID, string zapTraceSpan = null)
         {
-             await DeleteUsersIDAsyncWithHttpInfo(userID, zapTraceSpan);
+             return DeleteUsersIDAsyncWithHttpInfo(userID, zapTraceSpan);
 
         }
 
@@ -17022,9 +17022,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="authorization">An auth credential for the Basic scheme (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostUsersIDPasswordAsync (string userID, PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
+        public System.Threading.Tasks.Task PostUsersIDPasswordAsync (string userID, PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
         {
-             await PostUsersIDPasswordAsyncWithHttpInfo(userID, passwordResetBody, zapTraceSpan, authorization);
+             return PostUsersIDPasswordAsyncWithHttpInfo(userID, passwordResetBody, zapTraceSpan, authorization);
 
         }
 
@@ -17425,9 +17425,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <param name="authorization">An auth credential for the Basic scheme (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PutMePasswordAsync (PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
+        public System.Threading.Tasks.Task PutMePasswordAsync (PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
         {
-             await PutMePasswordAsyncWithHttpInfo(passwordResetBody, zapTraceSpan, authorization);
+             return PutMePasswordAsyncWithHttpInfo(passwordResetBody, zapTraceSpan, authorization);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/UsersService.cs
+++ b/Client/InfluxDB.Client.Api/Service/UsersService.cs
@@ -2376,7 +2376,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2523,7 +2523,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDMembersIDAsyncWithHttpInfo (string userID, string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDMembersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDMembersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2585,7 +2585,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2718,7 +2718,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2865,7 +2865,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteBucketsIDOwnersIDAsyncWithHttpInfo (string userID, string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteBucketsIDOwnersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteBucketsIDOwnersIDAsyncWithIRestResponse(userID, bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2927,7 +2927,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3060,7 +3060,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3207,7 +3207,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDMembersIDAsyncWithHttpInfo (string userID, string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDMembersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDMembersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3269,7 +3269,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3402,7 +3402,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3549,7 +3549,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteDashboardsIDOwnersIDAsyncWithHttpInfo (string userID, string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteDashboardsIDOwnersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteDashboardsIDOwnersIDAsyncWithIRestResponse(userID, dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3611,7 +3611,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3744,7 +3744,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3891,7 +3891,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteOrgsIDMembersIDAsyncWithHttpInfo (string userID, string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteOrgsIDMembersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteOrgsIDMembersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3953,7 +3953,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4086,7 +4086,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4233,7 +4233,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteOrgsIDOwnersIDAsyncWithHttpInfo (string userID, string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteOrgsIDOwnersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteOrgsIDOwnersIDAsyncWithIRestResponse(userID, orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4295,7 +4295,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4428,7 +4428,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4575,7 +4575,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDMembersIDAsyncWithHttpInfo (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDMembersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDMembersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4637,7 +4637,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -4770,7 +4770,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4917,7 +4917,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteScrapersIDOwnersIDAsyncWithHttpInfo (string userID, string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteScrapersIDOwnersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteScrapersIDOwnersIDAsyncWithIRestResponse(userID, scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -4979,7 +4979,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5112,7 +5112,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5259,7 +5259,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDMembersIDAsyncWithHttpInfo (string userID, string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDMembersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDMembersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5321,7 +5321,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5454,7 +5454,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5601,7 +5601,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTasksIDOwnersIDAsyncWithHttpInfo (string userID, string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTasksIDOwnersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTasksIDOwnersIDAsyncWithIRestResponse(userID, taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5663,7 +5663,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -5796,7 +5796,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -5943,7 +5943,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDMembersIDAsyncWithHttpInfo (string userID, string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDMembersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDMembersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6005,7 +6005,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6138,7 +6138,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6285,7 +6285,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteTelegrafsIDOwnersIDAsyncWithHttpInfo (string userID, string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteTelegrafsIDOwnersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteTelegrafsIDOwnersIDAsyncWithIRestResponse(userID, telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6347,7 +6347,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6469,7 +6469,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6604,7 +6604,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteUsersIDAsyncWithHttpInfo (string userID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteUsersIDAsyncWithIRestResponse(userID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteUsersIDAsyncWithIRestResponse(userID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6661,7 +6661,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -6784,7 +6784,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6905,7 +6905,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetBucketsIDMembersAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetBucketsIDMembersAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetBucketsIDMembersAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -6920,7 +6920,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetBucketsIDMembersAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDMembersAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDMembersAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -6977,7 +6977,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7100,7 +7100,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7221,7 +7221,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetBucketsIDOwnersAsync (string bucketID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetBucketsIDOwnersAsyncWithHttpInfo(bucketID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetBucketsIDOwnersAsyncWithHttpInfo(bucketID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7236,7 +7236,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetBucketsIDOwnersAsyncWithHttpInfo (string bucketID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetBucketsIDOwnersAsyncWithIRestResponse(bucketID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetBucketsIDOwnersAsyncWithIRestResponse(bucketID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7293,7 +7293,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7416,7 +7416,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7537,7 +7537,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetDashboardsIDMembersAsync (string dashboardID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetDashboardsIDMembersAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetDashboardsIDMembersAsyncWithHttpInfo(dashboardID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7552,7 +7552,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetDashboardsIDMembersAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDMembersAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDMembersAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7609,7 +7609,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -7732,7 +7732,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7853,7 +7853,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetDashboardsIDOwnersAsync (string dashboardID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -7868,7 +7868,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetDashboardsIDOwnersAsyncWithHttpInfo (string dashboardID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -7925,7 +7925,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8037,7 +8037,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8147,7 +8147,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> GetMeAsync (string zapTraceSpan = null)
         {
-             ApiResponse<User> localVarResponse = await GetMeAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<User> localVarResponse = await GetMeAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8161,7 +8161,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<User>> GetMeAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetMeAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetMeAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8213,7 +8213,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8336,7 +8336,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8457,7 +8457,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetOrgsIDMembersAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetOrgsIDMembersAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetOrgsIDMembersAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8472,7 +8472,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetOrgsIDMembersAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDMembersAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDMembersAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8529,7 +8529,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8652,7 +8652,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8773,7 +8773,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetOrgsIDOwnersAsync (string orgID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetOrgsIDOwnersAsyncWithHttpInfo(orgID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetOrgsIDOwnersAsyncWithHttpInfo(orgID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -8788,7 +8788,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetOrgsIDOwnersAsyncWithHttpInfo (string orgID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetOrgsIDOwnersAsyncWithIRestResponse(orgID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetOrgsIDOwnersAsyncWithIRestResponse(orgID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -8845,7 +8845,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -8968,7 +8968,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9089,7 +9089,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetScrapersIDMembersAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -9104,7 +9104,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetScrapersIDMembersAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9161,7 +9161,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -9284,7 +9284,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9405,7 +9405,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetScrapersIDOwnersAsync (string scraperTargetID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -9420,7 +9420,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetScrapersIDOwnersAsyncWithHttpInfo (string scraperTargetID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9477,7 +9477,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -9600,7 +9600,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9721,7 +9721,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetTasksIDMembersAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetTasksIDMembersAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetTasksIDMembersAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -9736,7 +9736,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetTasksIDMembersAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDMembersAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDMembersAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -9793,7 +9793,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -9916,7 +9916,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10037,7 +10037,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetTasksIDOwnersAsync (string taskID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetTasksIDOwnersAsyncWithHttpInfo(taskID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetTasksIDOwnersAsyncWithHttpInfo(taskID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -10052,7 +10052,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetTasksIDOwnersAsyncWithHttpInfo (string taskID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTasksIDOwnersAsyncWithIRestResponse(taskID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTasksIDOwnersAsyncWithIRestResponse(taskID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10109,7 +10109,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -10232,7 +10232,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10353,7 +10353,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMembers</returns>
         public async System.Threading.Tasks.Task<ResourceMembers> GetTelegrafsIDMembersAsync (string telegrafID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMembers> localVarResponse = await GetTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             ApiResponse<ResourceMembers> localVarResponse = await GetTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -10368,7 +10368,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMembers>> GetTelegrafsIDMembersAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10425,7 +10425,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -10548,7 +10548,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10669,7 +10669,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwners</returns>
         public async System.Threading.Tasks.Task<ResourceOwners> GetTelegrafsIDOwnersAsync (string telegrafID, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwners> localVarResponse = await GetTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, zapTraceSpan);
+             ApiResponse<ResourceOwners> localVarResponse = await GetTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -10684,7 +10684,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwners>> GetTelegrafsIDOwnersAsyncWithHttpInfo (string telegrafID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10741,7 +10741,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -10853,7 +10853,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -10963,7 +10963,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Users</returns>
         public async System.Threading.Tasks.Task<Users> GetUsersAsync (string zapTraceSpan = null)
         {
-             ApiResponse<Users> localVarResponse = await GetUsersAsyncWithHttpInfo(zapTraceSpan);
+             ApiResponse<Users> localVarResponse = await GetUsersAsyncWithHttpInfo(zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -10977,7 +10977,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Users>> GetUsersAsyncWithHttpInfo (string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetUsersAsyncWithIRestResponse(zapTraceSpan);
+            IRestResponse localVarResponse = await GetUsersAsyncWithIRestResponse(zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -11029,7 +11029,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -11152,7 +11152,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -11273,7 +11273,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> GetUsersIDAsync (string userID, string zapTraceSpan = null)
         {
-             ApiResponse<User> localVarResponse = await GetUsersIDAsyncWithHttpInfo(userID, zapTraceSpan);
+             ApiResponse<User> localVarResponse = await GetUsersIDAsyncWithHttpInfo(userID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -11288,7 +11288,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<User>> GetUsersIDAsyncWithHttpInfo (string userID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetUsersIDAsyncWithIRestResponse(userID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetUsersIDAsyncWithIRestResponse(userID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -11345,7 +11345,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -11495,7 +11495,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -11643,7 +11643,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> PatchUsersIDAsync (string userID, User user, string zapTraceSpan = null)
         {
-             ApiResponse<User> localVarResponse = await PatchUsersIDAsyncWithHttpInfo(userID, user, zapTraceSpan);
+             ApiResponse<User> localVarResponse = await PatchUsersIDAsyncWithHttpInfo(userID, user, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -11659,7 +11659,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<User>> PatchUsersIDAsyncWithHttpInfo (string userID, User user, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchUsersIDAsyncWithIRestResponse(userID, user, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchUsersIDAsyncWithIRestResponse(userID, user, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -11729,7 +11729,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -11879,7 +11879,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12027,7 +12027,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostBucketsIDMembersAsync (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostBucketsIDMembersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostBucketsIDMembersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -12043,7 +12043,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostBucketsIDMembersAsyncWithHttpInfo (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsIDMembersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsIDMembersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12113,7 +12113,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -12263,7 +12263,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12411,7 +12411,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostBucketsIDOwnersAsync (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostBucketsIDOwnersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostBucketsIDOwnersAsyncWithHttpInfo(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -12427,7 +12427,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostBucketsIDOwnersAsyncWithHttpInfo (string bucketID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostBucketsIDOwnersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostBucketsIDOwnersAsyncWithIRestResponse(bucketID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12497,7 +12497,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -12647,7 +12647,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12795,7 +12795,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostDashboardsIDMembersAsync (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostDashboardsIDMembersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostDashboardsIDMembersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -12811,7 +12811,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostDashboardsIDMembersAsyncWithHttpInfo (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDMembersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDMembersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -12881,7 +12881,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -13031,7 +13031,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -13179,7 +13179,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostDashboardsIDOwnersAsync (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostDashboardsIDOwnersAsyncWithHttpInfo(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -13195,7 +13195,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostDashboardsIDOwnersAsyncWithHttpInfo (string dashboardID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostDashboardsIDOwnersAsyncWithIRestResponse(dashboardID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -13265,7 +13265,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -13415,7 +13415,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -13563,7 +13563,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostOrgsIDMembersAsync (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostOrgsIDMembersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostOrgsIDMembersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -13579,7 +13579,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostOrgsIDMembersAsyncWithHttpInfo (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDMembersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDMembersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -13649,7 +13649,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -13799,7 +13799,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -13947,7 +13947,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostOrgsIDOwnersAsync (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostOrgsIDOwnersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostOrgsIDOwnersAsyncWithHttpInfo(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -13963,7 +13963,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostOrgsIDOwnersAsyncWithHttpInfo (string orgID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostOrgsIDOwnersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostOrgsIDOwnersAsyncWithIRestResponse(orgID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -14033,7 +14033,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -14183,7 +14183,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -14331,7 +14331,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostScrapersIDMembersAsync (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostScrapersIDMembersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -14347,7 +14347,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostScrapersIDMembersAsyncWithHttpInfo (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersIDMembersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -14417,7 +14417,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -14567,7 +14567,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -14715,7 +14715,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostScrapersIDOwnersAsync (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostScrapersIDOwnersAsyncWithHttpInfo(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -14731,7 +14731,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostScrapersIDOwnersAsyncWithHttpInfo (string scraperTargetID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostScrapersIDOwnersAsyncWithIRestResponse(scraperTargetID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -14801,7 +14801,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -14951,7 +14951,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15099,7 +15099,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostTasksIDMembersAsync (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostTasksIDMembersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostTasksIDMembersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -15115,7 +15115,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostTasksIDMembersAsyncWithHttpInfo (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDMembersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDMembersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15185,7 +15185,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -15335,7 +15335,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15483,7 +15483,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostTasksIDOwnersAsync (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostTasksIDOwnersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostTasksIDOwnersAsyncWithHttpInfo(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -15499,7 +15499,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostTasksIDOwnersAsyncWithHttpInfo (string taskID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTasksIDOwnersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTasksIDOwnersAsyncWithIRestResponse(taskID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15569,7 +15569,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -15719,7 +15719,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15867,7 +15867,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceMember</returns>
         public async System.Threading.Tasks.Task<ResourceMember> PostTelegrafsIDMembersAsync (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceMember> localVarResponse = await PostTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceMember> localVarResponse = await PostTelegrafsIDMembersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -15883,7 +15883,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceMember>> PostTelegrafsIDMembersAsyncWithHttpInfo (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsIDMembersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -15953,7 +15953,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -16103,7 +16103,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -16251,7 +16251,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of ResourceOwner</returns>
         public async System.Threading.Tasks.Task<ResourceOwner> PostTelegrafsIDOwnersAsync (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
-             ApiResponse<ResourceOwner> localVarResponse = await PostTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+             ApiResponse<ResourceOwner> localVarResponse = await PostTelegrafsIDOwnersAsyncWithHttpInfo(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -16267,7 +16267,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<ResourceOwner>> PostTelegrafsIDOwnersAsyncWithHttpInfo (string telegrafID, AddResourceMemberRequestBody addResourceMemberRequestBody, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan);
+            IRestResponse localVarResponse = await PostTelegrafsIDOwnersAsyncWithIRestResponse(telegrafID, addResourceMemberRequestBody, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -16337,7 +16337,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -16476,7 +16476,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -16613,7 +16613,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of User</returns>
         public async System.Threading.Tasks.Task<User> PostUsersAsync (User user, string zapTraceSpan = null)
         {
-             ApiResponse<User> localVarResponse = await PostUsersAsyncWithHttpInfo(user, zapTraceSpan);
+             ApiResponse<User> localVarResponse = await PostUsersAsyncWithHttpInfo(user, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -16628,7 +16628,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<User>> PostUsersAsyncWithHttpInfo (User user, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostUsersAsyncWithIRestResponse(user, zapTraceSpan);
+            IRestResponse localVarResponse = await PostUsersAsyncWithIRestResponse(user, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -16693,7 +16693,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -16859,7 +16859,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -17040,7 +17040,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostUsersIDPasswordAsyncWithHttpInfo (string userID, PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostUsersIDPasswordAsyncWithIRestResponse(userID, passwordResetBody, zapTraceSpan, authorization);
+            IRestResponse localVarResponse = await PostUsersIDPasswordAsyncWithIRestResponse(userID, passwordResetBody, zapTraceSpan, authorization).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -17118,7 +17118,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -17273,7 +17273,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -17442,7 +17442,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PutMePasswordAsyncWithHttpInfo (PasswordResetBody passwordResetBody, string zapTraceSpan = null, String authorization = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutMePasswordAsyncWithIRestResponse(passwordResetBody, zapTraceSpan, authorization);
+            IRestResponse localVarResponse = await PutMePasswordAsyncWithIRestResponse(passwordResetBody, zapTraceSpan, authorization).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -17515,7 +17515,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/VariablesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/VariablesService.cs
@@ -790,9 +790,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="variableID">The variable ID.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteVariablesIDAsync (string variableID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteVariablesIDAsync (string variableID, string zapTraceSpan = null)
         {
-             await DeleteVariablesIDAsyncWithHttpInfo(variableID, zapTraceSpan);
+             return DeleteVariablesIDAsyncWithHttpInfo(variableID, zapTraceSpan);
 
         }
 
@@ -1126,9 +1126,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="labelID">The label ID to delete.</param>
         /// <param name="zapTraceSpan">OpenTracing span context (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task DeleteVariablesIDLabelsIDAsync (string variableID, string labelID, string zapTraceSpan = null)
+        public System.Threading.Tasks.Task DeleteVariablesIDLabelsIDAsync (string variableID, string labelID, string zapTraceSpan = null)
         {
-             await DeleteVariablesIDLabelsIDAsyncWithHttpInfo(variableID, labelID, zapTraceSpan);
+             return DeleteVariablesIDLabelsIDAsyncWithHttpInfo(variableID, labelID, zapTraceSpan);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/VariablesService.cs
+++ b/Client/InfluxDB.Client.Api/Service/VariablesService.cs
@@ -671,7 +671,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -806,7 +806,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteVariablesIDAsyncWithHttpInfo (string variableID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteVariablesIDAsyncWithIRestResponse(variableID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteVariablesIDAsyncWithIRestResponse(variableID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -863,7 +863,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -996,7 +996,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1143,7 +1143,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> DeleteVariablesIDLabelsIDAsyncWithHttpInfo (string variableID, string labelID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await DeleteVariablesIDLabelsIDAsyncWithIRestResponse(variableID, labelID, zapTraceSpan);
+            IRestResponse localVarResponse = await DeleteVariablesIDLabelsIDAsyncWithIRestResponse(variableID, labelID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1205,7 +1205,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1327,7 +1327,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1447,7 +1447,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Variables</returns>
         public async System.Threading.Tasks.Task<Variables> GetVariablesAsync (string zapTraceSpan = null, string org = null, string orgID = null)
         {
-             ApiResponse<Variables> localVarResponse = await GetVariablesAsyncWithHttpInfo(zapTraceSpan, org, orgID);
+             ApiResponse<Variables> localVarResponse = await GetVariablesAsyncWithHttpInfo(zapTraceSpan, org, orgID).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1463,7 +1463,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Variables>> GetVariablesAsyncWithHttpInfo (string zapTraceSpan = null, string org = null, string orgID = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetVariablesAsyncWithIRestResponse(zapTraceSpan, org, orgID);
+            IRestResponse localVarResponse = await GetVariablesAsyncWithIRestResponse(zapTraceSpan, org, orgID).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1519,7 +1519,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1642,7 +1642,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1763,7 +1763,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Variable</returns>
         public async System.Threading.Tasks.Task<Variable> GetVariablesIDAsync (string variableID, string zapTraceSpan = null)
         {
-             ApiResponse<Variable> localVarResponse = await GetVariablesIDAsyncWithHttpInfo(variableID, zapTraceSpan);
+             ApiResponse<Variable> localVarResponse = await GetVariablesIDAsyncWithHttpInfo(variableID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -1778,7 +1778,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Variable>> GetVariablesIDAsyncWithHttpInfo (string variableID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetVariablesIDAsyncWithIRestResponse(variableID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetVariablesIDAsyncWithIRestResponse(variableID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -1835,7 +1835,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -1958,7 +1958,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2079,7 +2079,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelsResponse</returns>
         public async System.Threading.Tasks.Task<LabelsResponse> GetVariablesIDLabelsAsync (string variableID, string zapTraceSpan = null)
         {
-             ApiResponse<LabelsResponse> localVarResponse = await GetVariablesIDLabelsAsyncWithHttpInfo(variableID, zapTraceSpan);
+             ApiResponse<LabelsResponse> localVarResponse = await GetVariablesIDLabelsAsyncWithHttpInfo(variableID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2094,7 +2094,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelsResponse>> GetVariablesIDLabelsAsyncWithHttpInfo (string variableID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetVariablesIDLabelsAsyncWithIRestResponse(variableID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetVariablesIDLabelsAsyncWithIRestResponse(variableID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2151,7 +2151,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2301,7 +2301,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2449,7 +2449,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Variable</returns>
         public async System.Threading.Tasks.Task<Variable> PatchVariablesIDAsync (string variableID, Variable variable, string zapTraceSpan = null)
         {
-             ApiResponse<Variable> localVarResponse = await PatchVariablesIDAsyncWithHttpInfo(variableID, variable, zapTraceSpan);
+             ApiResponse<Variable> localVarResponse = await PatchVariablesIDAsyncWithHttpInfo(variableID, variable, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2465,7 +2465,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Variable>> PatchVariablesIDAsyncWithHttpInfo (string variableID, Variable variable, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchVariablesIDAsyncWithIRestResponse(variableID, variable, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchVariablesIDAsyncWithIRestResponse(variableID, variable, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2535,7 +2535,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -2674,7 +2674,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2811,7 +2811,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Variable</returns>
         public async System.Threading.Tasks.Task<Variable> PostVariablesAsync (Variable variable, string zapTraceSpan = null)
         {
-             ApiResponse<Variable> localVarResponse = await PostVariablesAsyncWithHttpInfo(variable, zapTraceSpan);
+             ApiResponse<Variable> localVarResponse = await PostVariablesAsyncWithHttpInfo(variable, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -2826,7 +2826,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Variable>> PostVariablesAsyncWithHttpInfo (Variable variable, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostVariablesAsyncWithIRestResponse(variable, zapTraceSpan);
+            IRestResponse localVarResponse = await PostVariablesAsyncWithIRestResponse(variable, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -2891,7 +2891,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3041,7 +3041,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3189,7 +3189,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of LabelResponse</returns>
         public async System.Threading.Tasks.Task<LabelResponse> PostVariablesIDLabelsAsync (string variableID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
-             ApiResponse<LabelResponse> localVarResponse = await PostVariablesIDLabelsAsyncWithHttpInfo(variableID, labelMapping, zapTraceSpan);
+             ApiResponse<LabelResponse> localVarResponse = await PostVariablesIDLabelsAsyncWithHttpInfo(variableID, labelMapping, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3205,7 +3205,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<LabelResponse>> PostVariablesIDLabelsAsyncWithHttpInfo (string variableID, LabelMapping labelMapping, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostVariablesIDLabelsAsyncWithIRestResponse(variableID, labelMapping, zapTraceSpan);
+            IRestResponse localVarResponse = await PostVariablesIDLabelsAsyncWithIRestResponse(variableID, labelMapping, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3275,7 +3275,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -3425,7 +3425,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3573,7 +3573,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of Variable</returns>
         public async System.Threading.Tasks.Task<Variable> PutVariablesIDAsync (string variableID, Variable variable, string zapTraceSpan = null)
         {
-             ApiResponse<Variable> localVarResponse = await PutVariablesIDAsyncWithHttpInfo(variableID, variable, zapTraceSpan);
+             ApiResponse<Variable> localVarResponse = await PutVariablesIDAsyncWithHttpInfo(variableID, variable, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -3589,7 +3589,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Variable>> PutVariablesIDAsyncWithHttpInfo (string variableID, Variable variable, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PutVariablesIDAsyncWithIRestResponse(variableID, variable, zapTraceSpan);
+            IRestResponse localVarResponse = await PutVariablesIDAsyncWithIRestResponse(variableID, variable, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -3659,7 +3659,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PUT, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/ViewsService.cs
+++ b/Client/InfluxDB.Client.Api/Service/ViewsService.cs
@@ -353,7 +353,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -485,7 +485,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> GetDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -501,7 +501,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> GetDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan);
+            IRestResponse localVarResponse = await GetDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -563,7 +563,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.GET, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {
@@ -724,7 +724,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -883,7 +883,7 @@ namespace InfluxDB.Client.Api.Service
         /// <returns>Task of View</returns>
         public async System.Threading.Tasks.Task<View> PatchDashboardsIDCellsIDViewAsync (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
-             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan);
+             ApiResponse<View> localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithHttpInfo(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
              return localVarResponse.Data;
 
         }
@@ -900,7 +900,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<View>> PatchDashboardsIDCellsIDViewAsyncWithHttpInfo (string dashboardID, string cellID, View view, string zapTraceSpan = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan);
+            IRestResponse localVarResponse = await PatchDashboardsIDCellsIDViewAsyncWithIRestResponse(dashboardID, cellID, view, zapTraceSpan).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -975,7 +975,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.PATCH, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDB.Client.Api/Service/WriteService.cs
+++ b/Client/InfluxDB.Client.Api/Service/WriteService.cs
@@ -570,9 +570,9 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="orgID">Specifies the ID of the destination organization for writes. If both &#x60;orgID&#x60; and &#x60;org&#x60; are specified, &#x60;org&#x60; takes precedence. (optional)</param>
         /// <param name="precision">The precision for the unix timestamps within the body line-protocol. (optional)</param>
         /// <returns>Task of void</returns>
-        public async System.Threading.Tasks.Task PostWriteAsync (string org, string bucket, byte[] body, string zapTraceSpan = null, string contentEncoding = null, string contentType = null, int? contentLength = null, string accept = null, string orgID = null, WritePrecision? precision = null)
+        public System.Threading.Tasks.Task PostWriteAsync (string org, string bucket, byte[] body, string zapTraceSpan = null, string contentEncoding = null, string contentType = null, int? contentLength = null, string accept = null, string orgID = null, WritePrecision? precision = null)
         {
-             await PostWriteAsyncWithHttpInfo(org, bucket, body, zapTraceSpan, contentEncoding, contentType, contentLength, accept, orgID, precision);
+             return PostWriteAsyncWithHttpInfo(org, bucket, body, zapTraceSpan, contentEncoding, contentType, contentLength, accept, orgID, precision);
 
         }
 

--- a/Client/InfluxDB.Client.Api/Service/WriteService.cs
+++ b/Client/InfluxDB.Client.Api/Service/WriteService.cs
@@ -383,7 +383,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -594,7 +594,7 @@ namespace InfluxDB.Client.Api.Service
         public async System.Threading.Tasks.Task<ApiResponse<Object>> PostWriteAsyncWithHttpInfo (string org, string bucket, byte[] body, string zapTraceSpan = null, string contentEncoding = null, string contentType = null, int? contentLength = null, string accept = null, string orgID = null, WritePrecision? precision = null)
         {
             // make the HTTP request
-            IRestResponse localVarResponse = await PostWriteAsyncWithIRestResponse(org, bucket, body, zapTraceSpan, contentEncoding, contentType, contentLength, accept, orgID, precision);
+            IRestResponse localVarResponse = await PostWriteAsyncWithIRestResponse(org, bucket, body, zapTraceSpan, contentEncoding, contentType, contentLength, accept, orgID, precision).ConfigureAwait(false);
 
             int localVarStatusCode = (int) localVarResponse.StatusCode;
 
@@ -681,7 +681,7 @@ namespace InfluxDB.Client.Api.Service
             // make the HTTP request
             IRestResponse localVarResponse = (IRestResponse) await this.Configuration.ApiClient.CallApiAsync(localVarPath,
                 Method.POST, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType).ConfigureAwait(false);
 
             if (ExceptionFactory != null)
             {

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -375,9 +375,9 @@ namespace InfluxDB.Client
         /// Get the health of an instance.
         /// </summary>
         /// <returns>health of an instance</returns>
-        public async Task<HealthCheck> HealthAsync()
+        public Task<HealthCheck> HealthAsync()
         {
-            return await GetHealthAsync(_healthService.GetHealthAsync());
+            return GetHealthAsync(_healthService.GetHealthAsync());
         }
 
         /// <summary>
@@ -404,11 +404,11 @@ namespace InfluxDB.Client
         /// <param name="onboarding">to setup defaults</param>
         /// <exception cref="HttpException">With status code 422 when an onboarding has already been completed</exception>
         /// <returns>defaults for first run</returns>
-        public async Task<OnboardingResponse> OnboardingAsync(OnboardingRequest onboarding)
+        public Task<OnboardingResponse> OnboardingAsync(OnboardingRequest onboarding)
         {
             Arguments.CheckNotNull(onboarding, nameof(onboarding));
 
-            return await _setupService.PostSetupAsync(onboarding);
+            return _setupService.PostSetupAsync(onboarding);
         }
 
         /// <summary>
@@ -431,17 +431,14 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return await task
-                .ContinueWith(t =>
-                {
-                    if (t.Exception != null)
-                    {
-                        return new HealthCheck("influxdb", t.Exception?.Message, default(List<HealthCheck>),
-                            HealthCheck.StatusEnum.Fail);
-                    }
-
-                    return t.Result;
-                }, CancellationToken.None);
+            try
+            {
+                return await task;
+            }
+            catch (Exception e)
+            {
+                return new HealthCheck("influxdb", e.Message, default, HealthCheck.StatusEnum.Fail);
+            }
         }
     }
 }

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -388,7 +388,7 @@ namespace InfluxDB.Client
         {
             try
             {
-                return await _readyService.GetReadyAsync();
+                return await _readyService.GetReadyAsync().ConfigureAwait(false);
             }
             catch (Exception e)
             {
@@ -417,7 +417,7 @@ namespace InfluxDB.Client
         /// <returns>True if onboarding has already been completed otherwise false</returns>
         public async Task<bool> IsOnboardingAllowedAsync()
         {
-            var isOnboarding = await _setupService.GetSetupAsync();
+            var isOnboarding = await _setupService.GetSetupAsync().ConfigureAwait(false);
 
             return isOnboarding.Allowed == true;
         }
@@ -433,7 +433,7 @@ namespace InfluxDB.Client
 
             try
             {
-                return await task;
+                return await task.ConfigureAwait(false);
             }
             catch (Exception e)
             {

--- a/Client/InfluxDBClientFactory.cs
+++ b/Client/InfluxDBClientFactory.cs
@@ -136,7 +136,7 @@ namespace InfluxDB.Client
         /// <param name="org">the name of an organization</param>
         /// <param name="bucket">the name of a bucket</param>
         /// <returns>Created default user, bucket, org.</returns>
-        public static async Task<OnboardingResponse> Onboarding(string url, string username, string password,
+        public static Task<OnboardingResponse> Onboarding(string url, string username, string password,
             string org,
             string bucket)
         {
@@ -148,7 +148,7 @@ namespace InfluxDB.Client
 
             var onboarding = new OnboardingRequest(username, password, org, bucket);
 
-            return await Onboarding(url, onboarding);
+            return Onboarding(url, onboarding);
         }
 
         /// <summary>

--- a/Client/InfluxDBClientFactory.cs
+++ b/Client/InfluxDBClientFactory.cs
@@ -165,7 +165,7 @@ namespace InfluxDB.Client
 
             using (var client = new InfluxDBClient(InfluxDBClientOptions.Builder.CreateNew().Url(url).Build()))
             {
-                return await client.OnboardingAsync(onboarding);
+                return await client.OnboardingAsync(onboarding).ConfigureAwait(false);
             }
         }
     }

--- a/Client/LabelsApi.cs
+++ b/Client/LabelsApi.cs
@@ -27,7 +27,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNotNull(request, nameof(request));
 
-            return (await _service.PostLabelsAsync(request)).Label;
+            var response = await _service.PostLabelsAsync(request);
+            return response.Label;
         }
 
         /// <summary>
@@ -37,14 +38,14 @@ namespace InfluxDB.Client
         /// <param name="properties">properties of a label</param>
         /// <param name="orgId">owner of a label</param>
         /// <returns>Added label</returns>
-        public async Task<Label> CreateLabelAsync(string name, Dictionary<string, string> properties,
+        public Task<Label> CreateLabelAsync(string name, Dictionary<string, string> properties,
             string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(properties, nameof(properties));
 
-            return await CreateLabelAsync(new LabelCreateRequest(orgId, name, properties));
+            return CreateLabelAsync(new LabelCreateRequest(orgId, name, properties));
         }
 
         /// <summary>
@@ -52,13 +53,13 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to update</param>
         /// <returns>Updated label</returns>
-        public async Task<Label> UpdateLabelAsync(Label label)
+        public Task<Label> UpdateLabelAsync(Label label)
         {
             Arguments.CheckNotNull(label, nameof(label));
 
             var labelUpdate = new LabelUpdate {Properties = label.Properties};
 
-            return await UpdateLabelAsync(label.Id, labelUpdate);
+            return UpdateLabelAsync(label.Id, labelUpdate);
         }
 
         /// <summary>
@@ -69,7 +70,8 @@ namespace InfluxDB.Client
         /// <returns>Updated label</returns>
         public async Task<Label> UpdateLabelAsync(string labelId, LabelUpdate labelUpdate)
         {
-            return (await _service.PatchLabelsIDAsync(labelId, labelUpdate)).Label;
+            var response = await _service.PatchLabelsIDAsync(labelId, labelUpdate);
+            return response.Label;
         }
 
         /// <summary>
@@ -77,11 +79,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(Label label)
+        public Task DeleteLabelAsync(Label label)
         {
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id);
+            return DeleteLabelAsync(label.Id);
         }
 
         /// <summary>
@@ -89,11 +91,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">ID of label to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(string labelId)
+        public Task DeleteLabelAsync(string labelId)
         {
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteLabelsIDAsync(labelId);
+            return _service.DeleteLabelsIDAsync(labelId);
         }
 
         /// <summary>
@@ -107,8 +109,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return await FindLabelByIdAsync(labelId)
-                            .ContinueWith(t => CloneLabelAsync(clonedName, t.Result)).Unwrap();
+            var label = await FindLabelByIdAsync(labelId);
+
+            return await CloneLabelAsync(clonedName, label);
         }
 
         /// <summary>
@@ -117,7 +120,7 @@ namespace InfluxDB.Client
         /// <param name="clonedName">name of cloned label</param>
         /// <param name="label">label to clone</param>
         /// <returns>cloned label</returns>
-        public async Task<Label> CloneLabelAsync(string clonedName, Label label)
+        public Task<Label> CloneLabelAsync(string clonedName, Label label)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(label, nameof(label));
@@ -125,7 +128,7 @@ namespace InfluxDB.Client
             var cloned =
                 new LabelCreateRequest(label.OrgID, clonedName, new Dictionary<string, string>(label.Properties));
 
-            return await CreateLabelAsync(cloned);
+            return CreateLabelAsync(cloned);
         }
 
         /// <summary>
@@ -137,7 +140,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return (await _service.GetLabelsIDAsync(labelId)).Label;
+            var response = await _service.GetLabelsIDAsync(labelId);
+            return response.Label;
         }
 
         /// <summary>
@@ -146,7 +150,8 @@ namespace InfluxDB.Client
         /// <returns>List all labels.</returns>
         public async Task<List<Label>> FindLabelsAsync()
         {
-            return (await _service.GetLabelsAsync()).Labels;
+            var response = await _service.GetLabelsAsync();
+            return response.Labels;
         }
 
         /// <summary>
@@ -154,11 +159,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">specifies the organization of the resource</param>
         /// <returns>all labels</returns>
-        public async Task<List<Label>> FindLabelsByOrgAsync(Organization organization)
+        public Task<List<Label>> FindLabelsByOrgAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await FindLabelsByOrgIdAsync(organization.Id);
+            return FindLabelsByOrgIdAsync(organization.Id);
         }
 
         /// <summary>
@@ -168,7 +173,8 @@ namespace InfluxDB.Client
         /// <returns>all labels</returns>
         public async Task<List<Label>> FindLabelsByOrgIdAsync(string orgId)
         {
-            return (await _service.GetLabelsAsync(null, orgId)).Labels;
+            var response = await _service.GetLabelsAsync(null, orgId);
+            return response.Labels;
         }
     }
 }

--- a/Client/LabelsApi.cs
+++ b/Client/LabelsApi.cs
@@ -27,7 +27,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNotNull(request, nameof(request));
 
-            var response = await _service.PostLabelsAsync(request);
+            var response = await _service.PostLabelsAsync(request).ConfigureAwait(false);
             return response.Label;
         }
 
@@ -70,7 +70,7 @@ namespace InfluxDB.Client
         /// <returns>Updated label</returns>
         public async Task<Label> UpdateLabelAsync(string labelId, LabelUpdate labelUpdate)
         {
-            var response = await _service.PatchLabelsIDAsync(labelId, labelUpdate);
+            var response = await _service.PatchLabelsIDAsync(labelId, labelUpdate).ConfigureAwait(false);
             return response.Label;
         }
 
@@ -109,9 +109,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            var label = await FindLabelByIdAsync(labelId);
+            var label = await FindLabelByIdAsync(labelId).ConfigureAwait(false);
 
-            return await CloneLabelAsync(clonedName, label);
+            return await CloneLabelAsync(clonedName, label).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -140,7 +140,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            var response = await _service.GetLabelsIDAsync(labelId);
+            var response = await _service.GetLabelsIDAsync(labelId).ConfigureAwait(false);
             return response.Label;
         }
 
@@ -150,7 +150,7 @@ namespace InfluxDB.Client
         /// <returns>List all labels.</returns>
         public async Task<List<Label>> FindLabelsAsync()
         {
-            var response = await _service.GetLabelsAsync();
+            var response = await _service.GetLabelsAsync().ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -173,7 +173,7 @@ namespace InfluxDB.Client
         /// <returns>all labels</returns>
         public async Task<List<Label>> FindLabelsByOrgIdAsync(string orgId)
         {
-            var response = await _service.GetLabelsAsync(null, orgId);
+            var response = await _service.GetLabelsAsync(null, orgId).ConfigureAwait(false);
             return response.Labels;
         }
     }

--- a/Client/NotificationEndpointsApi.cs
+++ b/Client/NotificationEndpointsApi.cs
@@ -54,7 +54,7 @@ namespace InfluxDB.Client
             var endpoint = new SlackNotificationEndpoint(type: NotificationEndpointType.Slack,
                 url: url, token: token, orgID: orgId, name: name, status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (SlackNotificationEndpoint) await CreateEndpointAsync(endpoint);
+            return (SlackNotificationEndpoint) await CreateEndpointAsync(endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -77,7 +77,7 @@ namespace InfluxDB.Client
                 clientURL: clientUrl, routingKey: routingKey, orgID: orgId, name: name,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (PagerDutyNotificationEndpoint) await CreateEndpointAsync(endpoint);
+            return (PagerDutyNotificationEndpoint) await CreateEndpointAsync(endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -101,7 +101,7 @@ namespace InfluxDB.Client
                 name: name, authMethod: HTTPNotificationEndpoint.AuthMethodEnum.None,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint);
+            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace InfluxDB.Client
                 password: password,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint);
+            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -156,7 +156,7 @@ namespace InfluxDB.Client
                 name: name, authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Bearer, token: token,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint);
+            return (HTTPNotificationEndpoint) await CreateEndpointAsync(endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -236,7 +236,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await FindNotificationEndpointsAsync(orgId, new FindOptions());
+            var response = await FindNotificationEndpointsAsync(orgId, new FindOptions()).ConfigureAwait(false);
             return response._NotificationEndpoints;
         }
 
@@ -280,8 +280,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            var endpoint = (SlackNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId);
-            return await CloneSlackEndpointAsync(name, token, endpoint);
+            var endpoint = (SlackNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+            return await CloneSlackEndpointAsync(name, token, endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -299,7 +299,7 @@ namespace InfluxDB.Client
 
             var cloned = new SlackNotificationEndpoint(endpoint.Url, token, name: name);
 
-            return (SlackNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned);
+            return (SlackNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -316,8 +316,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(routingKey, nameof(routingKey));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            var endpoint = (PagerDutyNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId);
-            return await ClonePagerDutyEndpointAsync(name, routingKey, endpoint);
+            var endpoint = (PagerDutyNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+            return await ClonePagerDutyEndpointAsync(name, routingKey, endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -336,7 +336,7 @@ namespace InfluxDB.Client
 
             var cloned = new PagerDutyNotificationEndpoint(endpoint.ClientURL, routingKey, name: name);
 
-            return (PagerDutyNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned);
+            return (PagerDutyNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -350,8 +350,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
             
-            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId);
-            return await CloneHttpEndpoint(name, endpoint);
+            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+            return await CloneHttpEndpoint(name, endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -369,7 +369,7 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.None, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned);
+            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -388,8 +388,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(password, nameof(password));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
             
-            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId);
-            return await CloneHttpEndpointBasicAuthAsync(name, username, password, endpoint);
+            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+            return await CloneHttpEndpointBasicAuthAsync(name, username, password, endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -414,7 +414,7 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Basic, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned);
+            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -431,8 +431,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(token, nameof(token));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId);
-            return await CloneHttpEndpointBearerAsync(name, token, endpoint);
+            var endpoint = (HTTPNotificationEndpoint) await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+            return await CloneHttpEndpointBearerAsync(name, token, endpoint).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -454,7 +454,7 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Bearer, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned);
+            return (HTTPNotificationEndpoint) await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -478,7 +478,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            var response = await _service.GetNotificationEndpointsIDLabelsAsync(endpointId);
+            var response = await _service.GetNotificationEndpointsIDLabelsAsync(endpointId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -509,7 +509,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostNotificationEndpointIDLabelsAsync(endpointId, mapping);
+            var response = await _service.PostNotificationEndpointIDLabelsAsync(endpointId, mapping).ConfigureAwait(false);
             return response.Label;
         }
 
@@ -549,12 +549,12 @@ namespace InfluxDB.Client
             clonedEndpoint.Status = toCloneEndpoint.Status;
             clonedEndpoint.Type = toCloneEndpoint.Type;
 
-            var created = await CreateEndpointAsync(clonedEndpoint);
-            var labels = await GetLabelsAsync(toCloneEndpoint);
+            var created = await CreateEndpointAsync(clonedEndpoint).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(toCloneEndpoint).ConfigureAwait(false);
             
             foreach (var label in labels)
             {
-                await AddLabelAsync(label, created);
+                await AddLabelAsync(label, created).ConfigureAwait(false);
             }
 
             return created;

--- a/Client/NotificationRulesApi.cs
+++ b/Client/NotificationRulesApi.cs
@@ -81,7 +81,7 @@ namespace InfluxDB.Client
             var rule = new SlackNotificationRule(SlackNotificationRuleBase.TypeEnum.Slack,
                 messageTemplate: messageTemplate);
 
-            return (SlackNotificationRule) await CreateRuleAsync(name, every, status, tagRules, endpoint, orgId, rule);
+            return (SlackNotificationRule) await CreateRuleAsync(name, every, status, tagRules, endpoint, orgId, rule).ConfigureAwait(false);
         }
 
         /**
@@ -124,7 +124,7 @@ namespace InfluxDB.Client
                 messageTemplate);
 
             return (PagerDutyNotificationRule) await CreateRuleAsync(name, every, status, tagRules, endpoint, orgId,
-                rule);
+                rule).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -144,7 +144,7 @@ namespace InfluxDB.Client
             var rule = new HTTPNotificationRule(HTTPNotificationRuleBase.TypeEnum.Http);
 
             return (HTTPNotificationRule) await CreateRuleAsync(name, every, status, tagRules, endpoint, orgId,
-                rule);
+                rule).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -234,7 +234,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await FindNotificationRulesAsync(orgId, new FindOptions());
+            var response = await FindNotificationRulesAsync(orgId, new FindOptions()).ConfigureAwait(false);
             return response._NotificationRules;
         }
 
@@ -281,7 +281,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            var response = await _service.GetNotificationRulesIDLabelsAsync(ruleId);
+            var response = await _service.GetNotificationRulesIDLabelsAsync(ruleId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -312,7 +312,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostNotificationRuleIDLabelsAsync(ruleId, mapping);
+            var response = await _service.PostNotificationRuleIDLabelsAsync(ruleId, mapping).ConfigureAwait(false);
             return response.Label;
         }
 

--- a/Client/NotificationRulesApi.cs
+++ b/Client/NotificationRulesApi.cs
@@ -29,7 +29,7 @@ namespace InfluxDB.Client
         /// <param name="endpoint">The endpoint to use for notification.</param>
         /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
         /// <returns>Notification rule created</returns>
-        public async Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
+        public Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
             RuleStatusLevel status, SlackNotificationEndpoint endpoint, string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
@@ -39,7 +39,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return await CreateSlackRuleAsync(name, every, messageTemplate, status, new List<TagRule>(), endpoint,
+            return CreateSlackRuleAsync(name, every, messageTemplate, status, new List<TagRule>(), endpoint,
                 orgId);
         }
 
@@ -152,11 +152,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="rule">Notification rule to create</param>
         /// <returns>Notification rule created</returns>
-        public async Task<NotificationRule> CreateRuleAsync(NotificationRule rule)
+        public Task<NotificationRule> CreateRuleAsync(NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            return await _service.CreateNotificationRuleAsync(rule);
+            return _service.CreateNotificationRuleAsync(rule);
         }
 
         /// <summary>
@@ -164,14 +164,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="rule">Notification rule update to apply</param>
         /// <returns>An updated notification rule</returns>
-        public async Task<NotificationRule> UpdateNotificationRuleAsync(NotificationRule rule)
+        public Task<NotificationRule> UpdateNotificationRuleAsync(NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
             Enum.TryParse(rule.Status.ToString(), true,
                 out NotificationRuleUpdate.StatusEnum status);
 
-            return await UpdateNotificationRuleAsync(rule.Id,
+            return UpdateNotificationRuleAsync(rule.Id,
                 new NotificationRuleUpdate(rule.Name, rule.Description, status));
         }
 
@@ -181,12 +181,12 @@ namespace InfluxDB.Client
         /// <param name="ruleId">The notification rule ID.</param>
         /// <param name="update">Notification rule update to apply</param>
         /// <returns>An updated notification rule</returns>
-        public async Task<NotificationRule> UpdateNotificationRuleAsync(string ruleId, NotificationRuleUpdate update)
+        public Task<NotificationRule> UpdateNotificationRuleAsync(string ruleId, NotificationRuleUpdate update)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
             Arguments.CheckNotNull(update, nameof(update));
 
-            return await _service.PatchNotificationRulesIDAsync(ruleId, update);
+            return _service.PatchNotificationRulesIDAsync(ruleId, update);
         }
 
         /// <summary>
@@ -194,11 +194,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="rule">The notification rule</param>
         /// <returns></returns>
-        public async Task DeleteNotificationRuleAsync(NotificationRule rule)
+        public Task DeleteNotificationRuleAsync(NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            await DeleteNotificationRuleAsync(rule.Id);
+            return DeleteNotificationRuleAsync(rule.Id);
         }
 
         /// <summary>
@@ -206,11 +206,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ruleId">The notification rule ID</param>
         /// <returns></returns>
-        public async Task DeleteNotificationRuleAsync(string ruleId)
+        public Task DeleteNotificationRuleAsync(string ruleId)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            await _service.DeleteNotificationRulesIDAsync(ruleId);
+            return _service.DeleteNotificationRulesIDAsync(ruleId);
         }
 
         /// <summary>
@@ -218,11 +218,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ruleId">The notification rule ID</param>
         /// <returns>The notification rule requested</returns>
-        public async Task<NotificationRule> FindNotificationRuleByIdAsync(string ruleId)
+        public Task<NotificationRule> FindNotificationRuleByIdAsync(string ruleId)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            return await _service.GetNotificationRulesIDAsync(ruleId);
+            return _service.GetNotificationRulesIDAsync(ruleId);
         }
 
         /// <summary>
@@ -234,7 +234,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await FindNotificationRulesAsync(orgId, new FindOptions()))._NotificationRules;
+            var response = await FindNotificationRulesAsync(orgId, new FindOptions());
+            return response._NotificationRules;
         }
 
         /// <summary>
@@ -243,12 +244,12 @@ namespace InfluxDB.Client
         /// <param name="orgId">Only show notification rules that belong to a specific organization ID.</param>
         /// <param name="findOptions">find options</param>
         /// <returns></returns>
-        public async Task<NotificationRules> FindNotificationRulesAsync(string orgId, FindOptions findOptions)
+        public Task<NotificationRules> FindNotificationRulesAsync(string orgId, FindOptions findOptions)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
-            return await _service.GetNotificationRulesAsync(orgId, offset: findOptions.Offset,
+            return _service.GetNotificationRulesAsync(orgId, offset: findOptions.Offset,
                 limit: findOptions.Limit);
         }
 
@@ -257,11 +258,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="rule">The notification rule.</param>
         /// <returns>A list of all labels for a notification rule</returns>
-        public async Task<List<Label>> GetLabelsAsync(NotificationRule rule)
+        public Task<List<Label>> GetLabelsAsync(NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            return await GetLabelsAsync(rule.Id);
+            return GetLabelsAsync(rule.Id);
         }
 
         /**
@@ -280,7 +281,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            return (await _service.GetNotificationRulesIDLabelsAsync(ruleId)).Labels;
+            var response = await _service.GetNotificationRulesIDLabelsAsync(ruleId);
+            return response.Labels;
         }
 
         /// <summary>
@@ -289,12 +291,12 @@ namespace InfluxDB.Client
         /// <param name="label">Label to add</param>
         /// <param name="rule">The notification rule.</param>
         /// <returns>The label was added to the notification rule</returns>
-        public async Task<Label> AddLabelAsync(Label label, NotificationRule rule)
+        public Task<Label> AddLabelAsync(Label label, NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return await AddLabelAsync(label.Id, rule.Id);
+            return AddLabelAsync(label.Id, rule.Id);
         }
 
         /// <summary>
@@ -310,7 +312,8 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            return (await _service.PostNotificationRuleIDLabelsAsync(ruleId, mapping)).Label;
+            var response = await _service.PostNotificationRuleIDLabelsAsync(ruleId, mapping);
+            return response.Label;
         }
 
         /// <summary>
@@ -318,12 +321,12 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">The label to delete.</param>
         /// <param name="rule">The notification rule.</param>
-        public async Task DeleteLabelAsync(Label label, NotificationRule rule)
+        public Task DeleteLabelAsync(Label label, NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id, rule.Id);
+            return DeleteLabelAsync(label.Id, rule.Id);
         }
 
         /// <summary>
@@ -331,15 +334,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">The ID of the label to delete.</param>
         /// <param name="ruleId">The notification rule ID.</param>
-        public async Task DeleteLabelAsync(string labelId, string ruleId)
+        public Task DeleteLabelAsync(string labelId, string ruleId)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteNotificationRulesIDLabelsIDAsync(ruleId, labelId);
+            return _service.DeleteNotificationRulesIDLabelsIDAsync(ruleId, labelId);
         }
 
-        private async Task<NotificationRule> CreateRuleAsync(string name, string every, RuleStatusLevel status,
+        private Task<NotificationRule> CreateRuleAsync(string name, string every, RuleStatusLevel status,
             List<TagRule> tagRules, NotificationEndpoint notificationEndpoint, string orgId, NotificationRule rule)
         {
             Arguments.CheckNotNull(rule, "rule");
@@ -352,7 +355,7 @@ namespace InfluxDB.Client
             rule.EndpointID = notificationEndpoint.Id;
             rule.Status = TaskStatusType.Active;
 
-            return await CreateRuleAsync(rule);
+            return CreateRuleAsync(rule);
         }
     }
 }

--- a/Client/OrganizationsApi.cs
+++ b/Client/OrganizationsApi.cs
@@ -91,8 +91,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var org = await FindOrganizationByIdAsync(orgId);
-            return await CloneOrganizationAsync(clonedName, org);
+            var org = await FindOrganizationByIdAsync(orgId).ConfigureAwait(false);
+            return await CloneOrganizationAsync(clonedName, org).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -130,7 +130,7 @@ namespace InfluxDB.Client
         /// <returns>List all organizations</returns>
         public async Task<List<Organization>> FindOrganizationsAsync(int? limit = null)
         {
-            var response = await _service.GetOrgsAsync(limit: limit);
+            var response = await _service.GetOrgsAsync(limit: limit).ConfigureAwait(false);
             return response.Orgs;
         }
 
@@ -165,7 +165,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetOrgsIDSecretsAsync(orgId);
+            var response = await _service.GetOrgsIDSecretsAsync(orgId).ConfigureAwait(false);
             return response.Secrets;
         }
 
@@ -260,7 +260,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetOrgsIDMembersAsync(orgId);
+            var response = await _service.GetOrgsIDMembersAsync(orgId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -341,7 +341,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetOrgsIDOwnersAsync(orgId);
+            var response = await _service.GetOrgsIDOwnersAsync(orgId).ConfigureAwait(false);
             return response.Users;
         }
 

--- a/Client/OrganizationsApi.cs
+++ b/Client/OrganizationsApi.cs
@@ -23,13 +23,13 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name"></param>
         /// <returns>Created organization</returns>
-        public async Task<Organization> CreateOrganizationAsync(string name)
+        public Task<Organization> CreateOrganizationAsync(string name)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
 
             var organization = new Organization(null, name);
 
-            return await CreateOrganizationAsync(organization);
+            return CreateOrganizationAsync(organization);
         }
 
         /// <summary>
@@ -37,11 +37,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">the organization to create</param>
         /// <returns>created organization</returns>
-        public async Task<Organization> CreateOrganizationAsync(Organization organization)
+        public Task<Organization> CreateOrganizationAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await _service.PostOrgsAsync(organization);
+            return _service.PostOrgsAsync(organization);
         }
 
         /// <summary>
@@ -49,11 +49,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">organization update to apply</param>
         /// <returns>updated organization</returns>
-        public async Task<Organization> UpdateOrganizationAsync(Organization organization)
+        public Task<Organization> UpdateOrganizationAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await _service.PatchOrgsIDAsync(organization.Id, organization);
+            return _service.PatchOrgsIDAsync(organization.Id, organization);
         }
 
         /// <summary>
@@ -61,11 +61,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">ID of organization to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteOrganizationAsync(string orgId)
+        public Task DeleteOrganizationAsync(string orgId)
         {
             Arguments.CheckNotNull(orgId, nameof(orgId));
 
-            await _service.DeleteOrgsIDAsync(orgId);
+            return _service.DeleteOrgsIDAsync(orgId);
         }
 
         /// <summary>
@@ -73,26 +73,26 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">organization to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteOrganizationAsync(Organization organization)
+        public Task DeleteOrganizationAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            await DeleteOrganizationAsync(organization.Id);
+            return DeleteOrganizationAsync(organization.Id);
         }
 
         /// <summary>
         /// Clone an organization.
         /// </summary>
         /// <param name="clonedName">name of cloned organization</param>
-        /// <param name="bucketId">ID of organization to clone</param>
+        /// <param name="orgId">ID of organization to clone</param>
         /// <returns>cloned organization</returns>
-        public async Task<Organization> CloneOrganizationAsync(string clonedName, string bucketId)
+        public async Task<Organization> CloneOrganizationAsync(string clonedName, string orgId)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
-            Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
+            Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return await FindOrganizationByIdAsync(bucketId).ContinueWith(t => 
-                            CloneOrganizationAsync(clonedName, t.Result)).Unwrap();
+            var org = await FindOrganizationByIdAsync(orgId);
+            return await CloneOrganizationAsync(clonedName, org);
         }
 
         /// <summary>
@@ -101,14 +101,14 @@ namespace InfluxDB.Client
         /// <param name="clonedName">name of cloned organization</param>
         /// <param name="organization">organization to clone</param>
         /// <returns>cloned organization</returns>
-        public async Task<Organization> CloneOrganizationAsync(string clonedName, Organization organization)
+        public Task<Organization> CloneOrganizationAsync(string clonedName, Organization organization)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(organization, nameof(organization));
 
             var cloned = new Organization(null, clonedName);
 
-            return await CreateOrganizationAsync(cloned);
+            return CreateOrganizationAsync(cloned);
         }
 
         /// <summary>
@@ -116,11 +116,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">ID of organization to get</param>
         /// <returns>organization details</returns>
-        public async Task<Organization> FindOrganizationByIdAsync(string orgId)
+        public Task<Organization> FindOrganizationByIdAsync(string orgId)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return await _service.GetOrgsIDAsync(orgId);
+            return _service.GetOrgsIDAsync(orgId);
         }
 
         /// <summary>
@@ -130,7 +130,8 @@ namespace InfluxDB.Client
         /// <returns>List all organizations</returns>
         public async Task<List<Organization>> FindOrganizationsAsync(int? limit = null)
         {
-            return (await _service.GetOrgsAsync(limit: limit)).Orgs;
+            var response = await _service.GetOrgsAsync(limit: limit);
+            return response.Orgs;
         }
 
         /// <summary>
@@ -143,11 +144,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">the organization for get secrets</param>
         /// <returns>the secret keys</returns>
-        public async Task<List<string>> GetSecretsAsync(Organization organization)
+        public Task<List<string>> GetSecretsAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await GetSecretsAsync(organization.Id);
+            return GetSecretsAsync(organization.Id);
         }
 
         /// <summary>
@@ -164,7 +165,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await _service.GetOrgsIDSecretsAsync(orgId)).Secrets;
+            var response = await _service.GetOrgsIDSecretsAsync(orgId);
+            return response.Secrets;
         }
 
         /// <summary>
@@ -173,12 +175,12 @@ namespace InfluxDB.Client
         /// <param name="secrets">secrets to update/add</param>
         /// <param name="organization">the organization for put secrets</param>
         /// <returns></returns>
-        public async Task PutSecretsAsync(Dictionary<string, string> secrets, Organization organization)
+        public Task PutSecretsAsync(Dictionary<string, string> secrets, Organization organization)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            await PutSecretsAsync(secrets, organization.Id);
+            return PutSecretsAsync(secrets, organization.Id);
         }
 
         /// <summary>
@@ -187,12 +189,12 @@ namespace InfluxDB.Client
         /// <param name="secrets">secrets to update/add</param>
         /// <param name="orgId">the organization for put secrets</param>
         /// <returns></returns>
-        public async Task PutSecretsAsync(Dictionary<string, string> secrets, string orgId)
+        public Task PutSecretsAsync(Dictionary<string, string> secrets, string orgId)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            await _service.PatchOrgsIDSecretsAsync(orgId, secrets);
+            return _service.PatchOrgsIDSecretsAsync(orgId, secrets);
         }
 
         /// <summary>
@@ -201,12 +203,12 @@ namespace InfluxDB.Client
         /// <param name="secrets">secrets to delete</param>
         /// <param name="organization">the organization for delete secrets</param>
         /// <returns>keys successfully patched</returns>
-        public async Task DeleteSecretsAsync(List<string> secrets, Organization organization)
+        public Task DeleteSecretsAsync(List<string> secrets, Organization organization)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            await DeleteSecretsAsync(secrets, organization.Id);
+            return DeleteSecretsAsync(secrets, organization.Id);
         }
 
         /// <summary>
@@ -215,12 +217,12 @@ namespace InfluxDB.Client
         /// <param name="secrets">secrets to delete</param>
         /// <param name="orgId">the organization for delete secrets</param>
         /// <returns>keys successfully patched</returns>
-        public async Task DeleteSecretsAsync(List<string> secrets, string orgId)
+        public Task DeleteSecretsAsync(List<string> secrets, string orgId)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            await DeleteSecretsAsync(new SecretKeys(secrets), orgId);
+            return DeleteSecretsAsync(new SecretKeys(secrets), orgId);
         }
         
         /// <summary>
@@ -229,12 +231,12 @@ namespace InfluxDB.Client
         /// <param name="secrets">secrets to delete</param>
         /// <param name="orgId">the organization for delete secrets</param>
         /// <returns>keys successfully patched</returns>
-        public async Task DeleteSecretsAsync(SecretKeys secrets, string orgId)
+        public Task DeleteSecretsAsync(SecretKeys secrets, string orgId)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            await _service.PostOrgsIDSecretsAsync(orgId, secrets);
+            return _service.PostOrgsIDSecretsAsync(orgId, secrets);
         }
 
         /// <summary>
@@ -242,11 +244,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">organization of the members</param>
         /// <returns>the List all members of an organization</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(Organization organization)
+        public Task<List<ResourceMember>> GetMembersAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await GetMembersAsync(organization.Id);
+            return GetMembersAsync(organization.Id);
         }
 
         /// <summary>
@@ -258,7 +260,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await _service.GetOrgsIDMembersAsync(orgId)).Users;
+            var response = await _service.GetOrgsIDMembersAsync(orgId);
+            return response.Users;
         }
 
         /// <summary>
@@ -267,12 +270,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of an organization</param>
         /// <param name="organization">the organization of a member</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(User member, Organization organization)
+        public Task<ResourceMember> AddMemberAsync(User member, Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return await AddMemberAsync(member.Id, organization.Id);
+            return AddMemberAsync(member.Id, organization.Id);
         }
 
         /// <summary>
@@ -281,12 +284,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="orgId">the ID of an organization</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(string memberId, string orgId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string orgId)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return await _service.PostOrgsIDMembersAsync(orgId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostOrgsIDMembersAsync(orgId, new AddResourceMemberRequestBody(memberId));
         }
 
         /// <summary>
@@ -295,12 +298,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of an organization</param>
         /// <param name="organization">the organization of a member</param>
         /// <returns></returns>
-        public async Task DeleteMemberAsync(User member, Organization organization)
+        public Task DeleteMemberAsync(User member, Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(member, nameof(member));
 
-            await DeleteMemberAsync(member.Id, organization.Id);
+            return DeleteMemberAsync(member.Id, organization.Id);
         }
 
         /// <summary>
@@ -309,12 +312,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="orgId">the ID of an organization</param>
         /// <returns></returns>
-        public async Task DeleteMemberAsync(string memberId, string orgId)
+        public Task DeleteMemberAsync(string memberId, string orgId)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            await _service.DeleteOrgsIDMembersIDAsync(memberId, orgId);
+            return _service.DeleteOrgsIDMembersIDAsync(memberId, orgId);
         }
 
         /// <summary>
@@ -322,11 +325,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">organization of the owners</param>
         /// <returns>the List all owners of an organization</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(Organization organization)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await GetOwnersAsync(organization.Id);
+            return GetOwnersAsync(organization.Id);
         }
 
         /// <summary>
@@ -338,7 +341,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await _service.GetOrgsIDOwnersAsync(orgId)).Users;
+            var response = await _service.GetOrgsIDOwnersAsync(orgId);
+            return response.Users;
         }
 
         /// <summary>
@@ -347,12 +351,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of an organization</param>
         /// <param name="organization">the organization of a owner</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(User owner, Organization organization)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return await AddOwnerAsync(owner.Id, organization.Id);
+            return AddOwnerAsync(owner.Id, organization.Id);
         }
 
         /// <summary>
@@ -361,12 +365,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="orgId">the ID of an organization</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(string ownerId, string orgId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string orgId)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return await _service.PostOrgsIDOwnersAsync(orgId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostOrgsIDOwnersAsync(orgId, new AddResourceMemberRequestBody(ownerId));
         }
 
         /// <summary>
@@ -375,12 +379,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of an organization</param>
         /// <param name="organization">the organization of a owner</param>
         /// <returns></returns>
-        public async Task DeleteOwnerAsync(User owner, Organization organization)
+        public Task DeleteOwnerAsync(User owner, Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            await DeleteOwnerAsync(owner.Id, organization.Id);
+            return DeleteOwnerAsync(owner.Id, organization.Id);
         }
 
         /// <summary>
@@ -389,12 +393,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="orgId">the ID of an organization</param>
         /// <returns></returns>
-        public async Task DeleteOwnerAsync(string ownerId, string orgId)
+        public Task DeleteOwnerAsync(string ownerId, string orgId)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            await _service.DeleteOrgsIDOwnersIDAsync(ownerId, orgId);
+            return _service.DeleteOrgsIDOwnersIDAsync(ownerId, orgId);
         }
     }
 }

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -55,11 +55,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public async Task<List<FluxTable>> QueryAsync(string query)
+        public Task<List<FluxTable>> QueryAsync(string query)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return await QueryAsync(query, _options.Org);
+            return QueryAsync(query, _options.Org);
         }
 
         /// <summary>
@@ -75,12 +75,12 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public async Task<List<FluxTable>> QueryAsync(string query, string org)
+        public Task<List<FluxTable>> QueryAsync(string query, string org)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return await QueryAsync(CreateQuery(query, _defaultDialect), org);
+            return QueryAsync(CreateQuery(query, _defaultDialect), org);
         }
 
         /// <summary>
@@ -95,11 +95,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public async Task<List<FluxTable>> QueryAsync(Query query)
+        public Task<List<FluxTable>> QueryAsync(Query query)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return await QueryAsync(query, _options.Org);
+            return QueryAsync(query, _options.Org);
         }
 
         /// <summary>
@@ -140,11 +140,11 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async Task<List<T>> QueryAsync<T>(string query)
+        public Task<List<T>> QueryAsync<T>(string query)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return await QueryAsync<T>(query, _options.Org);
+            return QueryAsync<T>(query, _options.Org);
         }
 
         /// <summary>
@@ -161,12 +161,12 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async Task<List<T>> QueryAsync<T>(string query, string org)
+        public Task<List<T>> QueryAsync<T>(string query, string org)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return await QueryAsync<T>(CreateQuery(query), org);
+            return QueryAsync<T>(CreateQuery(query), org);
         }
 
         /// <summary>
@@ -220,11 +220,11 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async Task<List<T>> QueryAsync<T>(Query query)
+        public Task<List<T>> QueryAsync<T>(Query query)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return await QueryAsync<T>(query, _options.Org);
+            return QueryAsync<T>(query, _options.Org);
         }
 
         /// <summary>
@@ -263,12 +263,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext);
         }
 
         /// <summary>
@@ -280,12 +280,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer);
         }
 
         /// <summary>
@@ -296,12 +296,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext);
         }
 
         /// <summary>
@@ -313,12 +313,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer);
         }
 
         /// <summary>
@@ -330,47 +330,12 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, _options.Org, onNext);
-        }
-
-        /// <summary>
-        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
-        /// to a <see cref="onNext"/> consumer.
-        /// </summary>
-        /// <param name="query">the flux query to execute</param>
-        /// <param name="org">specifies the source organization</param>
-        /// <param name="onNext">the callback to consume the mapped Measurements with capability
-        /// to discontinue a streaming query</param>
-        /// <typeparam name="T">the type of measurement</typeparam>
-        /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext)
-        {
-            Arguments.CheckNonEmptyString(query, nameof(query));
-            Arguments.CheckNotNull(onNext, nameof(onNext));
-
-            await QueryAsync(query, org, onNext, ErrorConsumer);
-        }
-
-        /// <summary>
-        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
-        /// to a <see cref="onNext"/> consumer.
-        /// </summary>
-        /// <param name="query">the flux query to execute</param>
-        /// <param name="onNext">the callback to consume the mapped Measurements with capability
-        /// to discontinue a streaming query</param>
-        /// <typeparam name="T">the type of measurement</typeparam>
-        /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext)
-        {
-            Arguments.CheckNotNull(query, nameof(query));
-            Arguments.CheckNotNull(onNext, nameof(onNext));
-
-            await QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext);
         }
 
         /// <summary>
@@ -383,49 +348,47 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNotNull(onNext, nameof(onNext));
+
+            return QueryAsync(query, org, onNext, ErrorConsumer);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements with capability
+        /// to discontinue a streaming query</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>async task</returns>
+        public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            await QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, _options.Org, onNext);
         }
 
         /// <summary>
-        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream <see cref="FluxRecord"/>
-        /// to <see cref="onNext"/> consumer.
-        /// </summary>
-        /// <param name="query">the flux query to execute</param>
-        /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
-        /// <param name="onError">the callback to consume any error notification</param>
-        /// <returns>async task</returns>
-        public async Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
-        {
-            Arguments.CheckNonEmptyString(query, nameof(query));
-            Arguments.CheckNotNull(onNext, nameof(onNext));
-            Arguments.CheckNotNull(onError, nameof(onError));
-
-            await QueryAsync(query, _options.Org, onNext, onError);
-        }
-
-        /// <summary>
-        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream <see cref="FluxRecord"/>
-        /// to <see cref="onNext"/> consumer.
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
-        /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
-        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements with capability
+        /// to discontinue a streaming query</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
+        public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext)
         {
-            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
-            Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, ErrorConsumer);
         }
 
         /// <summary>
@@ -436,14 +399,14 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError)
         {
-            Arguments.CheckNotNull(query, nameof(query));
+            Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError);
         }
 
         /// <summary>
@@ -455,14 +418,51 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
+            Action<Exception> onError)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNotNull(onNext, nameof(onNext));
+            Arguments.CheckNotNull(onError, nameof(onError));
+
+            return QueryAsync(query, org, onNext, onError, EmptyAction);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream <see cref="FluxRecord"/>
+        /// to <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <returns>async task</returns>
+        public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, _options.Org, onNext, onError);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream <see cref="FluxRecord"/>
+        /// to <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <returns>async task</returns>
+        public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
+            Action<Exception> onError)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+            Arguments.CheckNotNull(onNext, nameof(onNext));
+            Arguments.CheckNotNull(onError, nameof(onError));
+
+            return QueryAsync(query, org, onNext, onError, EmptyAction);
         }
 
         /// <summary>
@@ -475,14 +475,14 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError);
         }
 
         /// <summary>
@@ -496,14 +496,14 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction);
         }
 
         /// <summary>
@@ -516,14 +516,14 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
             Action<Exception> onError)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError);
         }
 
         /// <summary>
@@ -537,14 +537,14 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            await QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction);
         }
 
         /// <summary>
@@ -556,7 +556,7 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -565,7 +565,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
         }
 
         /// <summary>
@@ -578,7 +578,7 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -589,7 +589,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerRecord(onNext);
 
-            await QueryAsync(CreateQuery(query, _defaultDialect), org, consumer, onError, onComplete);
+            return QueryAsync(CreateQuery(query, _defaultDialect), org, consumer, onError, onComplete);
         }
 
         /// <summary>
@@ -601,7 +601,7 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -610,7 +610,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
         }
 
         /// <summary>
@@ -623,7 +623,7 @@ namespace InfluxDB.Client
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <returns>async task</returns>
-        public async Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
+        public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -634,7 +634,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerRecord(onNext);
 
-            await QueryAsync(query, org, consumer, onError, onComplete);
+            return QueryAsync(query, org, consumer, onError, onComplete);
         }
 
         /// <summary>
@@ -648,7 +648,7 @@ namespace InfluxDB.Client
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -657,7 +657,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
         }
 
         /// <summary>
@@ -672,7 +672,7 @@ namespace InfluxDB.Client
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -684,7 +684,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(onNext);
 
-            await QueryAsync(CreateQuery(query, _defaultDialect), org, consumer, onError, onComplete);
+            return QueryAsync(CreateQuery(query, _defaultDialect), org, consumer, onError, onComplete);
         }
 
         /// <summary>
@@ -698,7 +698,7 @@ namespace InfluxDB.Client
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -707,7 +707,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
         }
 
         /// <summary>
@@ -722,7 +722,7 @@ namespace InfluxDB.Client
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public async Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
+        public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -733,7 +733,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(onNext);
 
-            await QueryAsync(query, org, consumer, onError, onComplete);
+            return QueryAsync(query, org, consumer, onError, onComplete);
         }
 
         /// <summary>
@@ -748,11 +748,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(string query)
+        public Task<string> QueryRawAsync(string query)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return await QueryRawAsync(query, _options.Org);
+            return QueryRawAsync(query, _options.Org);
         }
 
         /// <summary>
@@ -768,12 +768,12 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(string query, string org)
+        public Task<string> QueryRawAsync(string query, string org)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return await QueryRawAsync(query, org, _defaultDialect);
+            return QueryRawAsync(query, org, _defaultDialect);
         }
 
         /// <summary>
@@ -788,11 +788,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(Query query)
+        public Task<string> QueryRawAsync(Query query)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return await QueryRawAsync(query, _options.Org);
+            return QueryRawAsync(query, _options.Org);
         }
 
         /// <summary>
@@ -836,11 +836,11 @@ namespace InfluxDB.Client
         /// <param name="dialect">Dialect is an object defining the options to use when encoding the response.
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(string query, Dialect dialect)
+        public Task<string> QueryRawAsync(string query, Dialect dialect)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return await QueryRawAsync(query, _options.Org, dialect);
+            return QueryRawAsync(query, _options.Org, dialect);
         }
 
         /// <summary>
@@ -858,12 +858,12 @@ namespace InfluxDB.Client
         /// <param name="dialect">Dialect is an object defining the options to use when encoding the response.
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(string query, string org, Dialect dialect)
+        public Task<string> QueryRawAsync(string query, string org, Dialect dialect)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return await QueryRawAsync(CreateQuery(query, dialect), org);
+            return QueryRawAsync(CreateQuery(query, dialect), org);
         }
 
         /// <summary>
@@ -874,12 +874,12 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Action<ICancellable, string> onResponse
+        public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse
         )
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, onResponse);
+            return QueryRawAsync(query, _options.Org, onResponse);
         }
 
         /// <summary>
@@ -891,13 +891,13 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse
+        public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse
         )
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, onResponse, ErrorConsumer);
         }
 
         /// <summary>
@@ -908,11 +908,11 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse)
+        public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, onResponse);
+            return QueryRawAsync(query, _options.Org, onResponse);
         }
 
         /// <summary>
@@ -924,13 +924,13 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse
+        public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse
         )
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, onResponse, ErrorConsumer);
         }
 
         /// <summary>
@@ -943,11 +943,11 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Dialect dialect, Action<ICancellable, string> onResponse)
+        public Task QueryRawAsync(string query, Dialect dialect, Action<ICancellable, string> onResponse)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, dialect, onResponse);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse);
         }
 
         /// <summary>
@@ -961,14 +961,14 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Dialect dialect,
+        public Task QueryRawAsync(string query, string org, Dialect dialect,
             Action<ICancellable, string> onResponse
         )
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, dialect, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, dialect, onResponse, ErrorConsumer);
         }
 
         /// <summary>
@@ -980,12 +980,12 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, null, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, null, onResponse, onError);
         }
 
         /// <summary>
@@ -998,13 +998,13 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, null, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, null, onResponse, onError, EmptyAction);
         }
 
         /// <summary>
@@ -1016,12 +1016,12 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, onResponse, onError);
         }
         
         /// <summary>
@@ -1034,13 +1034,13 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, onResponse, onError, EmptyAction);
         }
 
         /// <summary>
@@ -1054,13 +1054,13 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Dialect dialect,
+        public Task QueryRawAsync(string query, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, dialect, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError);
         }
         
         /// <summary>
@@ -1075,14 +1075,14 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Dialect dialect,
+        public Task QueryRawAsync(string query, string org, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, dialect, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, dialect, onResponse, onError, EmptyAction);
         }
 
         /// <summary>
@@ -1095,13 +1095,13 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            await QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
         }
         
         /// <summary>
@@ -1115,14 +1115,14 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await QueryRawAsync(query, org, null, onResponse, onError, onComplete);
+            return QueryRawAsync(query, org, null, onResponse, onError, onComplete);
         }
 
         /// <summary>
@@ -1135,14 +1135,13 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-
-            await QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
         }
 
         /// <summary>
@@ -1156,7 +1155,7 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
+        public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
         {
@@ -1165,7 +1164,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(query, org);
 
-            await QueryRaw(requestMessage, onResponse, onError, onComplete);
+            return QueryRaw(requestMessage, onResponse, onError, onComplete);
         }
 
         /// <summary>
@@ -1180,7 +1179,7 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, Dialect dialect,
+        public Task QueryRawAsync(string query, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
@@ -1190,7 +1189,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryRawAsync(query, _options.Org, dialect, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError, onComplete);
         }
 
         /// <summary>
@@ -1206,7 +1205,7 @@ namespace InfluxDB.Client
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
         /// <returns></returns>
-        public async Task QueryRawAsync(string query, string org, Dialect dialect,
+        public Task QueryRawAsync(string query, string org, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
             Action onComplete)
@@ -1217,7 +1216,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            await QueryRawAsync(CreateQuery(query, dialect), org, onResponse, onError, onComplete);
+            return QueryRawAsync(CreateQuery(query, dialect), org, onResponse, onError, onComplete);
         }
 
         protected override void BeforeIntercept(RestRequest request)
@@ -1230,7 +1229,7 @@ namespace InfluxDB.Client
             return _service.Configuration.ApiClient.AfterIntercept(statusCode, headers, body);
         }
 
-        private async Task QueryAsync(Query query, string org, FluxCsvParser.IFluxResponseConsumer consumer,
+        private Task QueryAsync(Query query, string org, FluxCsvParser.IFluxResponseConsumer consumer,
             Action<Exception> onError,
             Action onComplete)
 
@@ -1243,7 +1242,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(query, org);
 
-            await Query(requestMessage, consumer, onError, onComplete);
+            return Query(requestMessage, consumer, onError, onComplete);
         }
 
         private RestRequest CreateRequest(Query query, string org)

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -122,7 +122,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxCsvParser.FluxResponseConsumerTable();
 
-            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction);
+            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return consumer.Tables;
         }
@@ -183,7 +183,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), _options.Org);
 
-            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken))
+            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken).ConfigureAwait(false))
                 yield return record;
         }
 
@@ -203,7 +203,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(CreateQuery(query), org);
 
-            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken))
+            await foreach (var record in QueryEnumerable<T>(requestMessage, cancellationToken).ConfigureAwait(false))
                 yield return record;
         }
 
@@ -250,7 +250,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>((cancellable, poco) => { measurements.Add(poco); });
 
-            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction);
+            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return measurements;
         }
@@ -817,7 +817,7 @@ namespace InfluxDB.Client
 
             void Consumer(ICancellable cancellable, string row) => rows.Add(row);
 
-            await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction);
+            await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
 
             return string.Join("\n", rows);
         }

--- a/Client/ScraperTargetsApi.cs
+++ b/Client/ScraperTargetsApi.cs
@@ -115,8 +115,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var scraperTarget = await FindScraperTargetByIdAsync(scraperTargetId);
-            return await CloneScraperTargetAsync(clonedName, scraperTarget);
+            var scraperTarget = await FindScraperTargetByIdAsync(scraperTargetId).ConfigureAwait(false);
+            return await CloneScraperTargetAsync(clonedName, scraperTarget).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -134,11 +134,11 @@ namespace InfluxDB.Client
             var cloned = new ScraperTargetRequest(clonedName, scraperTargetResponse.Type, scraperTargetResponse.Url,
                 scraperTargetResponse.OrgID, scraperTargetResponse.BucketID);
 
-            var created = await CreateScraperTargetAsync(cloned);
-            var labels = await GetLabelsAsync(scraperTargetResponse);
+            var created = await CreateScraperTargetAsync(cloned).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(scraperTargetResponse).ConfigureAwait(false);
             foreach (var label in labels)
             {
-                await AddLabelAsync(label, created);
+                await AddLabelAsync(label, created).ConfigureAwait(false);
             }
 
             return created;
@@ -162,7 +162,7 @@ namespace InfluxDB.Client
         /// <returns>A list of ScraperTargets</returns>
         public async Task<List<ScraperTargetResponse>> FindScraperTargetsAsync()
         {
-            var response = await _service.GetScrapersAsync();
+            var response = await _service.GetScrapersAsync().ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -187,7 +187,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetScrapersAsync(null, orgId);
+            var response = await _service.GetScrapersAsync(null, orgId).ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -212,7 +212,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDMembersAsync(scraperTargetId);
+            var response = await _service.GetScrapersIDMembersAsync(scraperTargetId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -294,7 +294,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDOwnersAsync(scraperTargetId);
+            var response = await _service.GetScrapersIDOwnersAsync(scraperTargetId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -377,7 +377,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDLabelsAsync(scraperTargetId);
+            var response = await _service.GetScrapersIDLabelsAsync(scraperTargetId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -408,7 +408,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostScrapersIDLabelsAsync(scraperTargetId, mapping);
+            var response = await _service.PostScrapersIDLabelsAsync(scraperTargetId, mapping).ConfigureAwait(false);
             return response.Label;
         }
 

--- a/Client/SourcesApi.cs
+++ b/Client/SourcesApi.cs
@@ -25,11 +25,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="source">source to create</param>
         /// <returns>created Source</returns>
-        public async Task<Source> CreateSourceAsync(Source source)
+        public Task<Source> CreateSourceAsync(Source source)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return await _service.PostSourcesAsync(source);
+            return _service.PostSourcesAsync(source);
         }
 
         /// <summary>
@@ -37,11 +37,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="source">source update to apply</param>
         /// <returns>updated source</returns>
-        public async Task<Source> UpdateSourceAsync(Source source)
+        public Task<Source> UpdateSourceAsync(Source source)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return await _service.PatchSourcesIDAsync(source.Id, source);
+            return _service.PatchSourcesIDAsync(source.Id, source);
         }
 
         /// <summary>
@@ -49,11 +49,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="sourceId">ID of source to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteSourceAsync(string sourceId)
+        public Task DeleteSourceAsync(string sourceId)
         {
             Arguments.CheckNotNull(sourceId, nameof(sourceId));
 
-            await _service.DeleteSourcesIDAsync(sourceId);
+            return _service.DeleteSourcesIDAsync(sourceId);
         }
 
         /// <summary>
@@ -61,11 +61,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="source">source to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteSourceAsync(Source source)
+        public Task DeleteSourceAsync(Source source)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            await DeleteSourceAsync(source.Id);
+            return DeleteSourceAsync(source.Id);
         }
 
         /// <summary>
@@ -79,7 +79,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return await FindSourceByIdAsync(sourceId).ContinueWith(t => CloneSourceAsync(clonedName, t.Result)).Unwrap();
+            var source = await FindSourceByIdAsync(sourceId);
+            return await CloneSourceAsync(clonedName, source);
         }
 
         /// <summary>
@@ -88,7 +89,7 @@ namespace InfluxDB.Client
         /// <param name="clonedName">name of cloned source</param>
         /// <param name="source">source to clone</param>
         /// <returns>cloned source</returns>
-        public async Task<Source> CloneSourceAsync(string clonedName, Source source)
+        public Task<Source> CloneSourceAsync(string clonedName, Source source)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(source, nameof(source));
@@ -110,7 +111,7 @@ namespace InfluxDB.Client
                 DefaultRP = source.DefaultRP
             };
 
-            return await CreateSourceAsync(cloned);
+            return CreateSourceAsync(cloned);
         }
 
         /// <summary>
@@ -118,11 +119,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="sourceId">ID of source to get</param>
         /// <returns>source details</returns>
-        public async Task<Source> FindSourceByIdAsync(string sourceId)
+        public Task<Source> FindSourceByIdAsync(string sourceId)
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return await _service.GetSourcesIDAsync(sourceId);
+            return _service.GetSourcesIDAsync(sourceId);
         }
 
         /// <summary>
@@ -131,7 +132,8 @@ namespace InfluxDB.Client
         /// <returns>A list of sources</returns>
         public async Task<List<Source>> FindSourcesAsync()
         {
-            return (await _service.GetSourcesAsync())._Sources;
+            var response = await _service.GetSourcesAsync();
+            return response._Sources;
         }
 
         /// <summary>
@@ -139,11 +141,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="source">filter buckets to a specific source</param>
         /// <returns>The buckets for source. If source does not exist than return null.</returns>
-        public async Task<List<Bucket>> FindBucketsBySourceAsync(Source source)
+        public Task<List<Bucket>> FindBucketsBySourceAsync(Source source)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return await FindBucketsBySourceIdAsync(source.Id);
+            return FindBucketsBySourceIdAsync(source.Id);
         }
 
         /// <summary>
@@ -155,7 +157,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return (await _service.GetSourcesIDBucketsAsync(sourceId))._Buckets;
+            var response = await _service.GetSourcesIDBucketsAsync(sourceId);
+            return response._Buckets;
         }
 
         /// <summary>
@@ -163,11 +166,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="source">source to check health</param>
         /// <returns>health of source</returns>
-        public async Task<HealthCheck> HealthAsync(Source source)
+        public Task<HealthCheck> HealthAsync(Source source)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return await HealthAsync(source.Id);
+            return HealthAsync(source.Id);
 
         }
 
@@ -176,11 +179,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="sourceId">source to check health</param>
         /// <returns>health of source</returns>
-        public async Task<HealthCheck> HealthAsync(string sourceId)
+        public Task<HealthCheck> HealthAsync(string sourceId)
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return await InfluxDBClient.GetHealthAsync(_service.GetSourcesIDHealthAsync(sourceId));
+            return InfluxDBClient.GetHealthAsync(_service.GetSourcesIDHealthAsync(sourceId));
         }
     }
 }

--- a/Client/SourcesApi.cs
+++ b/Client/SourcesApi.cs
@@ -79,8 +79,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            var source = await FindSourceByIdAsync(sourceId);
-            return await CloneSourceAsync(clonedName, source);
+            var source = await FindSourceByIdAsync(sourceId).ConfigureAwait(false);
+            return await CloneSourceAsync(clonedName, source).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace InfluxDB.Client
         /// <returns>A list of sources</returns>
         public async Task<List<Source>> FindSourcesAsync()
         {
-            var response = await _service.GetSourcesAsync();
+            var response = await _service.GetSourcesAsync().ConfigureAwait(false);
             return response._Sources;
         }
 
@@ -157,7 +157,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            var response = await _service.GetSourcesIDBucketsAsync(sourceId);
+            var response = await _service.GetSourcesIDBucketsAsync(sourceId).ConfigureAwait(false);
             return response._Buckets;
         }
 

--- a/Client/TasksApi.cs
+++ b/Client/TasksApi.cs
@@ -41,7 +41,7 @@ namespace InfluxDB.Client
         /// <param name="task"></param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async Task<TaskType> CreateTaskAsync(TaskType task)
+        public Task<TaskType> CreateTaskAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
@@ -49,7 +49,7 @@ namespace InfluxDB.Client
             var taskCreateRequest = new TaskCreateRequest(orgID: task.OrgID, org: task.Org, status: status,
                 flux: task.Flux, description: task.Description);
 
-            return await CreateTaskAsync(taskCreateRequest);
+            return CreateTaskAsync(taskCreateRequest);
         }
 
         /// <summary>
@@ -57,11 +57,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskCreateRequest">task to create (required)</param>
         /// <returns>Task created</returns>
-        public async Task<TaskType> CreateTaskAsync(TaskCreateRequest taskCreateRequest)
+        public Task<TaskType> CreateTaskAsync(TaskCreateRequest taskCreateRequest)
         {
             Arguments.CheckNotNull(taskCreateRequest, nameof(taskCreateRequest));
 
-            return await _service.PostTasksAsync(taskCreateRequest);
+            return _service.PostTasksAsync(taskCreateRequest);
         }
 
         /// <summary>
@@ -75,7 +75,7 @@ namespace InfluxDB.Client
         /// <param name="organization">the organization that owns this Task</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
+        public Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
             Organization organization)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
@@ -83,7 +83,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(cron, nameof(cron));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await CreateTaskCronAsync(name, flux, cron, organization.Id);
+            return CreateTaskCronAsync(name, flux, cron, organization.Id);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace InfluxDB.Client
         /// <param name="orgId">the organization ID that owns this Task</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
+        public Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
             string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
@@ -107,7 +107,7 @@ namespace InfluxDB.Client
 
             var task = CreateTaskAsync(name, flux, null, cron, orgId);
 
-            return await CreateTaskAsync(task);
+            return CreateTaskAsync(task);
         }
 
         /// <summary>
@@ -121,7 +121,7 @@ namespace InfluxDB.Client
         /// <param name="organization">the organization that owns this Task</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
+        public Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
             Organization organization)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
@@ -129,7 +129,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(every, nameof(every));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await CreateTaskEveryAsync(name, flux, every, organization.Id);
+            return CreateTaskEveryAsync(name, flux, every, organization.Id);
         }
 
         /// <summary>
@@ -143,7 +143,7 @@ namespace InfluxDB.Client
         /// <param name="orgId">the organization ID that owns this Task</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
-        public async Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
+        public Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
             string orgId)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
@@ -153,7 +153,7 @@ namespace InfluxDB.Client
 
             var task = CreateTaskAsync(name, flux, every, null, orgId);
 
-            return await CreateTaskAsync(task);
+            return CreateTaskAsync(task);
         }
 
         /// <summary>
@@ -161,7 +161,7 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">task update to apply</param>
         /// <returns>task updated</returns>
-        public async Task<TaskType> UpdateTaskAsync(TaskType task)
+        public Task<TaskType> UpdateTaskAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
@@ -169,7 +169,7 @@ namespace InfluxDB.Client
 
             var request = new TaskUpdateRequest(status, task.Flux, task.Name, task.Every, task.Cron);
 
-            return await UpdateTaskAsync(task.Id, request);
+            return UpdateTaskAsync(task.Id, request);
         }
 
 
@@ -179,12 +179,12 @@ namespace InfluxDB.Client
         /// <param name="taskId">ID of task to get</param>
         /// <param name="request">task update to apply</param>
         /// <returns>task updated</returns>
-        public async Task<TaskType> UpdateTaskAsync(string taskId, TaskUpdateRequest request)
+        public Task<TaskType> UpdateTaskAsync(string taskId, TaskUpdateRequest request)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNotNull(request, nameof(request));
 
-            return await _service.PatchTasksIDAsync(taskId, request);
+            return _service.PatchTasksIDAsync(taskId, request);
         }
 
         /// <summary>
@@ -192,11 +192,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task to delete</param>
         /// <returns>task deleted</returns>
-        public async Task DeleteTaskAsync(string taskId)
+        public Task DeleteTaskAsync(string taskId)
         {
             Arguments.CheckNotNull(taskId, nameof(taskId));
 
-            await _service.DeleteTasksIDAsync(taskId);
+            return _service.DeleteTasksIDAsync(taskId);
         }
 
         /// <summary>
@@ -204,11 +204,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">task to delete</param>
         /// <returns>task deleted</returns>
-        public async Task DeleteTaskAsync(TaskType task)
+        public Task DeleteTaskAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            await DeleteTaskAsync(task.Id);
+            return DeleteTaskAsync(task.Id);
         }
 
         /// <summary>
@@ -220,7 +220,9 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return await FindTaskByIdAsync(taskId).ContinueWith(t => CloneTaskAsync(t.Result)).Unwrap();
+            var task = await FindTaskByIdAsync(taskId);
+            
+            return await CloneTaskAsync(task);
         }
 
         /// <summary>
@@ -236,20 +238,14 @@ namespace InfluxDB.Client
             var cloned = new TaskCreateRequest(orgID: task.OrgID, org: task.Org, status: status,
                 flux: task.Flux, description: task.Description);
 
-            return await CreateTaskAsync(cloned).ContinueWith(created =>
+            var created = await CreateTaskAsync(cloned);
+            var labels = await GetLabelsAsync(task);
+            foreach (var label in labels)
             {
-                //
-                // Add labels
-                //
-                return GetLabelsAsync(task)
-                    .ContinueWith(labels => { return labels.Result.Select(label => AddLabelAsync(label, created.Result)); })
-                    .ContinueWith(async tasks =>
-                    {
-                        await Task.WhenAll(tasks.Result);
-                        return created.Result;
-                    })
-                    .Unwrap();
-            }).Unwrap();
+                await AddLabelAsync(label, created);
+            }
+
+            return created;
         }
 
         /// <summary>
@@ -257,11 +253,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task to get</param>
         /// <returns>task details</returns>
-        public async Task<TaskType> FindTaskByIdAsync(string taskId)
+        public Task<TaskType> FindTaskByIdAsync(string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return await _service.GetTasksIDAsync(taskId);
+            return _service.GetTasksIDAsync(taskId);
         }
 
         /// <summary>
@@ -269,11 +265,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="user">filter tasks to a specific user</param>
         /// <returns>A list of tasks</returns>
-        public async Task<List<TaskType>> FindTasksByUserAsync(User user)
+        public Task<List<TaskType>> FindTasksByUserAsync(User user)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return await FindTasksByUserIdAsync(user.Id);
+            return FindTasksByUserIdAsync(user.Id);
         }
 
         /// <summary>
@@ -281,9 +277,9 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="userId">filter tasks to a specific user ID</param>
         /// <returns>A list of tasks</returns>
-        public async Task<List<TaskType>> FindTasksByUserIdAsync(string userId)
+        public Task<List<TaskType>> FindTasksByUserIdAsync(string userId)
         {
-            return await FindTasksAsync(null, userId);
+            return FindTasksAsync(null, userId);
         }
 
         /// <summary>
@@ -291,11 +287,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">filter tasks to a specific organization</param>
         /// <returns>A list of tasks</returns>
-        public async Task<List<TaskType>> FindTasksByOrganizationAsync(Organization organization)
+        public Task<List<TaskType>> FindTasksByOrganizationAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await FindTasksByOrganizationIdAsync(organization.Id);
+            return FindTasksByOrganizationIdAsync(organization.Id);
         }
 
 
@@ -304,9 +300,9 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">filter tasks to a specific organization ID</param>
         /// <returns>A list of tasks</returns>
-        public async Task<List<TaskType>> FindTasksByOrganizationIdAsync(string orgId)
+        public Task<List<TaskType>> FindTasksByOrganizationIdAsync(string orgId)
         {
-            return await FindTasksAsync(null, null, orgId);
+            return FindTasksAsync(null, null, orgId);
         }
 
         /// <summary>
@@ -318,7 +314,8 @@ namespace InfluxDB.Client
         /// <returns>A list of tasks</returns>
         public async Task<List<TaskType>> FindTasksAsync(string afterId = null, string userId = null, string orgId = null)
         {
-            return (await _service.GetTasksAsync(null, null, afterId, userId, orgId))._Tasks;
+            var response = await _service.GetTasksAsync(null, null, afterId, userId, orgId);
+            return response._Tasks;
         }
 
         /// <summary>
@@ -326,11 +323,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">task of the members</param>
         /// <returns>the List all members of a task</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(TaskType task)
+        public Task<List<ResourceMember>> GetMembersAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, "task");
 
-            return await GetMembersAsync(task.Id);
+            return GetMembersAsync(task.Id);
         }
 
         /// <summary>
@@ -342,7 +339,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return (await _service.GetTasksIDMembersAsync(taskId)).Users;
+            var response = await _service.GetTasksIDMembersAsync(taskId);
+            return response.Users;
         }
 
         /// <summary>
@@ -351,12 +349,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of a task</param>
         /// <param name="task">the task of a member</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(User member, TaskType task)
+        public Task<ResourceMember> AddMemberAsync(User member, TaskType task)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(member, "member");
 
-            return await AddMemberAsync(member.Id, task.Id);
+            return AddMemberAsync(member.Id, task.Id);
         }
 
         /// <summary>
@@ -365,12 +363,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="taskId">the ID of a task</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceMember> AddMemberAsync(string memberId, string taskId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return await _service.PostTasksIDMembersAsync(taskId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostTasksIDMembersAsync(taskId, new AddResourceMemberRequestBody(memberId));
         }
 
         /// <summary>
@@ -379,12 +377,12 @@ namespace InfluxDB.Client
         /// <param name="member">the member of a task</param>
         /// <param name="task">the task of a member</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(User member, TaskType task)
+        public Task DeleteMemberAsync(User member, TaskType task)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(member, "member");
 
-            await DeleteMemberAsync(member.Id, task.Id);
+            return DeleteMemberAsync(member.Id, task.Id);
         }
 
         /// <summary>
@@ -393,12 +391,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">the ID of a member</param>
         /// <param name="taskId">the ID of a task</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(string memberId, string taskId)
+        public Task DeleteMemberAsync(string memberId, string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            await _service.DeleteTasksIDMembersIDAsync(memberId, taskId);
+            return _service.DeleteTasksIDMembersIDAsync(memberId, taskId);
         }
 
         /// <summary>
@@ -406,11 +404,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">task of the owners</param>
         /// <returns>the List all owners of a task</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(TaskType task)
+        public Task<List<ResourceOwner>> GetOwnersAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, "Task is required");
 
-            return await GetOwnersAsync(task.Id);
+            return GetOwnersAsync(task.Id);
         }
 
         /// <summary>
@@ -422,7 +420,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return (await _service.GetTasksIDOwnersAsync(taskId)).Users;
+            var response = await _service.GetTasksIDOwnersAsync(taskId);
+            return response.Users;
         }
 
         /// <summary>
@@ -431,12 +430,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of a task</param>
         /// <param name="task">the task of a owner</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(User owner, TaskType task)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, TaskType task)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(owner, "owner");
 
-            return await AddOwnerAsync(owner.Id, task.Id);
+            return AddOwnerAsync(owner.Id, task.Id);
         }
 
         /// <summary>
@@ -445,12 +444,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="taskId">the ID of a task</param>
         /// <returns>created mapping</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(string ownerId, string taskId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return await _service.PostTasksIDOwnersAsync(taskId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostTasksIDOwnersAsync(taskId, new AddResourceMemberRequestBody(ownerId));
         }
 
         /// <summary>
@@ -459,12 +458,12 @@ namespace InfluxDB.Client
         /// <param name="owner">the owner of a task</param>
         /// <param name="task">the task of a owner</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(User owner, TaskType task)
+        public Task DeleteOwnerAsync(User owner, TaskType task)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(owner, "owner");
 
-            await DeleteOwnerAsync(owner.Id, task.Id);
+            return DeleteOwnerAsync(owner.Id, task.Id);
         }
 
         /// <summary>
@@ -473,12 +472,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="taskId">the ID of a task</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(string ownerId, string taskId)
+        public Task DeleteOwnerAsync(string ownerId, string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            await _service.DeleteTasksIDOwnersIDAsync(ownerId, taskId);
+            return _service.DeleteTasksIDOwnersIDAsync(ownerId, taskId);
         }
 
         /// <summary>
@@ -486,11 +485,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">task to get logs for</param>
         /// <returns>the list of all logs for a task</returns>
-        public async Task<List<LogEvent>> GetLogsAsync(TaskType task)
+        public Task<List<LogEvent>> GetLogsAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return await GetLogsAsync(task.Id);
+            return GetLogsAsync(task.Id);
         }
 
         /// <summary>
@@ -502,7 +501,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return (await _service.GetTasksIDLogsAsync(taskId)).Events;
+            var response = await _service.GetTasksIDLogsAsync(taskId);
+            return response.Events;
         }
 
         /// <summary>
@@ -510,11 +510,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task"> task to get runs for</param>
         /// <returns>the list of run records for a task</returns>
-        public async Task<List<Run>> GetRunsAsync(TaskType task)
+        public Task<List<Run>> GetRunsAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return await GetRunsAsync(task, null, null, null);
+            return GetRunsAsync(task, null, null, null);
         }
 
 
@@ -526,12 +526,12 @@ namespace InfluxDB.Client
         /// <param name="beforeTime">filter runs to those scheduled before this time</param>
         /// <param name="limit">the number of runs to return. Default value: 20.</param>
         /// <returns>the list of run records for a task</returns>
-        public async Task<List<Run>> GetRunsAsync(TaskType task, DateTime? afterTime,
+        public Task<List<Run>> GetRunsAsync(TaskType task, DateTime? afterTime,
             DateTime? beforeTime, int? limit)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return await GetRunsAsync(task.Id, task.Org, afterTime, beforeTime, limit);
+            return GetRunsAsync(task.Id, task.Org, afterTime, beforeTime, limit);
         }
 
         /// <summary>
@@ -540,12 +540,12 @@ namespace InfluxDB.Client
         /// <param name="taskId">ID of task to get runs for</param>
         /// <param name="orgId">ID of organization</param>
         /// <returns>the list of run records for a task</returns>
-        public async Task<List<Run>> GetRunsAsync(string taskId, string orgId)
+        public Task<List<Run>> GetRunsAsync(string taskId, string orgId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return await GetRunsAsync(taskId, orgId, null, null, null);
+            return GetRunsAsync(taskId, orgId, null, null, null);
         }
 
         /// <summary>
@@ -563,7 +563,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return (await _service.GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime))._Runs;
+            var response = await _service.GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime);
+            return response._Runs;
         }
 
         /// <summary>
@@ -572,12 +573,12 @@ namespace InfluxDB.Client
         /// <param name="taskId">ID of task to get runs for</param>
         /// <param name="runId">ID of run</param>
         /// <returns>a single run record for a task</returns>
-        public async Task<Run> GetRunAsync(string taskId, string runId)
+        public Task<Run> GetRunAsync(string taskId, string runId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return await _service.GetTasksIDRunsIDAsync(taskId, runId);
+            return _service.GetTasksIDRunsIDAsync(taskId, runId);
         }
 
         /// <summary>
@@ -585,11 +586,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="run">the run to retry</param>
         /// <returns>the executed run</returns>
-        public async Task<Run> RetryRunAsync(Run run)
+        public Task<Run> RetryRunAsync(Run run)
         {
             Arguments.CheckNotNull(run, nameof(run));
 
-            return await RetryRunAsync(run.TaskID, run.Id);
+            return RetryRunAsync(run.TaskID, run.Id);
         }
 
         /// <summary>
@@ -598,12 +599,12 @@ namespace InfluxDB.Client
         /// <param name="taskId">ID of task with the run to retry</param>
         /// <param name="runId">ID of run to retry</param>
         /// <returns>the executed run</returns>
-        public async Task<Run> RetryRunAsync(string taskId, string runId)
+        public Task<Run> RetryRunAsync(string taskId, string runId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return await _service.PostTasksIDRunsIDRetryAsync(taskId, runId);
+            return _service.PostTasksIDRunsIDRetryAsync(taskId, runId);
         }
 
         /// <summary>
@@ -611,11 +612,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="run">the run to cancel</param>
         /// <returns></returns>
-        public async Task CancelRunAsync(Run run)
+        public Task CancelRunAsync(Run run)
         {
             Arguments.CheckNotNull(run, nameof(run));
 
-            await CancelRunAsync(run.TaskID, run.Id);
+            return CancelRunAsync(run.TaskID, run.Id);
         }
 
         /// <summary>
@@ -624,12 +625,12 @@ namespace InfluxDB.Client
         /// <param name="taskId">ID of task with the run to cancel</param>
         /// <param name="runId">ID of run to cancel</param>
         /// <returns></returns>
-        public async Task CancelRunAsync(string taskId, string runId)
+        public Task CancelRunAsync(string taskId, string runId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            await _service.DeleteTasksIDRunsIDAsync(taskId, runId);
+            return _service.DeleteTasksIDRunsIDAsync(taskId, runId);
         }
 
         /// <summary>
@@ -637,9 +638,9 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="run">the run to gets logs for it</param>
         /// <returns>the list of all logs for a run</returns>
-        public async Task<List<LogEvent>> GetRunLogsAsync(Run run)
+        public Task<List<LogEvent>> GetRunLogsAsync(Run run)
         {
-            return await GetRunLogsAsync(run.TaskID, run.Id);
+            return GetRunLogsAsync(run.TaskID, run.Id);
         }
 
         /// <summary>
@@ -653,7 +654,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return (await _service.GetTasksIDRunsIDLogsAsync(taskId, runId)).Events;
+            var response = await _service.GetTasksIDRunsIDLogsAsync(taskId, runId);
+            return response.Events;
         }
 
         /// <summary>
@@ -661,11 +663,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="task">a Task of the labels</param>
         /// <returns>the List all labels of a Task</returns>
-        public async Task<List<Label>> GetLabelsAsync(TaskType task)
+        public Task<List<Label>> GetLabelsAsync(TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return await GetLabelsAsync(task.Id);
+            return GetLabelsAsync(task.Id);
         }
 
         /// <summary>
@@ -677,7 +679,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return (await _service.GetTasksIDLabelsAsync(taskId)).Labels;
+            var response = await _service.GetTasksIDLabelsAsync(taskId);
+            return response.Labels;
         }
 
         /// <summary>
@@ -686,12 +689,12 @@ namespace InfluxDB.Client
         /// <param name="label">the label of a Task</param>
         /// <param name="task">a Task of a label</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(Label label, TaskType task)
+        public Task<Label> AddLabelAsync(Label label, TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return await AddLabelAsync(label.Id, task.Id);
+            return AddLabelAsync(label.Id, task.Id);
         }
 
         /// <summary>
@@ -707,7 +710,8 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            return (await _service.PostTasksIDLabelsAsync(taskId, mapping)).Label;
+            var response = await _service.PostTasksIDLabelsAsync(taskId, mapping);
+            return response.Label;
         }
 
         /// <summary>
@@ -716,12 +720,12 @@ namespace InfluxDB.Client
         /// <param name="label">the label of a Task</param>
         /// <param name="task">a Task of a owner</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(Label label, TaskType task)
+        public Task DeleteLabelAsync(Label label, TaskType task)
         {
             Arguments.CheckNotNull(task, nameof(task));
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id, task.Id);
+            return DeleteLabelAsync(label.Id, task.Id);
         }
 
         /// <summary>
@@ -730,12 +734,12 @@ namespace InfluxDB.Client
         /// <param name="labelId">the ID of a label</param>
         /// <param name="taskId">the ID of a Task</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(string labelId, string taskId)
+        public Task DeleteLabelAsync(string labelId, string taskId)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteTasksIDLabelsIDAsync(taskId, labelId);
+            return _service.DeleteTasksIDLabelsIDAsync(taskId, labelId);
         }
 
         private TaskType CreateTaskAsync(string name, string flux, string every, string cron, string orgId)

--- a/Client/TasksApi.cs
+++ b/Client/TasksApi.cs
@@ -220,9 +220,9 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var task = await FindTaskByIdAsync(taskId);
+            var task = await FindTaskByIdAsync(taskId).ConfigureAwait(false);
             
-            return await CloneTaskAsync(task);
+            return await CloneTaskAsync(task).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -238,11 +238,11 @@ namespace InfluxDB.Client
             var cloned = new TaskCreateRequest(orgID: task.OrgID, org: task.Org, status: status,
                 flux: task.Flux, description: task.Description);
 
-            var created = await CreateTaskAsync(cloned);
-            var labels = await GetLabelsAsync(task);
+            var created = await CreateTaskAsync(cloned).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(task).ConfigureAwait(false);
             foreach (var label in labels)
             {
-                await AddLabelAsync(label, created);
+                await AddLabelAsync(label, created).ConfigureAwait(false);
             }
 
             return created;
@@ -314,7 +314,7 @@ namespace InfluxDB.Client
         /// <returns>A list of tasks</returns>
         public async Task<List<TaskType>> FindTasksAsync(string afterId = null, string userId = null, string orgId = null)
         {
-            var response = await _service.GetTasksAsync(null, null, afterId, userId, orgId);
+            var response = await _service.GetTasksAsync(null, null, afterId, userId, orgId).ConfigureAwait(false);
             return response._Tasks;
         }
 
@@ -339,7 +339,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDMembersAsync(taskId);
+            var response = await _service.GetTasksIDMembersAsync(taskId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -420,7 +420,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDOwnersAsync(taskId);
+            var response = await _service.GetTasksIDOwnersAsync(taskId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -501,7 +501,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDLogsAsync(taskId);
+            var response = await _service.GetTasksIDLogsAsync(taskId).ConfigureAwait(false);
             return response.Events;
         }
 
@@ -563,7 +563,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime);
+            var response = await _service.GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime).ConfigureAwait(false);
             return response._Runs;
         }
 
@@ -654,7 +654,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            var response = await _service.GetTasksIDRunsIDLogsAsync(taskId, runId);
+            var response = await _service.GetTasksIDRunsIDLogsAsync(taskId, runId).ConfigureAwait(false);
             return response.Events;
         }
 
@@ -679,7 +679,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDLabelsAsync(taskId);
+            var response = await _service.GetTasksIDLabelsAsync(taskId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -710,7 +710,7 @@ namespace InfluxDB.Client
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostTasksIDLabelsAsync(taskId, mapping);
+            var response = await _service.PostTasksIDLabelsAsync(taskId, mapping).ConfigureAwait(false);
             return response.Label;
         }
 

--- a/Client/TelegrafsApi.cs
+++ b/Client/TelegrafsApi.cs
@@ -30,10 +30,10 @@ namespace InfluxDB.Client
         /// <param name="org">The organization that owns this config</param>
         /// <param name="plugins">The telegraf plugins config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
             List<TelegrafPlugin> plugins)
         {
-            return await CreateTelegrafAsync(name, description, org, CreateAgentConfiguration(), plugins);
+            return CreateTelegrafAsync(name, description, org, CreateAgentConfiguration(), plugins);
         }
 
         /// <summary>
@@ -45,10 +45,10 @@ namespace InfluxDB.Client
         /// <param name="agentConfiguration">The telegraf agent config</param>
         /// <param name="plugins">The telegraf plugins config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
             Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins)
         {
-            return await CreateTelegrafAsync(name, description, org.Id, agentConfiguration, plugins);
+            return CreateTelegrafAsync(name, description, org.Id, agentConfiguration, plugins);
         }
 
         /// <summary>
@@ -59,10 +59,10 @@ namespace InfluxDB.Client
         /// <param name="orgId">The organization that owns this config</param>
         /// <param name="plugins">The telegraf plugins config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
             List<TelegrafPlugin> plugins)
         {
-            return await CreateTelegrafAsync(name, description, orgId, CreateAgentConfiguration(), plugins);
+            return CreateTelegrafAsync(name, description, orgId, CreateAgentConfiguration(), plugins);
         }
 
         /// <summary>
@@ -74,7 +74,7 @@ namespace InfluxDB.Client
         /// <param name="agentConfiguration">The telegraf agent config</param>
         /// <param name="plugins">The telegraf plugins config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
             Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins)
         {
             var config = new StringBuilder();
@@ -115,7 +115,7 @@ namespace InfluxDB.Client
             var request = new TelegrafRequest(name: name, description: description, orgID: orgId,
                 config: config.ToString());
 
-            return await CreateTelegrafAsync(request);
+            return CreateTelegrafAsync(request);
         }
 
         /// <summary>
@@ -127,10 +127,10 @@ namespace InfluxDB.Client
         /// <param name="config">ConfigTOML contains the raw toml config</param>
         /// <param name="metadata">Metadata for the config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
             string config, TelegrafRequestMetadata metadata)
         {
-            return await CreateTelegrafAsync(name, description, org.Id, config, metadata);
+            return CreateTelegrafAsync(name, description, org.Id, config, metadata);
         }
 
         /// <summary>
@@ -142,12 +142,12 @@ namespace InfluxDB.Client
         /// <param name="config">ConfigTOML contains the raw toml config</param>
         /// <param name="metadata">Metadata for the config</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+        public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
             string config, TelegrafRequestMetadata metadata)
         {
             var request = new TelegrafRequest(name, description, metadata, config, orgId);
 
-            return await CreateTelegrafAsync(request);
+            return CreateTelegrafAsync(request);
         }
 
         /// <summary>
@@ -155,11 +155,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegrafRequest">Telegraf Configuration to create</param>
         /// <returns>Telegraf config created</returns>
-        public async Task<Telegraf> CreateTelegrafAsync(TelegrafRequest telegrafRequest)
+        public Task<Telegraf> CreateTelegrafAsync(TelegrafRequest telegrafRequest)
         {
             Arguments.CheckNotNull(telegrafRequest, nameof(telegrafRequest));
 
-            return await _service.PostTelegrafsAsync(telegrafRequest);
+            return _service.PostTelegrafsAsync(telegrafRequest);
         }
 
         /// <summary>
@@ -197,14 +197,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">telegraf config update to apply</param>
         /// <returns>An updated telegraf</returns>
-        public async Task<Telegraf> UpdateTelegrafAsync(Telegraf telegraf)
+        public Task<Telegraf> UpdateTelegrafAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
             var request = new TelegrafRequest(telegraf.Name, telegraf.Description, telegraf.Metadata, telegraf.Config,
                 telegraf.OrgID);
 
-            return await UpdateTelegrafAsync(telegraf.Id, request);
+            return UpdateTelegrafAsync(telegraf.Id, request);
         }
 
         /// <summary>
@@ -213,12 +213,12 @@ namespace InfluxDB.Client
         /// <param name="telegrafId">ID of telegraf config</param>
         /// <param name="telegrafRequest">telegraf config update to apply</param>
         /// <returns>An updated telegraf</returns>
-        public async Task<Telegraf> UpdateTelegrafAsync(string telegrafId, TelegrafRequest telegrafRequest)
+        public Task<Telegraf> UpdateTelegrafAsync(string telegrafId, TelegrafRequest telegrafRequest)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNotNull(telegrafRequest, nameof(telegrafRequest));
 
-            return await _service.PutTelegrafsIDAsync(telegrafId, telegrafRequest);
+            return _service.PutTelegrafsIDAsync(telegrafId, telegrafRequest);
         }
 
         /// <summary>
@@ -226,11 +226,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">telegraf config to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteTelegrafAsync(Telegraf telegraf)
+        public Task DeleteTelegrafAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            await DeleteTelegrafAsync(telegraf.Id);
+            return DeleteTelegrafAsync(telegraf.Id);
         }
 
         /// <summary>
@@ -238,11 +238,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config to delete</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteTelegrafAsync(string telegrafId)
+        public Task DeleteTelegrafAsync(string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            await _service.DeleteTelegrafsIDAsync(telegrafId);
+            return _service.DeleteTelegrafsIDAsync(telegrafId);
         }
 
         /// <summary>
@@ -256,8 +256,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return await FindTelegrafByIdAsync(telegrafId).ContinueWith(t => CloneTelegrafAsync(clonedName, t.Result))
-                .Unwrap();
+            var telegraf = await FindTelegrafByIdAsync(telegrafId);
+            
+            return await CloneTelegrafAsync(clonedName, telegraf);
         }
 
         /// <summary>
@@ -274,23 +275,14 @@ namespace InfluxDB.Client
             var cloned = new TelegrafRequest(clonedName, telegraf.Description, telegraf.Metadata, telegraf.Config,
                 telegraf.OrgID);
 
-            return await CreateTelegrafAsync(cloned).ContinueWith(created =>
+            var created = await CreateTelegrafAsync(cloned);
+            var labels = await GetLabelsAsync(telegraf);
+            foreach (var label in labels)
             {
-                //
-                // Add labels
-                //
-                return GetLabelsAsync(telegraf)
-                    .ContinueWith(labels =>
-                    {
-                        return labels.Result.Select(label => AddLabelAsync(label, created.Result));
-                    })
-                    .ContinueWith(async tasks =>
-                    {
-                        await Task.WhenAll(tasks.Result);
-                        return created.Result;
-                    })
-                    .Unwrap();
-            }).Unwrap();
+                await AddLabelAsync(label, created);
+            }
+
+            return created;
         }
 
         /// <summary>
@@ -302,17 +294,18 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return await _service.GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json")
-                .ContinueWith(t => (Telegraf) _service.Configuration.ApiClient.Deserialize(t.Result, typeof(Telegraf)));
+            var response = await _service.GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json");
+            
+            return (Telegraf) _service.Configuration.ApiClient.Deserialize(response, typeof(Telegraf));
         }
 
         /// <summary>
         /// Returns a list of telegraf configs.
         /// </summary>
         /// <returns>A list of telegraf configs</returns>
-        public async Task<List<Telegraf>> FindTelegrafsAsync()
+        public Task<List<Telegraf>> FindTelegrafsAsync()
         {
-            return await FindTelegrafsByOrgIdAsync(null);
+            return FindTelegrafsByOrgIdAsync(null);
         }
 
         /// <summary>
@@ -320,11 +313,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">specifies the organization of the telegraf configs</param>
         /// <returns>A list of telegraf configs</returns>
-        public async Task<List<Telegraf>> FindTelegrafsByOrgAsync(Organization organization)
+        public Task<List<Telegraf>> FindTelegrafsByOrgAsync(Organization organization)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return await FindTelegrafsByOrgIdAsync(organization.Id);
+            return FindTelegrafsByOrgIdAsync(organization.Id);
         }
 
         /// <summary>
@@ -334,7 +327,8 @@ namespace InfluxDB.Client
         /// <returns>A list of telegraf configs</returns>
         public async Task<List<Telegraf>> FindTelegrafsByOrgIdAsync(string orgId)
         {
-            return (await _service.GetTelegrafsAsync(orgId)).Configurations;
+            var response = await _service.GetTelegrafsAsync(orgId);
+            return response.Configurations;
         }
 
         /// <summary>
@@ -342,11 +336,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">telegraf config to get</param>
         /// <returns>telegraf config details in TOML format</returns>
-        public async Task<string> GetTOMLAsync(Telegraf telegraf)
+        public Task<string> GetTOMLAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return await GetTOMLAsync(telegraf.Id);
+            return GetTOMLAsync(telegraf.Id);
         }
 
         /// <summary>
@@ -354,11 +348,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config to get</param>
         /// <returns>telegraf config details in TOML format</returns>
-        public async Task<string> GetTOMLAsync(string telegrafId)
+        public Task<string> GetTOMLAsync(string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return await _service.GetTelegrafsIDstringAsync(telegrafId, null, "application/toml");
+            return _service.GetTelegrafsIDstringAsync(telegrafId, null, "application/toml");
         }
 
         /// <summary>
@@ -366,11 +360,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>a list of telegraf config members</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(Telegraf telegraf)
+        public Task<List<ResourceMember>> GetMembersAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return await GetMembersAsync(telegraf.Id);
+            return GetMembersAsync(telegraf.Id);
         }
 
         /// <summary>
@@ -382,7 +376,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return (await _service.GetTelegrafsIDMembersAsync(telegrafId)).Users;
+            var response = await _service.GetTelegrafsIDMembersAsync(telegrafId);
+            return response.Users;
         }
 
         /// <summary>
@@ -391,12 +386,12 @@ namespace InfluxDB.Client
         /// <param name="member">user to add as member</param>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>member added to telegraf</returns>
-        public async Task<ResourceMember> AddMemberAsync(User member, Telegraf telegraf)
+        public Task<ResourceMember> AddMemberAsync(User member, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return await AddMemberAsync(member.Id, telegraf.Id);
+            return AddMemberAsync(member.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -405,12 +400,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">user ID to add as member</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
         /// <returns>member added to telegraf</returns>
-        public async Task<ResourceMember> AddMemberAsync(string memberId, string telegrafId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return await _service.PostTelegrafsIDMembersAsync(telegrafId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostTelegrafsIDMembersAsync(telegrafId, new AddResourceMemberRequestBody(memberId));
         }
 
         /// <summary>
@@ -419,12 +414,12 @@ namespace InfluxDB.Client
         /// <param name="member">member to remove</param>
         /// <param name="telegraf">the telegraf</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(User member, Telegraf telegraf)
+        public Task DeleteMemberAsync(User member, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(member, nameof(member));
 
-            await DeleteMemberAsync(member.Id, telegraf.Id);
+            return DeleteMemberAsync(member.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -433,12 +428,12 @@ namespace InfluxDB.Client
         /// <param name="memberId">ID of member to remove</param>
         /// <param name="telegrafId">ID of the telegraf</param>
         /// <returns>member removed</returns>
-        public async Task DeleteMemberAsync(string memberId, string telegrafId)
+        public Task DeleteMemberAsync(string memberId, string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            await _service.DeleteTelegrafsIDMembersIDAsync(memberId, telegrafId);
+            return _service.DeleteTelegrafsIDMembersIDAsync(memberId, telegrafId);
         }
 
         /// <summary>
@@ -446,11 +441,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>a list of telegraf config owners</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(Telegraf telegraf)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return await GetOwnersAsync(telegraf.Id);
+            return GetOwnersAsync(telegraf.Id);
         }
 
         /// <summary>
@@ -462,7 +457,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return (await _service.GetTelegrafsIDOwnersAsync(telegrafId)).Users;
+            var response = await _service.GetTelegrafsIDOwnersAsync(telegrafId);
+            return response.Users;
         }
 
         /// <summary>
@@ -471,12 +467,12 @@ namespace InfluxDB.Client
         /// <param name="owner">user to add as owner</param>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>telegraf config owner added</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(User owner, Telegraf telegraf)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return await AddOwnerAsync(owner.Id, telegraf.Id);
+            return AddOwnerAsync(owner.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -485,12 +481,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">ID of user to add as owner</param>
         /// <param name="telegrafId"> ID of the telegraf config</param>
         /// <returns>telegraf config owner added</returns>
-        public async Task<ResourceOwner> AddOwnerAsync(string ownerId, string telegrafId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return await _service.PostTelegrafsIDOwnersAsync(telegrafId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostTelegrafsIDOwnersAsync(telegrafId, new AddResourceMemberRequestBody(ownerId));
         }
 
         /// <summary>
@@ -499,12 +495,12 @@ namespace InfluxDB.Client
         /// <param name="owner">owner to remove</param>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(User owner, Telegraf telegraf)
+        public Task DeleteOwnerAsync(User owner, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            await DeleteOwnerAsync(owner.Id, telegraf.Id);
+            return DeleteOwnerAsync(owner.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -513,12 +509,12 @@ namespace InfluxDB.Client
         /// <param name="ownerId">ID of owner to remove</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
         /// <returns>owner removed</returns>
-        public async Task DeleteOwnerAsync(string ownerId, string telegrafId)
+        public Task DeleteOwnerAsync(string ownerId, string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            await _service.DeleteTelegrafsIDOwnersIDAsync(ownerId, telegrafId);
+            return _service.DeleteTelegrafsIDOwnersIDAsync(ownerId, telegrafId);
         }
 
         /// <summary>
@@ -526,11 +522,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>a list of all labels for a telegraf config</returns>
-        public async Task<List<Label>> GetLabelsAsync(Telegraf telegraf)
+        public Task<List<Label>> GetLabelsAsync(Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return await GetLabelsAsync(telegraf.Id);
+            return GetLabelsAsync(telegraf.Id);
         }
 
         /// <summary>
@@ -542,7 +538,8 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return (await _service.GetTelegrafsIDLabelsAsync(telegrafId)).Labels;
+            var response = await _service.GetTelegrafsIDLabelsAsync(telegrafId);
+            return response.Labels;
         }
 
         /// <summary>
@@ -551,12 +548,12 @@ namespace InfluxDB.Client
         /// <param name="label">label to add</param>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(Label label, Telegraf telegraf)
+        public Task<Label> AddLabelAsync(Label label, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return await AddLabelAsync(label.Id, telegraf.Id);
+            return AddLabelAsync(label.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -570,7 +567,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return (await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId))).Label;
+            var response = await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId));
+            return response.Label;
         }
 
         /// <summary>
@@ -579,12 +577,12 @@ namespace InfluxDB.Client
         /// <param name="label">label to delete</param>
         /// <param name="telegraf">the telegraf config</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(Label label, Telegraf telegraf)
+        public Task DeleteLabelAsync(Label label, Telegraf telegraf)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(label, nameof(label));
 
-            await DeleteLabelAsync(label.Id, telegraf.Id);
+            return DeleteLabelAsync(label.Id, telegraf.Id);
         }
 
         /// <summary>
@@ -593,12 +591,12 @@ namespace InfluxDB.Client
         /// <param name="labelId">ID of label to delete</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
         /// <returns>delete has been accepted</returns>
-        public async Task DeleteLabelAsync(string labelId, string telegrafId)
+        public Task DeleteLabelAsync(string labelId, string telegrafId)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            await _service.DeleteTelegrafsIDLabelsIDAsync(telegrafId, labelId);
+            return _service.DeleteTelegrafsIDLabelsIDAsync(telegrafId, labelId);
         }
 
         private void AppendConfiguration(StringBuilder config, string key, object value)

--- a/Client/TelegrafsApi.cs
+++ b/Client/TelegrafsApi.cs
@@ -256,9 +256,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var telegraf = await FindTelegrafByIdAsync(telegrafId);
+            var telegraf = await FindTelegrafByIdAsync(telegrafId).ConfigureAwait(false);
             
-            return await CloneTelegrafAsync(clonedName, telegraf);
+            return await CloneTelegrafAsync(clonedName, telegraf).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -275,11 +275,11 @@ namespace InfluxDB.Client
             var cloned = new TelegrafRequest(clonedName, telegraf.Description, telegraf.Metadata, telegraf.Config,
                 telegraf.OrgID);
 
-            var created = await CreateTelegrafAsync(cloned);
-            var labels = await GetLabelsAsync(telegraf);
+            var created = await CreateTelegrafAsync(cloned).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(telegraf).ConfigureAwait(false);
             foreach (var label in labels)
             {
-                await AddLabelAsync(label, created);
+                await AddLabelAsync(label, created).ConfigureAwait(false);
             }
 
             return created;
@@ -294,7 +294,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json");
+            var response = await _service.GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json").ConfigureAwait(false);
             
             return (Telegraf) _service.Configuration.ApiClient.Deserialize(response, typeof(Telegraf));
         }
@@ -327,7 +327,7 @@ namespace InfluxDB.Client
         /// <returns>A list of telegraf configs</returns>
         public async Task<List<Telegraf>> FindTelegrafsByOrgIdAsync(string orgId)
         {
-            var response = await _service.GetTelegrafsAsync(orgId);
+            var response = await _service.GetTelegrafsAsync(orgId).ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -376,7 +376,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDMembersAsync(telegrafId);
+            var response = await _service.GetTelegrafsIDMembersAsync(telegrafId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -457,7 +457,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDOwnersAsync(telegrafId);
+            var response = await _service.GetTelegrafsIDOwnersAsync(telegrafId).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -538,7 +538,7 @@ namespace InfluxDB.Client
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDLabelsAsync(telegrafId);
+            var response = await _service.GetTelegrafsIDLabelsAsync(telegrafId).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -567,7 +567,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            var response = await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId));
+            var response = await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId)).ConfigureAwait(false);
             return response.Label;
         }
 

--- a/Client/UsersApi.cs
+++ b/Client/UsersApi.cs
@@ -123,9 +123,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(userId, nameof(userId));
 
-            var user = await FindUserByIdAsync(userId);
+            var user = await FindUserByIdAsync(userId).ConfigureAwait(false);
             
-            return await CloneUserAsync(clonedName, user);
+            return await CloneUserAsync(clonedName, user).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            var me = await MeAsync();
+            var me = await MeAsync().ConfigureAwait(false);
             if (me == null)
             {
                 Trace.WriteLine("User is not authenticated.");
@@ -173,7 +173,7 @@ namespace InfluxDB.Client
             
             var header = InfluxDBClient.AuthorizationHeader(me.Name, oldPassword);
 
-            await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header);
+            await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace InfluxDB.Client
         /// <returns>List all users</returns>
         public async Task<List<User>> FindUsersAsync()
         {
-            var response = await _service.GetUsersAsync();
+            var response = await _service.GetUsersAsync().ConfigureAwait(false);
             return response._Users;
         }
 

--- a/Client/UsersApi.cs
+++ b/Client/UsersApi.cs
@@ -23,13 +23,13 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name">name of the user</param>
         /// <returns>Created user</returns>
-        public async Task<User> CreateUserAsync(string name)
+        public Task<User> CreateUserAsync(string name)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
 
             var user = new User(name: name);
 
-            return await CreateUserAsync(user);
+            return CreateUserAsync(user);
         }
 
         /// <summary>
@@ -37,11 +37,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="user">name of the user</param>
         /// <returns>Created user</returns>
-        public async Task<User> CreateUserAsync(User user)
+        public Task<User> CreateUserAsync(User user)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return await _service.PostUsersAsync(user);
+            return _service.PostUsersAsync(user);
         }
 
         /// <summary>
@@ -49,11 +49,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="user">user update to apply</param>
         /// <returns>user updated</returns>
-        public async Task<User> UpdateUserAsync(User user)
+        public Task<User> UpdateUserAsync(User user)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return await _service.PatchUsersIDAsync(user.Id, user);
+            return _service.PatchUsersIDAsync(user.Id, user);
         }
 
         /// <summary>
@@ -63,13 +63,13 @@ namespace InfluxDB.Client
         /// <param name="oldPassword">old password</param>
         /// <param name="newPassword">new password</param>
         /// <returns>user updated</returns>
-        public async Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword)
+        public Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword)
         {
             Arguments.CheckNotNull(user, nameof(user));
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            await UpdateUserPasswordAsync(user.Id, user.Name, oldPassword, newPassword);
+            return UpdateUserPasswordAsync(user.Id, user.Name, oldPassword, newPassword);
         }
 
         /// <summary>
@@ -79,13 +79,13 @@ namespace InfluxDB.Client
         /// <param name="oldPassword">old password</param>
         /// <param name="newPassword">new password</param>
         /// <returns>user updated</returns>
-        public async Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword)
+        public Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            await FindUserByIdAsync(userId).ContinueWith(t => UpdateUserPasswordAsync(t.Result, oldPassword, newPassword));
+            return FindUserByIdAsync(userId).ContinueWith(t => UpdateUserPasswordAsync(t.Result, oldPassword, newPassword));
         }
 
         /// <summary>
@@ -93,11 +93,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="userId">ID of user to delete</param>
         /// <returns>async task</returns>
-        public async Task DeleteUserAsync(string userId)
+        public Task DeleteUserAsync(string userId)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
 
-            await _service.DeleteUsersIDAsync(userId);
+            return _service.DeleteUsersIDAsync(userId);
         }
 
         /// <summary>
@@ -105,11 +105,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="user">user to delete</param>
         /// <returns>async task</returns>
-        public async Task DeleteUserAsync(User user)
+        public Task DeleteUserAsync(User user)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            await DeleteUserAsync(user.Id);
+            return DeleteUserAsync(user.Id);
         }
 
         /// <summary>
@@ -123,7 +123,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(userId, nameof(userId));
 
-            return await FindUserByIdAsync(userId).ContinueWith(t => CloneUserAsync(clonedName, t.Result)).Unwrap();
+            var user = await FindUserByIdAsync(userId);
+            
+            return await CloneUserAsync(clonedName, user);
         }
 
         /// <summary>
@@ -132,23 +134,23 @@ namespace InfluxDB.Client
         /// <param name="clonedName">name of cloned user</param>
         /// <param name="user">user to clone</param>
         /// <returns>cloned user</returns>
-        public async Task<User> CloneUserAsync(string clonedName, User user)
+        public Task<User> CloneUserAsync(string clonedName, User user)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(user, nameof(user));
 
             var cloned = new User(name: clonedName);
 
-            return await CreateUserAsync(cloned);
+            return CreateUserAsync(cloned);
         }
 
         /// <summary>
         /// Returns currently authenticated user.
         /// </summary>
         /// <returns>currently authenticated user</returns>
-        public async Task<User> MeAsync()
+        public Task<User> MeAsync()
         {
-            return await _service.GetMeAsync();
+            return _service.GetMeAsync();
         }
 
         /// <summary>
@@ -162,19 +164,16 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            await MeAsync().ContinueWith(async t =>
+            var me = await MeAsync();
+            if (me == null)
             {
-                if (t.Result == null)
-                {
-                    Trace.WriteLine("User is not authenticated.");
+                Trace.WriteLine("User is not authenticated.");
+                return;
+            }
+            
+            var header = InfluxDBClient.AuthorizationHeader(me.Name, oldPassword);
 
-                    return;
-                }
-
-                var header = InfluxDBClient.AuthorizationHeader(t.Result.Name, oldPassword);
-
-                await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header);
-            }).Unwrap();
+            await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header);
         }
 
         /// <summary>
@@ -182,11 +181,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="userId">ID of user to get</param>
         /// <returns>User Details</returns>
-        public async Task<User> FindUserByIdAsync(string userId)
+        public Task<User> FindUserByIdAsync(string userId)
         {
             Arguments.CheckNonEmptyString(userId, nameof(userId));
 
-            return await _service.GetUsersIDAsync(userId);
+            return _service.GetUsersIDAsync(userId);
         }
 
         /// <summary>
@@ -195,10 +194,11 @@ namespace InfluxDB.Client
         /// <returns>List all users</returns>
         public async Task<List<User>> FindUsersAsync()
         {
-            return (await _service.GetUsersAsync())._Users;
+            var response = await _service.GetUsersAsync();
+            return response._Users;
         }
 
-        private async Task UpdateUserPasswordAsync(string userId, string userName, string oldPassword,
+        private Task UpdateUserPasswordAsync(string userId, string userName, string oldPassword,
             string newPassword)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
@@ -208,7 +208,7 @@ namespace InfluxDB.Client
 
             var header = InfluxDBClient.AuthorizationHeader(userName, oldPassword);
 
-            await _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null, header);
+            return _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null, header);
         }
     }
 }

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -37,11 +37,11 @@ namespace InfluxDB.Client
         ///     specifies the record in InfluxDB Line Protocol.
         ///     The <see cref="record" /> is considered as one batch unit.
         /// </param>
-        public async Task WriteRecordAsync(WritePrecision precision, string record)
+        public Task WriteRecordAsync(WritePrecision precision, string record)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteRecordAsync(_options.Bucket, _options.Org, precision, record);
+            return WriteRecordAsync(_options.Bucket, _options.Org, precision, record);
         }
 
         /// <summary>
@@ -54,13 +54,13 @@ namespace InfluxDB.Client
         ///     specifies the record in InfluxDB Line Protocol.
         ///     The <see cref="record" /> is considered as one batch unit.
         /// </param>
-        public async Task WriteRecordAsync(string bucket, string org, WritePrecision precision, string record)
+        public Task WriteRecordAsync(string bucket, string org, WritePrecision precision, string record)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteRecordsAsync(bucket, org, precision, new List<string> {record});
+            return WriteRecordsAsync(bucket, org, precision, new List<string> {record});
         }
 
         /// <summary>
@@ -68,11 +68,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
-        public async Task WriteRecordsAsync(WritePrecision precision, List<string> records)
+        public Task WriteRecordsAsync(WritePrecision precision, List<string> records)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteRecordsAsync(_options.Bucket, _options.Org, precision, records);
+            return WriteRecordsAsync(_options.Bucket, _options.Org, precision, records);
         }
 
         /// <summary>
@@ -82,7 +82,7 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes</param>
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
-        public async Task WriteRecordsAsync(string bucket, string org, WritePrecision precision, List<string> records)
+        public Task WriteRecordsAsync(string bucket, string org, WritePrecision precision, List<string> records)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -96,7 +96,7 @@ namespace InfluxDB.Client
                 list.Add(data);
             }
 
-            await WriteData(org, bucket, precision, list);
+            return WriteData(org, bucket, precision, list);
         }
 
         /// <summary>
@@ -104,11 +104,11 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
-        public async Task WriteRecordsAsync(WritePrecision precision, params string[] records)
+        public Task WriteRecordsAsync(WritePrecision precision, params string[] records)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteRecordsAsync(_options.Bucket, _options.Org, precision, records);
+            return WriteRecordsAsync(_options.Bucket, _options.Org, precision, records);
         }
 
         /// <summary>
@@ -118,23 +118,23 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes</param>
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
-        public async Task WriteRecordsAsync(string bucket, string org, WritePrecision precision,
+        public Task WriteRecordsAsync(string bucket, string org, WritePrecision precision,
                         params string[] records)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteRecordsAsync(bucket, org, precision, records.ToList());
+            return WriteRecordsAsync(bucket, org, precision, records.ToList());
         }
 
         /// <summary>
         /// Write a Data point into specified bucket.
         /// </summary>
         /// <param name="point">specifies the Data point to write into bucket</param>
-        public async Task WritePointAsync(PointData point)
+        public Task WritePointAsync(PointData point)
         {
-            await WritePointAsync(_options.Bucket, _options.Org, point);
+            return WritePointAsync(_options.Bucket, _options.Org, point);
         }
 
         /// <summary>
@@ -143,23 +143,23 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes</param>
         /// <param name="org">specifies the destination organization for writes</param>
         /// <param name="point">specifies the Data point to write into bucket</param>
-        public async Task WritePointAsync(string bucket, string org, PointData point)
+        public Task WritePointAsync(string bucket, string org, PointData point)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            if (point == null) return;
+            if (point == null) return Task.CompletedTask;
 
-            await WritePointsAsync(bucket, org, new List<PointData> {point});
+            return WritePointsAsync(bucket, org, new List<PointData> {point});
         }
 
         /// <summary>
         /// Write Data points into specified bucket.
         /// </summary>
         /// <param name="points">specifies the Data points to write into bucket</param>
-        public async Task WritePointsAsync(List<PointData> points)
+        public Task WritePointsAsync(List<PointData> points)
         {
-            await WritePointsAsync(_options.Bucket, _options.Org, points);
+            return WritePointsAsync(_options.Bucket, _options.Org, points);
         }
 
         /// <summary>
@@ -188,9 +188,9 @@ namespace InfluxDB.Client
         /// Write Data points into specified bucket.
         /// </summary>
         /// <param name="points">specifies the Data points to write into bucket</param>
-        public async Task WritePointsAsync(params PointData[] points)
+        public Task WritePointsAsync(params PointData[] points)
         {
-            await WritePointsAsync(_options.Bucket, _options.Org, points);
+            return WritePointsAsync(_options.Bucket, _options.Org, points);
         }
 
         /// <summary>
@@ -199,12 +199,12 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes</param>
         /// <param name="org">specifies the destination organization for writes</param>
         /// <param name="points">specifies the Data points to write into bucket</param>
-        public async Task WritePointsAsync(string bucket, string org, params PointData[] points)
+        public Task WritePointsAsync(string bucket, string org, params PointData[] points)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            await WritePointsAsync(bucket, org, points.ToList());
+            return WritePointsAsync(bucket, org, points.ToList());
         }
 
         /// <summary>
@@ -213,11 +213,11 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurement">specifies the Measurement to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementAsync<TM>(WritePrecision precision, TM measurement)
+        public Task WriteMeasurementAsync<TM>(WritePrecision precision, TM measurement)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteMeasurementAsync(_options.Bucket, _options.Org, precision, measurement);
+            return WriteMeasurementAsync(_options.Bucket, _options.Org, precision, measurement);
         }
 
         /// <summary>
@@ -228,15 +228,15 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurement">specifies the Measurement to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementAsync<TM>(string bucket, string org, WritePrecision precision, TM measurement)
+        public Task WriteMeasurementAsync<TM>(string bucket, string org, WritePrecision precision, TM measurement)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            if (measurement == null) return;
+            if (measurement == null) return Task.CompletedTask;
 
-            await WriteMeasurementsAsync(bucket, org, precision, new List<TM>() {measurement});
+            return WriteMeasurementsAsync(bucket, org, precision, new List<TM>() {measurement});
         }
 
         /// <summary>
@@ -245,11 +245,11 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurements">specifies Measurements to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementsAsync<TM>(WritePrecision precision, List<TM> measurements)
+        public Task WriteMeasurementsAsync<TM>(WritePrecision precision, List<TM> measurements)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteMeasurementsAsync(_options.Bucket, _options.Org, precision, measurements);
+            return WriteMeasurementsAsync(_options.Bucket, _options.Org, precision, measurements);
         }
 
         /// <summary>
@@ -260,8 +260,8 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurements">specifies Measurements to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementsAsync<TM>(string bucket, string org, WritePrecision precision,
-                        List<TM> measurements)
+        public Task WriteMeasurementsAsync<TM>(string bucket, string org, WritePrecision precision,
+            List<TM> measurements)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -277,7 +277,7 @@ namespace InfluxDB.Client
                 list.Add(data);
             }
 
-            await WriteData(org, bucket, precision, list);
+            return WriteData(org, bucket, precision, list);
         }
 
         /// <summary>
@@ -286,11 +286,11 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurements">specifies Measurements to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementsAsync<TM>(WritePrecision precision, params TM[] measurements)
+        public Task WriteMeasurementsAsync<TM>(WritePrecision precision, params TM[] measurements)
         {
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteMeasurementsAsync(_options.Bucket, _options.Org, precision, measurements);
+            return WriteMeasurementsAsync(_options.Bucket, _options.Org, precision, measurements);
         }
 
         /// <summary>
@@ -301,17 +301,17 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
         /// <param name="measurements">specifies Measurements to write into bucket</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public async Task WriteMeasurementsAsync<TM>(string bucket, string org, WritePrecision precision,
+        public Task WriteMeasurementsAsync<TM>(string bucket, string org, WritePrecision precision,
                         params TM[] measurements)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
             Arguments.CheckNotNull(precision, nameof(precision));
 
-            await WriteMeasurementsAsync(bucket, org, precision, measurements.ToList());
+            return WriteMeasurementsAsync(bucket, org, precision, measurements.ToList());
         }
 
-        private async Task WriteData(string org, string bucket, WritePrecision precision, IEnumerable<BatchWriteData> data)
+        private Task WriteData(string org, string bucket, WritePrecision precision, IEnumerable<BatchWriteData> data)
         {
             var sb = new StringBuilder("");
             
@@ -331,13 +331,13 @@ namespace InfluxDB.Client
             if (sb.Length == 0)
             {
                 Trace.WriteLine($"The writes: {data} doesn't contains any Line Protocol, skipping");
-                return;
+                return Task.CompletedTask;
             }
             
             // remove last \n
             sb.Remove(sb.Length - 1, 1);
 
-            await _service.PostWriteAsync(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null , 
+            return _service.PostWriteAsync(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null , 
                             "identity", "text/plain; charset=utf-8", null, "application/json", null, precision);
         }
     }

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -180,7 +180,7 @@ namespace InfluxDB.Client
                     .Select(it => new BatchWritePoint(options, _options, it))
                     .ToList();
 
-                await WriteData(org, bucket, grouped.Key, groupedPoints);
+                await WriteData(org, bucket, grouped.Key, groupedPoints).ConfigureAwait(false);
             }
         }
 


### PR DESCRIPTION
Closes #152

## Proposed Changes

1. Always use `Task.ConfigureAwait(false)` to avoid unnecessary context switching and potential dead-locks. 
    ```csharp
    await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction);
    ```
    =>
    ```csharp
    await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
    ```
1. Avoid useless `await`
    ```csharp
    public async Task<List<FluxTable>> QueryAsync(string query)
    {
       Arguments.CheckNonEmptyString(query, nameof(query));

       return await QueryAsync(query, _options.Org);
    }
    ```
    =>
    ```csharp
    public Task<List<FluxTable>> QueryAsync(string query)
    {
       Arguments.CheckNonEmptyString(query, nameof(query));

       return QueryAsync(query, _options.Org);
    }
    ```

## TD;LR
- https://devblogs.microsoft.com/dotnet/configureawait-faq/
- https://medium.com/bynder-tech/c-why-you-should-use-configureawait-false-in-your-library-code-d7837dce3d7f
- https://medium.com/@deep_blue_day/long-story-short-async-await-best-practices-in-net-1f39d7d84050

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
