### PR TITLE
fix: DateTime is always serialized into UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.17.0 [unreleased]
 
+### Bug Fixes
+1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
+
 ## 1.16.0 [2021-03-05]
 
 ### Bug Fixes

--- a/Client.Test/ApiClientTest.cs
+++ b/Client.Test/ApiClientTest.cs
@@ -1,0 +1,42 @@
+using System;
+using InfluxDB.Client.Api.Client;
+using InfluxDB.Client.Core;
+using InfluxDB.Client.Core.Internal;
+using NUnit.Framework;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class ApiClientTest
+    {
+        private ApiClient _apiClient;
+
+        [SetUp]
+        public void SetUp()
+        {
+            var options = new InfluxDBClientOptions.Builder()
+                .Url("http://localhost:8086")
+                .AuthenticateToken("my-token".ToCharArray())
+                .Build();
+            
+            _apiClient = new ApiClient(options, new LoggingHandler(LogLevel.Body), new GzipHandler());
+        }
+        
+        [Test]
+        public void SerializeDateTime()
+        {
+            var serialized = _apiClient.Serialize( new DateTime(2022, 1, 1));
+            
+            Assert.AreEqual("\"2022-01-01T00:00:00Z\"", serialized);
+        }
+        
+        [Test]
+        public void SerializeUtcDateTime()
+        {
+            var dateTime = DateTime.Parse("2020-03-05T00:00:00Z");
+            var serialized = _apiClient.Serialize(dateTime);
+            
+            Assert.AreEqual("\"2020-03-05T00:00:00Z\"", serialized);
+        }
+    }
+}

--- a/Client.Test/ItDeleteApiTest.cs
+++ b/Client.Test/ItDeleteApiTest.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Configuration;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
-using InfluxDB.Client.Core;
 using InfluxDB.Client.Writes;
 using NUnit.Framework;
 
@@ -61,16 +60,6 @@ namespace InfluxDB.Client.Test
         private Organization _organization;
         private string _token;
 
-        [Measurement("h2o")]
-        private class H20Measurement
-        {
-            [Column("location", IsTag = true)] public string Location { get; set; }
-
-            [Column("level")] public double? Level { get; set; }
-
-            [Column(IsTimestamp = true)] public DateTime Time { get; set; }
-        }
-
         [Test]
         public async Task Delete()
         {
@@ -90,7 +79,7 @@ namespace InfluxDB.Client.Test
 
             _deleteApi = Client.GetDeleteApi();
 
-            await _deleteApi.Delete(DateTime.Now.AddHours(-1), DateTime.Now, "", _bucket, _organization);
+            await _deleteApi.Delete(new DateTime(2018, 1, 1), new DateTime(2022, 1, 1), "", _bucket, _organization);
 
             var tablesAfterDelete1 = await _queryApi.QueryAsync(query, _organization.Id);
 

--- a/Client.Test/ItDeleteApiTest.cs
+++ b/Client.Test/ItDeleteApiTest.cs
@@ -79,7 +79,7 @@ namespace InfluxDB.Client.Test
 
             _deleteApi = Client.GetDeleteApi();
 
-            await _deleteApi.Delete(new DateTime(2018, 1, 1), new DateTime(2022, 1, 1), "", _bucket, _organization);
+            await _deleteApi.Delete(DateTime.Now.AddHours(-1), DateTime.Now, "", _bucket, _organization);
 
             var tablesAfterDelete1 = await _queryApi.QueryAsync(query, _organization.Id);
 

--- a/Client/InfluxDB.Client.Api/Client/ApiClient.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiClient.cs
@@ -31,7 +31,8 @@ namespace InfluxDB.Client.Api.Client
     {
         private JsonSerializerSettings serializerSettings = new JsonSerializerSettings
         {
-            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor
+            ConstructorHandling = ConstructorHandling.AllowNonPublicDefaultConstructor,
+            DateTimeZoneHandling = DateTimeZoneHandling.Utc
         };
 
         /// <summary>
@@ -349,7 +350,7 @@ namespace InfluxDB.Client.Api.Client
         {
             try
             {
-                return obj != null ? JsonConvert.SerializeObject(obj) : null;
+                return obj != null ? JsonConvert.SerializeObject(obj, serializerSettings) : null;
             }
             catch (Exception e)
             {


### PR DESCRIPTION
Closes #167 

## Proposed Changes

The `DateTime` is serialized into UTC to satisfy `RFC3339Nano` format.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
