### PR TITLE
fix: correct structure for Flux AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
+1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fixed domain structure for Flux AST
 
 ## 1.16.0 [2021-03-05]
 

--- a/Client/InfluxDB.Client.Api/Domain/BadStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/BadStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// A placeholder for statements for which no correct statement nodes can be created
     /// </summary>
     [DataContract]
-    public partial class BadStatement :  IEquatable<BadStatement>
+    public partial class BadStatement : Statement,  IEquatable<BadStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BadStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="text">Raw source text.</param>
-        public BadStatement(string type = default(string), string text = default(string))
+        public BadStatement(string type = default(string), string text = default(string)) : base()
         {
             this.Type = type;
             this.Text = text;
@@ -62,6 +62,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class BadStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Text: ").Append(Text).Append("\n");
             sb.Append("}\n");
@@ -72,7 +73,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -97,12 +98,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Text == input.Text ||
                     (this.Text != null &&
@@ -118,7 +119,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Text != null)

--- a/Client/InfluxDB.Client.Api/Domain/BooleanLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/BooleanLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents boolean values
     /// </summary>
     [DataContract]
-    public partial class BooleanLiteral :  IEquatable<BooleanLiteral>
+    public partial class BooleanLiteral : Expression,  IEquatable<BooleanLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BooleanLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public BooleanLiteral(string type = default(string), bool? value = default(bool?))
+        public BooleanLiteral(string type = default(string), bool? value = default(bool?)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class BooleanLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/BuiltinStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/BuiltinStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Declares a builtin identifier and its type
     /// </summary>
     [DataContract]
-    public partial class BuiltinStatement :  IEquatable<BuiltinStatement>
+    public partial class BuiltinStatement : Statement,  IEquatable<BuiltinStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="BuiltinStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="id">id.</param>
-        public BuiltinStatement(string type = default(string), Identifier id = default(Identifier))
+        public BuiltinStatement(string type = default(string), Identifier id = default(Identifier)) : base()
         {
             this.Type = type;
             this.Id = id;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class BuiltinStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Id: ").Append(Id).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     
                     (this.Id != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Id != null)

--- a/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents an instant in time with nanosecond precision using the syntax of golang&#39;s RFC3339 Nanosecond variant
     /// </summary>
     [DataContract]
-    public partial class DateTimeLiteral :  IEquatable<DateTimeLiteral>
+    public partial class DateTimeLiteral : Expression,  IEquatable<DateTimeLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DateTimeLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public DateTimeLiteral(string type = default(string), string value = default(string))
+        public DateTimeLiteral(string type = default(string), DateTime? value = default(DateTime?)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -51,7 +51,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Gets or Sets Value
         /// </summary>
         [DataMember(Name="value", EmitDefaultValue=false)]
-        public string Value { get; set; }
+        public DateTime? Value { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class DateTimeLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/DurationLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/DurationLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents the elapsed time between two instants as an int64 nanosecond count with syntax of golang&#39;s time.Duration
     /// </summary>
     [DataContract]
-    public partial class DurationLiteral :  IEquatable<DurationLiteral>
+    public partial class DurationLiteral : Expression,  IEquatable<DurationLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="DurationLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="values">Duration values.</param>
-        public DurationLiteral(string type = default(string), List<Duration> values = default(List<Duration>))
+        public DurationLiteral(string type = default(string), List<Duration> values = default(List<Duration>)) : base()
         {
             this.Type = type;
             this.Values = values;
@@ -62,6 +62,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class DurationLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Values: ").Append(Values).Append("\n");
             sb.Append("}\n");
@@ -72,7 +73,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -97,12 +98,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Values == input.Values ||
                     this.Values != null &&
@@ -118,7 +119,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Values != null)

--- a/Client/InfluxDB.Client.Api/Domain/ExpressionStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/ExpressionStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// May consist of an expression that does not return a value and is executed solely for its side-effects
     /// </summary>
     [DataContract]
-    public partial class ExpressionStatement :  IEquatable<ExpressionStatement>
+    public partial class ExpressionStatement : Statement,  IEquatable<ExpressionStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ExpressionStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="expression">expression.</param>
-        public ExpressionStatement(string type = default(string), Expression expression = default(Expression))
+        public ExpressionStatement(string type = default(string), Expression expression = default(Expression)) : base()
         {
             this.Type = type;
             this.Expression = expression;
@@ -62,6 +62,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class ExpressionStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Expression: ").Append(Expression).Append("\n");
             sb.Append("}\n");
@@ -72,7 +73,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -97,12 +98,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     
                     (this.Expression != null &&
@@ -118,7 +119,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Expression != null)

--- a/Client/InfluxDB.Client.Api/Domain/FloatLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/FloatLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents floating point numbers according to the double representations defined by the IEEE-754-1985
     /// </summary>
     [DataContract]
-    public partial class FloatLiteral :  IEquatable<FloatLiteral>
+    public partial class FloatLiteral : Expression,  IEquatable<FloatLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="FloatLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public FloatLiteral(string type = default(string), decimal? value = default(decimal?))
+        public FloatLiteral(string type = default(string), decimal? value = default(decimal?)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class FloatLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/IntegerLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/IntegerLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents integer numbers
     /// </summary>
     [DataContract]
-    public partial class IntegerLiteral :  IEquatable<IntegerLiteral>
+    public partial class IntegerLiteral : Expression,  IEquatable<IntegerLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="IntegerLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public IntegerLiteral(string type = default(string), string value = default(string))
+        public IntegerLiteral(string type = default(string), string value = default(string)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class IntegerLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/OptionStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/OptionStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// A single variable declaration
     /// </summary>
     [DataContract]
-    public partial class OptionStatement :  IEquatable<OptionStatement>
+    public partial class OptionStatement : Statement,  IEquatable<OptionStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OptionStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="assignment">assignment.</param>
-        public OptionStatement(string type = default(string), Object assignment = default(Object))
+        public OptionStatement(string type = default(string), Object assignment = default(Object)) : base()
         {
             this.Type = type;
             this.Assignment = assignment;
@@ -62,6 +62,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class OptionStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Assignment: ").Append(Assignment).Append("\n");
             sb.Append("}\n");
@@ -72,7 +73,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -97,12 +98,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Assignment == input.Assignment ||
                     (this.Assignment != null &&
@@ -118,7 +119,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Assignment != null)

--- a/Client/InfluxDB.Client.Api/Domain/PipeLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PipeLiteral.cs
@@ -27,13 +27,13 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents a specialized literal value, indicating the left hand value of a pipe expression
     /// </summary>
     [DataContract]
-    public partial class PipeLiteral :  IEquatable<PipeLiteral>
+    public partial class PipeLiteral : Expression,  IEquatable<PipeLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="PipeLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
-        public PipeLiteral(string type = default(string))
+        public PipeLiteral(string type = default(string)) : base()
         {
             this.Type = type;
         }
@@ -53,6 +53,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class PipeLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -62,7 +63,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -87,7 +88,7 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
@@ -103,7 +104,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 return hashCode;

--- a/Client/InfluxDB.Client.Api/Domain/RegexpLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/RegexpLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Expressions begin and end with &#x60;/&#x60; and are regular expressions with syntax accepted by RE2
     /// </summary>
     [DataContract]
-    public partial class RegexpLiteral :  IEquatable<RegexpLiteral>
+    public partial class RegexpLiteral : Expression,  IEquatable<RegexpLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="RegexpLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public RegexpLiteral(string type = default(string), string value = default(string))
+        public RegexpLiteral(string type = default(string), string value = default(string)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class RegexpLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/ReturnStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/ReturnStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Defines an expression to return
     /// </summary>
     [DataContract]
-    public partial class ReturnStatement :  IEquatable<ReturnStatement>
+    public partial class ReturnStatement : Statement,  IEquatable<ReturnStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ReturnStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="argument">argument.</param>
-        public ReturnStatement(string type = default(string), Expression argument = default(Expression))
+        public ReturnStatement(string type = default(string), Expression argument = default(Expression)) : base()
         {
             this.Type = type;
             this.Argument = argument;
@@ -62,6 +62,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class ReturnStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Argument: ").Append(Argument).Append("\n");
             sb.Append("}\n");
@@ -72,7 +73,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -97,12 +98,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     
                     (this.Argument != null &&
@@ -118,7 +119,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Argument != null)

--- a/Client/InfluxDB.Client.Api/Domain/StringLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/StringLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Expressions begin and end with double quote marks
     /// </summary>
     [DataContract]
-    public partial class StringLiteral :  IEquatable<StringLiteral>
+    public partial class StringLiteral : Expression,  IEquatable<StringLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="StringLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public StringLiteral(string type = default(string), string value = default(string))
+        public StringLiteral(string type = default(string), string value = default(string)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class StringLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)

--- a/Client/InfluxDB.Client.Api/Domain/TestStatement.cs
+++ b/Client/InfluxDB.Client.Api/Domain/TestStatement.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Declares a Flux test case
     /// </summary>
     [DataContract]
-    public partial class TestStatement :  IEquatable<TestStatement>
+    public partial class TestStatement : Statement,  IEquatable<TestStatement>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="TestStatement" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="assignment">assignment.</param>
-        public TestStatement(string type = default(string), VariableAssignment assignment = default(VariableAssignment))
+        public TestStatement(string type = default(string), VariableAssignment assignment = default(VariableAssignment)) : base()
         {
             this.Type = type;
             this.Assignment = assignment;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class TestStatement {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Assignment: ").Append(Assignment).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     
                     (this.Assignment != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Assignment != null)

--- a/Client/InfluxDB.Client.Api/Domain/UnsignedIntegerLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/UnsignedIntegerLiteral.cs
@@ -27,14 +27,14 @@ namespace InfluxDB.Client.Api.Domain
     /// Represents integer numbers
     /// </summary>
     [DataContract]
-    public partial class UnsignedIntegerLiteral :  IEquatable<UnsignedIntegerLiteral>
+    public partial class UnsignedIntegerLiteral : Expression,  IEquatable<UnsignedIntegerLiteral>
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="UnsignedIntegerLiteral" /> class.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
         /// <param name="value">value.</param>
-        public UnsignedIntegerLiteral(string type = default(string), string value = default(string))
+        public UnsignedIntegerLiteral(string type = default(string), string value = default(string)) : base()
         {
             this.Type = type;
             this.Value = value;
@@ -61,6 +61,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             var sb = new StringBuilder();
             sb.Append("class UnsignedIntegerLiteral {\n");
+            sb.Append("  ").Append(base.ToString().Replace("\n", "\n  ")).Append("\n");
             sb.Append("  Type: ").Append(Type).Append("\n");
             sb.Append("  Value: ").Append(Value).Append("\n");
             sb.Append("}\n");
@@ -71,7 +72,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Returns the JSON string presentation of the object
         /// </summary>
         /// <returns>JSON string presentation of the object</returns>
-        public virtual string ToJson()
+        public override string ToJson()
         {
             return JsonConvert.SerializeObject(this, Formatting.Indented);
         }
@@ -96,12 +97,12 @@ namespace InfluxDB.Client.Api.Domain
             if (input == null)
                 return false;
 
-            return 
+            return base.Equals(input) && 
                 (
                     this.Type == input.Type ||
                     (this.Type != null &&
                     this.Type.Equals(input.Type))
-                ) && 
+                ) && base.Equals(input) && 
                 (
                     this.Value == input.Value ||
                     (this.Value != null &&
@@ -117,7 +118,7 @@ namespace InfluxDB.Client.Api.Domain
         {
             unchecked // Overflow is fine, just wrap
             {
-                int hashCode = 41;
+                int hashCode = base.GetHashCode();
                 if (this.Type != null)
                     hashCode = hashCode * 59 + this.Type.GetHashCode();
                 if (this.Value != null)


### PR DESCRIPTION
Related to #146

## Proposed Changes

Fixed domain structure for Flux AST.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
