### PR TITLE
feat: add type argument for query

### DIFF
--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -233,7 +233,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
 
             if (value is DateTimeOffset dateTimeOffset)
             {
-                return dateTimeOffset.DateTime;
+                return dateTimeOffset.UtcDateTime;
             }
 
             if (value is IConvertible)

--- a/Client.Legacy.Test/FluxResultMapperTest.cs
+++ b/Client.Legacy.Test/FluxResultMapperTest.cs
@@ -30,7 +30,20 @@ namespace Client.Legacy.Test
             Assert.AreEqual("aws.north.1", poco.Host);
             Assert.AreEqual("carolina", poco.DifferentName);
         }
-        
+
+        [Test]
+        public void MapByColumnNameType()
+        {
+            var fluxRecord = new FluxRecord(0);
+            fluxRecord.Values["host"] = "aws.north.1";
+            fluxRecord.Values["region"] = "carolina";
+
+            var poco = _parser.ToPoco(fluxRecord, typeof(PocoDifferentNameProperty)) as PocoDifferentNameProperty;
+
+            Assert.AreEqual("aws.north.1", poco.Host);
+            Assert.AreEqual("carolina", poco.DifferentName);
+        }
+
         private class PocoDifferentNameProperty
         {
             [Column("host")] 
@@ -61,6 +74,27 @@ namespace Client.Legacy.Test
             Assert.AreEqual(Instant.FromDateTimeUtc(now), poco.Timestamp);
         }
 
+        [Test]
+        public void MapTimestampWithInstantTimeType()
+        {
+            var now = DateTime.UtcNow;
+
+            var fluxRecord = new FluxRecord(0);
+            fluxRecord.Values["tag"] = "production";
+            fluxRecord.Values["min"] = 10.5;
+            fluxRecord.Values["max"] = 20.0;
+            fluxRecord.Values["avg"] = 18.0D;
+            fluxRecord.Values["_time"] = Instant.FromDateTimeUtc(now);
+
+            var poco = _parser.ToPoco(fluxRecord, typeof(PointWithoutTimestampNameInstant)) as PointWithoutTimestampNameInstant;
+
+            Assert.AreEqual("production", poco.Tag);
+            Assert.AreEqual(10.5, poco.Minimum);
+            Assert.AreEqual(20, poco.Maximum);
+            Assert.AreEqual(18, poco.Average);
+            Assert.AreEqual(Instant.FromDateTimeUtc(now), poco.Timestamp);
+        }
+
         private class PointWithoutTimestampNameInstant
         {
             [Column("tag", IsTag = true)] public string Tag { get; set; }
@@ -83,6 +117,27 @@ namespace Client.Legacy.Test
             fluxRecord.Values["_time"] = Instant.FromDateTimeUtc(now);
 
             var poco = _parser.ToPoco<PointWithoutTimestampName>(fluxRecord);
+
+            Assert.AreEqual("production", poco.Tag);
+            Assert.AreEqual(10.5, poco.Minimum);
+            Assert.AreEqual(20, poco.Maximum);
+            Assert.AreEqual(18, poco.Average);
+            Assert.AreEqual(now, poco.Timestamp);
+        }
+
+        [Test]
+        public void MapTimestampDifferentNameType()
+        {
+            var now = DateTime.UtcNow;
+
+            var fluxRecord = new FluxRecord(0);
+            fluxRecord.Values["tag"] = "production";
+            fluxRecord.Values["min"] = 10.5;
+            fluxRecord.Values["max"] = 20.0;
+            fluxRecord.Values["avg"] = (Double)18;
+            fluxRecord.Values["_time"] = Instant.FromDateTimeUtc(now);
+
+            var poco = _parser.ToPoco(fluxRecord, typeof(PointWithoutTimestampName)) as PointWithoutTimestampName;
 
             Assert.AreEqual("production", poco.Tag);
             Assert.AreEqual(10.5, poco.Minimum);


### PR DESCRIPTION
Closes #

## Proposed Changes

Some times I can not use generic type to poco query.
so I'd like to use type parameter to get poco.
I added type parameter to query funtions.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
