### PR TITLE
feat: add QuerySyncApi, add possibility to use custom mapper from/to DomainObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.17.0 [unreleased]
 
+### Features
+1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Added `QueryApiSync` for synchronous querying
+1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Added `IDomainObjectMapper` for custom mapping DomainObject from/to InfluxDB
+
 ### Bug Fixes
 1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
 1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fixed domain structure for Flux AST

--- a/Client.Core.Test/AbstractMockServerTest.cs
+++ b/Client.Core.Test/AbstractMockServerTest.cs
@@ -7,7 +7,7 @@ namespace InfluxDB.Client.Core.Test
 {
     public class AbstractMockServerTest : AbstractTest
     {
-        protected FluentMockServer MockServer;
+        protected WireMockServer MockServer;
         protected string MockServerUrl;
 
         [SetUp]
@@ -18,7 +18,7 @@ namespace InfluxDB.Client.Core.Test
                 return;
             }
             
-            MockServer = FluentMockServer.Start(new FluentMockServerSettings
+            MockServer = WireMockServer.Start(new WireMockServerSettings
             {
                 UseSSL = false
             });

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -16,7 +16,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-        <PackageReference Include="WireMock.Net" Version="1.0.7" />
+        <PackageReference Include="WireMock.Net" Version="1.4.6" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Client.Core/Flux/Internal/AttributesCache.cs
+++ b/Client.Core/Flux/Internal/AttributesCache.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reflection;
+
+namespace InfluxDB.Client.Core.Flux.Internal
+{
+    /// <summary>
+    /// The cache for DomainObject attributes. The attributes are used for mapping from/to DomainObject.
+    /// </summary>
+    public class AttributesCache
+    {
+        // Reflection results are cached for poco type property and attribute lookups as an optimization since
+        // calls are invoked continuously for a given type and will not change over library lifetime
+        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache =
+            new ConcurrentDictionary<Type, PropertyInfo[]>();
+
+        private static readonly ConcurrentDictionary<PropertyInfo, Column> AttributeCache =
+            new ConcurrentDictionary<PropertyInfo, Column>();
+
+        /// <summary>
+        /// Get properties for specified Type.
+        /// </summary>
+        /// <param name="type">type of DomainObject</param>
+        /// <returns>properties for DomainObject</returns>
+        public PropertyInfo[] GetProperties(Type type)
+        {
+            Arguments.CheckNotNull(type, nameof(type));
+
+            return PropertyCache.GetOrAdd(type, _ => type.GetProperties());
+        }
+        
+        /// <summary>
+        /// Get Mapping attribute for specified propery.
+        /// </summary>
+        /// <param name="property">property of DomainObject</param>
+        /// <returns>Property Attribute</returns>
+        public Column GetAttribute(PropertyInfo property)
+        {
+            Arguments.CheckNotNull(property, nameof(property));
+
+            return AttributeCache.GetOrAdd(property, _ =>
+            {
+                var attributes = property.GetCustomAttributes(typeof(Column), false);
+                return attributes.Length > 0 ? attributes[0] as Column : null;
+            });
+        }
+
+        /// <summary>
+        /// Get name of field or tag for specified attribute and property
+        /// </summary>
+        /// <param name="attribute">attribute of DomainObject</param>
+        /// <param name="property">property of DomainObject</param>
+        /// <returns>name used for mapping</returns>
+        public string GetColumnName(Column attribute, PropertyInfo property)
+        {
+            Arguments.CheckNotNull(property, nameof(property));
+
+            if (attribute != null && !string.IsNullOrEmpty(attribute.Name))
+            {
+                return attribute.Name;
+            }
+
+            return property.Name;
+        }
+    }
+}

--- a/Client.Core/Flux/Internal/FluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/FluxResultMapper.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
@@ -12,14 +11,32 @@ using NodaTime;
                               "437e86d95804a1aeeb0de18ac3728782f9dc8dbae2e806167a8bb64c0402278edcefd78c13dbe7f8d13de" +
                               "36eb36221ec215c66ee2dfe7943de97b869c5eea4d92f92d345ced67de5ac8fc3cd2f8dd7e3c0c53bdb0c" +
                               "c433af859033d069cad397a7")]
+[assembly: InternalsVisibleTo("Client.Linq.Test, PublicKey=00240000048000009400000006020000002400005" +
+                              "25341310004000001000100efaac865f88dd35c90dc548945405aae34056eedbe42cad60971f89a861a78" +
+                              "437e86d95804a1aeeb0de18ac3728782f9dc8dbae2e806167a8bb64c0402278edcefd78c13dbe7f8d13de" +
+                              "36eb36221ec215c66ee2dfe7943de97b869c5eea4d92f92d345ced67de5ac8fc3cd2f8dd7e3c0c53bdb0c" +
+                              "c433af859033d069cad397a7")]
+[assembly: InternalsVisibleTo("InfluxDB.Client, PublicKey=00240000048000009400000006020000002400005" +
+                              "25341310004000001000100efaac865f88dd35c90dc548945405aae34056eedbe42cad60971f89a861a78" +
+                              "437e86d95804a1aeeb0de18ac3728782f9dc8dbae2e806167a8bb64c0402278edcefd78c13dbe7f8d13de" +
+                              "36eb36221ec215c66ee2dfe7943de97b869c5eea4d92f92d345ced67de5ac8fc3cd2f8dd7e3c0c53bdb0c" +
+                              "c433af859033d069cad397a7")]
+[assembly: InternalsVisibleTo("InfluxDB.Client.Flux, PublicKey=00240000048000009400000006020000002400005" +
+                              "25341310004000001000100efaac865f88dd35c90dc548945405aae34056eedbe42cad60971f89a861a78" +
+                              "437e86d95804a1aeeb0de18ac3728782f9dc8dbae2e806167a8bb64c0402278edcefd78c13dbe7f8d13de" +
+                              "36eb36221ec215c66ee2dfe7943de97b869c5eea4d92f92d345ced67de5ac8fc3cd2f8dd7e3c0c53bdb0c" +
+                              "c433af859033d069cad397a7")]
+
 namespace InfluxDB.Client.Core.Flux.Internal
 {
-    internal class FluxResultMapper
+    internal class FluxResultMapper : IFluxResultMapper
     {
-        // Reflection results are cached for poco type property and attribute lookups as an optimization since
-        // calls are invoked continuously for a given type and will not change over library lifetime
-        private static readonly ConcurrentDictionary<Type, PropertyInfo[]> PropertyCache = new ConcurrentDictionary<Type, PropertyInfo[]>();
-        private static readonly ConcurrentDictionary<PropertyInfo, Column> AttributeCache = new ConcurrentDictionary<PropertyInfo, Column>();
+        private readonly AttributesCache _attributesCache = new AttributesCache();
+
+        public T ConvertToEntity<T>(FluxRecord fluxRecord)
+        {
+            return ToPoco<T>(fluxRecord);
+        }
 
         /// <summary>
         /// Maps FluxRecord into custom POCO class.
@@ -35,21 +52,17 @@ namespace InfluxDB.Client.Core.Flux.Internal
             try
             {
                 var type = typeof(T);
-                var poco = (T)Activator.CreateInstance(type);
+                var poco = (T) Activator.CreateInstance(type);
 
                 // copy record to case insensitive dictionary (do this once)
                 var recordValues =
                     new Dictionary<string, object>(record.Values, StringComparer.InvariantCultureIgnoreCase);
 
-                var properties = PropertyCache.GetOrAdd(type, _ => type.GetProperties());
+                var properties = _attributesCache.GetProperties(type);
 
                 foreach (var property in properties)
                 {
-                    var attribute = AttributeCache.GetOrAdd(property, _ =>
-                    {
-                        var attributes = property.GetCustomAttributes(typeof(Column), false);
-                        return attributes.Length > 0 ? attributes[0] as Column : null;
-                    });
+                    var attribute = _attributesCache.GetAttribute(property);
 
                     if (attribute != null && attribute.IsTimestamp)
                     {
@@ -57,12 +70,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     }
                     else
                     {
-                        var columnName = property.Name;
-
-                        if (attribute != null && !string.IsNullOrEmpty(attribute.Name))
-                        {
-                            columnName = attribute.Name;
-                        }
+                        var columnName = _attributesCache.GetColumnName(attribute, property);
 
                         string col = null;
 
@@ -139,7 +147,8 @@ namespace InfluxDB.Client.Core.Flux.Internal
             {
                 throw new InfluxException(
                     $"Class '{poco.GetType().Name}' field '{property.Name}' was defined with a different field type and caused an exception. " +
-                    $"The correct type is '{value.GetType().Name}' (current field value: '{value}'). Exception: {ex.Message}", ex);
+                    $"The correct type is '{value.GetType().Name}' (current field value: '{value}'). Exception: {ex.Message}",
+                    ex);
             }
         }
 
@@ -157,10 +166,11 @@ namespace InfluxDB.Client.Core.Flux.Internal
 
             if (value is IConvertible)
             {
-                return (DateTime)Convert.ChangeType(value, typeof(DateTime));
+                return (DateTime) Convert.ChangeType(value, typeof(DateTime));
             }
 
-            throw new InvalidCastException($"Object value of type {value.GetType().Name} cannot be converted to {nameof(DateTime)}");
+            throw new InvalidCastException(
+                $"Object value of type {value.GetType().Name} cannot be converted to {nameof(DateTime)}");
         }
 
         private Instant ToInstantValue(object value)
@@ -175,7 +185,8 @@ namespace InfluxDB.Client.Core.Flux.Internal
                 return Instant.FromDateTimeUtc(dateTime);
             }
 
-            throw new InvalidCastException($"Object value of type {value.GetType().Name} cannot be converted to {nameof(Instant)}");
+            throw new InvalidCastException(
+                $"Object value of type {value.GetType().Name} cannot be converted to {nameof(Instant)}");
         }
     }
 }

--- a/Client.Core/Flux/Internal/IFluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/IFluxResultMapper.cs
@@ -1,0 +1,18 @@
+using InfluxDB.Client.Core.Flux.Domain;
+
+namespace InfluxDB.Client.Core.Flux.Internal
+{
+    /// <summary>
+    /// Mapper that is used to map FluxRecord into DomainObject.
+    /// </summary>
+    public interface IFluxResultMapper
+    {
+        /// <summary>
+        /// Converts FluxRecord to DomainObject specified by Type.
+        /// </summary>
+        /// <param name="fluxRecord">Flux record</param>
+        /// <typeparam name="T">Type of DomainObject</typeparam>
+        /// <returns>Converted DomainObject</returns>
+        T ConvertToEntity<T>(FluxRecord fluxRecord);
+    }
+}

--- a/Client.Core/Internal/LoggingHandler.cs
+++ b/Client.Core/Internal/LoggingHandler.cs
@@ -114,7 +114,7 @@ namespace InfluxDB.Client.Core.Internal
         {
             return parameters
                 .Where(parameter => parameter.Type.Equals(type))
-                .Select(h => new HttpHeader {Name = h.Name, Value = h.Value.ToString()})
+                .Select(h => new HttpHeader(h.Name, h.Value.ToString()))
                 .ToList();
         }
 

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -15,7 +15,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
         <PackageReference Include="Moq" Version="4.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
-        <PackageReference Include="Tomlyn" Version="0.1.1" />
+        <PackageReference Include="Tomlyn.Signed" Version="0.1.2" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Client.Test/GzipHandlerTest.cs
+++ b/Client.Test/GzipHandlerTest.cs
@@ -138,8 +138,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual("gzip", requestEntry.RequestMessage.Headers["Content-Encoding"].First());
             Assert.AreEqual("identity",
                 requestEntry.RequestMessage.Headers["Accept-Encoding"].First());
-            Assert.AreNotEqual("h2o_feet,location=coyote_creek level\\ water_level=1.0 1",
-                requestEntry.RequestMessage.Body);
+            Assert.AreEqual("gzip", requestEntry.RequestMessage.DetectedCompression);
         }
     }
 }

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -159,7 +159,7 @@ namespace InfluxDB.Client.Test
         }
         
         [Test]
-        public async Task TrailingSlashInUrl()
+        public void TrailingSlashInUrl()
         {
             MockServer
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())

--- a/Client.Test/ItBucketsApiTest.cs
+++ b/Client.Test/ItBucketsApiTest.cs
@@ -102,7 +102,6 @@ namespace InfluxDB.Client.Test
             Assert.IsNotEmpty(bucket.Id);
             Assert.AreEqual(bucket.Name, bucketName);
             Assert.AreEqual(bucket.OrgID, _organization.Id);
-            Assert.AreEqual(bucket.RetentionRules.Count, 0);
         }
 
         [Test]

--- a/Client.Test/QueryApiSyncTest.cs
+++ b/Client.Test/QueryApiSyncTest.cs
@@ -1,0 +1,75 @@
+using System;
+using InfluxDB.Client.Core;
+using InfluxDB.Client.Core.Test;
+using NUnit.Framework;
+using WireMock.RequestBuilders;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class QueryApiSyncTest : AbstractMockServerTest
+    {
+        private InfluxDBClient _influxDbClient;
+        private QueryApiSync _queryApiSync;
+
+        private const string Data =
+            "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,double\n"
+            + "#group,false,false,false,false,false,false,false,false,false,false\n"
+            + "#default,_result,,,,,,,,,\n"
+            + ",result,table,_start,_stop,_time,id,_field,_measurement,host,_value\n"
+            + ",,0,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,ab,free,mem,A,12.25\n"
+            + ",,0,1970-01-01T00:00:10Z,1970-01-01T00:00:20Z,1970-01-01T00:00:10Z,cd,free,mem,A,13.00\n";
+
+        [SetUp]
+        public new void SetUp()
+        {
+            var options = InfluxDBClientOptions.Builder
+                .CreateNew()
+                .Url(MockServerUrl)
+                .AuthenticateToken("token")
+                .Org("my-org")
+                .Build();
+            
+            _influxDbClient = InfluxDBClientFactory.Create(options);
+            _queryApiSync = _influxDbClient.GetQueryApiSync();
+        }
+
+        [Test]
+        public void Measurement()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/query").UsingPost())
+                .RespondWith(CreateResponse(Data));
+
+            var measurements = _queryApiSync.QuerySync<SyncPoco>("from(...");
+
+            Assert.AreEqual(2, measurements.Count);
+            Assert.AreEqual(12.25, measurements[0].Value);
+            Assert.AreEqual(13.00, measurements[1].Value);
+        }
+
+        [Test]
+        public void FluxTable()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/query").UsingPost())
+                .RespondWith(CreateResponse(Data));
+
+            var tables = _queryApiSync.QuerySync("from(...");
+
+            Assert.AreEqual(1, tables.Count);
+            Assert.AreEqual(2, tables[0].Records.Count);
+            Assert.AreEqual(12.25, tables[0].Records[0].GetValue());
+            Assert.AreEqual(13.00, tables[0].Records[1].GetValue());
+        }
+
+        private class SyncPoco
+        {
+            [Column("id", IsTag = true)] public string Tag { get; set; }
+
+            [Column("_value")] public double Value { get; set; }
+
+            [Column(IsTimestamp = true)] public Object Timestamp { get; set; }
+        }
+    }
+}

--- a/Client.Test/RetryAttemptTest.cs
+++ b/Client.Test/RetryAttemptTest.cs
@@ -142,7 +142,7 @@ namespace InfluxDB.Client.Test
 
         private HttpException CreateException(int retryAfter = 10)
         {
-            var headers = new List<HttpHeader> {new HttpHeader {Name = "Retry-After", Value = retryAfter.ToString()}};
+            var headers = new List<HttpHeader> {new HttpHeader("Retry-After", retryAfter.ToString())};
             var exception = HttpException.Create("", headers, "", HttpStatusCode.TooManyRequests);
             return exception;
         }

--- a/Client/IDomainObjectMapper.cs
+++ b/Client/IDomainObjectMapper.cs
@@ -1,0 +1,22 @@
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Internal;
+using InfluxDB.Client.Writes;
+
+namespace InfluxDB.Client
+{
+    /// <summary>
+    /// An implementation of this class is used to convert DomainObject entity into <see cref="InfluxDB.Client.Writes.PointData"/>
+    /// and <see cref="InfluxDB.Client.Core.Flux.Domain.FluxRecord"/> back to DomainObject. 
+    /// </summary>
+    public interface IDomainObjectMapper: IFluxResultMapper
+    {
+        /// <summary>
+        /// Converts DomainObject to corresponding PointData.
+        /// </summary>
+        /// <param name="entity">DomainObject to convert</param>
+        /// <param name="precision">Required timestamp precision</param>
+        /// <typeparam name="T">Type of DomainObject</typeparam>
+        /// <returns>Converted DataPoint</returns>
+        PointData ConvertToPointData<T>(T entity, WritePrecision precision);
+    }
+}

--- a/Client/Internal/DefaultDomainObjectMapper.cs
+++ b/Client/Internal/DefaultDomainObjectMapper.cs
@@ -1,0 +1,26 @@
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Core.Flux.Internal;
+using InfluxDB.Client.Writes;
+
+namespace InfluxDB.Client.Internal
+{
+    /// <summary>
+    /// Default implementation of DomainObject mapper.
+    /// </summary>
+    internal class DefaultDomainObjectMapper : IDomainObjectMapper
+    {
+        private readonly FluxResultMapper _resultMapper = new FluxResultMapper();
+        private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
+
+        public T ConvertToEntity<T>(FluxRecord fluxRecord)
+        {
+            return _resultMapper.ToPoco<T>(fluxRecord);
+        }
+
+        public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
+        {
+            return _measurementMapper.ToPoint(entity, precision);
+        }
+    }
+}

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -1,0 +1,204 @@
+using System;
+using System.Collections.Generic;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Api.Service;
+using InfluxDB.Client.Core;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Core.Flux.Internal;
+using InfluxDB.Client.Core.Internal;
+using RestSharp;
+
+namespace InfluxDB.Client
+{
+    /// <summary>
+    /// The synchronous version of QueryApi.
+    /// </summary>
+    public class QueryApiSync: AbstractQueryClient
+    {
+        private readonly InfluxDBClientOptions _options;
+        private readonly QueryService _service;
+
+        protected internal QueryApiSync(InfluxDBClientOptions options, QueryService service, IFluxResultMapper mapper) : base(service.Configuration
+            .ApiClient.RestClient, mapper)
+        {
+            Arguments.CheckNotNull(options, nameof(options));
+            Arguments.CheckNotNull(service, nameof(service));
+
+            _options = options;
+            _service = service;
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public List<T> QuerySync<T>(string query)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+
+            return QuerySync<T>(query, _options.Org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public List<T> QuerySync<T>(string query, string org)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNonEmptyString(org, nameof(org));
+
+            return QuerySync<T>(QueryApi.CreateQuery(query, QueryApi.DefaultDialect), org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public List<T> QuerySync<T>(Query query)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+
+            return QuerySync<T>(query, _options.Org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        public List<T> QuerySync<T>(Query query, string org)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+            Arguments.CheckNonEmptyString(org, nameof(org));
+
+            var measurements = new List<T>();
+
+            var consumer = new FluxResponseConsumerPoco<T>((cancellable, poco) => { measurements.Add(poco); }, Mapper);
+            
+            var requestMessage = _service.PostQueryWithRestRequest(null, "application/json", null, org, null, query);
+
+            QuerySync(requestMessage, consumer, ErrorConsumer, EmptyAction);
+
+            return measurements;
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        public List<FluxTable> QuerySync(string query)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+
+            return QuerySync(query, _options.Org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        public List<FluxTable> QuerySync(string query, string org)
+        {
+            Arguments.CheckNonEmptyString(query, nameof(query));
+            Arguments.CheckNonEmptyString(org, nameof(org));
+
+            return QuerySync(QueryApi.CreateQuery(query, QueryApi.DefaultDialect), org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        public List<FluxTable> QuerySync(Query query)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+
+            return QuerySync(query, _options.Org);
+        }
+        
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        public List<FluxTable> QuerySync(Query query, string org)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+            Arguments.CheckNonEmptyString(org, nameof(org));
+
+            var consumer = new FluxCsvParser.FluxResponseConsumerTable();
+            
+            var requestMessage = _service.PostQueryWithRestRequest(null, "application/json", null, org, null, query);
+
+            QuerySync(requestMessage, consumer, ErrorConsumer, EmptyAction);
+
+            return consumer.Tables;
+        }
+
+        protected override void BeforeIntercept(RestRequest request)
+        {
+            _service.Configuration.ApiClient.BeforeIntercept(request);
+        }
+
+        protected override T AfterIntercept<T>(int statusCode, Func<IList<HttpHeader>> headers, T body)
+        {
+            return _service.Configuration.ApiClient.AfterIntercept(statusCode, headers, body);
+        }
+    }
+}

--- a/Client/README.md
+++ b/Client/README.md
@@ -24,6 +24,7 @@ The reference client that allows query, write and management (bucket, organizati
     - health check
 - [Advanced Usage](#advanced-usage)
     - [Monitoring & Alerting](#monitoring--alerting)
+    - [Custom mapping of DomainObject to/from InfluxDB](#custom-mapping-of-domainobject-tofrom-influxdb)
     - [Client configuration file](#client-configuration-file)
     - [Client connection string](#client-connection-string)
     - [Gzip support](#gzip-support)
@@ -873,6 +874,182 @@ await Client
     .GetNotificationRulesApi()
     .CreateSlackRuleAsync("Critical status to Slack", "10s", "${ r._message }", RuleStatusLevel.CRIT, endpoint, org.Id);
 ```
+
+### Custom mapping of DomainObject to/from InfluxDB
+
+The [default mapper](/Client/Internal/DefaultDomainObjectMapper.cs) uses [Column](#by-poco) attributes to define how the DomainObject will be mapped `to` and `from` the InfluxDB.
+The our APIs also allow to specify custom mapper. For more information see following example:
+
+```c#
+using System;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Writes;
+
+namespace Examples
+{
+    public static class CustomDomainMapping
+    {
+        /// <summary>
+        /// Define Domain Object
+        /// </summary>
+        private class Sensor
+        {
+            /// <summary>
+            /// Type of sensor.
+            /// </summary>
+            public String Type { get; set; }
+            
+            /// <summary>
+            /// Version of sensor.
+            /// </summary>
+            public String Version { get; set; }
+
+            /// <summary>
+            /// Measured value.
+            /// </summary>
+            public double Value { get; set; }
+
+            public DateTimeOffset Timestamp { get; set; }
+
+            public override string ToString()
+            {
+                return $"{Timestamp:MM/dd/yyyy hh:mm:ss.fff tt} {Type}, {Version} value: {Value}";
+            }
+        }
+
+        /// <summary>
+        /// Define Custom Domain Object Converter
+        /// </summary>
+        private class DomainEntityConverter : IDomainObjectMapper
+        {
+            /// <summary>
+            /// Convert to DomainObject.
+            /// </summary>
+            public T ConvertToEntity<T>(FluxRecord fluxRecord)
+            {
+                if (typeof(T) != typeof(Sensor))
+                {
+                    throw new NotSupportedException($"This converter doesn't supports: {typeof(T)}");
+                }
+
+                var customEntity = new Sensor
+                {
+                    Type = Convert.ToString(fluxRecord.GetValueByKey("type")),
+                    Version = Convert.ToString(fluxRecord.GetValueByKey("version")),
+                    Value = Convert.ToDouble(fluxRecord.GetValueByKey("data")),
+                    Timestamp = fluxRecord.GetTime().GetValueOrDefault().ToDateTimeUtc(),
+                };
+                
+                return (T) Convert.ChangeType(customEntity, typeof(T));
+            }
+
+            /// <summary>
+            /// Convert to Point
+            /// </summary>
+            public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
+            {
+                if (!(entity is Sensor sensor))
+                {
+                    throw new NotSupportedException($"This converter doesn't supports: {entity}");
+                }
+
+                var point = PointData
+                    .Measurement("sensor")
+                    .Tag("type", sensor.Type)
+                    .Tag("version", sensor.Version)
+                    .Field("data", sensor.Value)
+                    .Timestamp(sensor.Timestamp, precision);
+
+                return point;
+            }
+        }
+
+        public static async Task Main(string[] args)
+        {
+            const string host = "http://localhost:9999";
+            const string token = "my-token";
+            const string bucket = "my-bucket";
+            const string organization = "my-org";
+            var options = new InfluxDBClientOptions.Builder()
+                .Url(host)
+                .AuthenticateToken(token.ToCharArray())
+                .Org(organization)
+                .Bucket(bucket)
+                .Build();
+
+            var converter = new DomainEntityConverter();
+            var client = InfluxDBClientFactory.Create(options);
+
+            //
+            // Prepare data to write
+            //
+            var time = new DateTimeOffset(2020, 11, 15, 8, 20, 15,
+                new TimeSpan(3, 0, 0));
+
+            var entity1 = new Sensor
+            {
+                Timestamp = time,
+                Type = "temperature",
+                Version = "v0.0.2",
+                Value = 15
+            };
+            var entity2 = new Sensor
+            {
+                Timestamp = time.AddHours(1),
+                Type = "temperature",
+                Version = "v0.0.2",
+                Value = 15
+            };
+            var entity3 = new Sensor
+            {
+                Timestamp = time.AddHours(2),
+                Type = "humidity",
+                Version = "v0.13",
+                Value = 74
+            };
+            var entity4 = new Sensor
+            {
+                Timestamp = time.AddHours(3),
+                Type = "humidity",
+                Version = "v0.13",
+                Value = 82
+            };
+
+            //
+            // Write data
+            //
+            await client.GetWriteApiAsync(converter)
+                .WriteMeasurementsAsync(WritePrecision.S, entity1, entity2, entity3, entity4);
+
+            //
+            // Query Data to Domain object
+            //
+            var queryApi = client.GetQueryApiSync(converter);
+
+            //
+            // Select ALL
+            //
+            var query = $"from(bucket:\"{bucket}\") " +
+                        "|> range(start: 0) " +
+                        "|> filter(fn: (r) => r[\"_measurement\"] == \"sensor\")" +
+                        "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+           
+            var sensors = queryApi.QuerySync<Sensor>(query);
+            //
+            // Print result
+            //
+            sensors.ForEach(it => Console.WriteLine(it.ToString()));
+
+            client.Dispose();
+        }
+    }
+}
+```
+
+- sources: [CustomDomainMapping.cs](/Examples/CustomDomainMapping.cs)
 
 ### Client configuration file
 

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
 using InfluxDB.Client.Core;
-using InfluxDB.Client.Internal;
 using InfluxDB.Client.Writes;
 
 namespace InfluxDB.Client
@@ -16,15 +15,18 @@ namespace InfluxDB.Client
         private readonly InfluxDBClient _influxDbClient;
         private readonly InfluxDBClientOptions _options;
         private readonly WriteService _service;
-        private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
+        private readonly IDomainObjectMapper _mapper;
 
         protected internal WriteApiAsync(InfluxDBClientOptions options, WriteService service,
-                        InfluxDBClient influxDbClient)
+            IDomainObjectMapper mapper,
+            InfluxDBClient influxDbClient)
         {
             Arguments.CheckNotNull(service, nameof(service));
+            Arguments.CheckNotNull(mapper, nameof(mapper));
             Arguments.CheckNotNull(influxDbClient, nameof(_influxDbClient));
 
             _options = options;
+            _mapper = mapper;
             _influxDbClient = influxDbClient;
             _service = service;
         }
@@ -273,7 +275,7 @@ namespace InfluxDB.Client
             {
                 var options = new BatchWriteOptions(bucket, org, precision);
 
-                BatchWriteData data = new BatchWriteMeasurement<TM>(options, _options, measurement, _measurementMapper);
+                BatchWriteData data = new BatchWriteMeasurement<TM>(options, _options, measurement, _mapper);
                 list.Add(data);
             }
 

--- a/Examples/CustomDomainMapping.cs
+++ b/Examples/CustomDomainMapping.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Writes;
+
+namespace Examples
+{
+    public static class CustomDomainMapping
+    {
+        /// <summary>
+        /// Define Domain Object
+        /// </summary>
+        private class Sensor
+        {
+            /// <summary>
+            /// Type of sensor.
+            /// </summary>
+            public String Type { get; set; }
+            
+            /// <summary>
+            /// Version of sensor.
+            /// </summary>
+            public String Version { get; set; }
+
+            /// <summary>
+            /// Measured value.
+            /// </summary>
+            public double Value { get; set; }
+
+            public DateTimeOffset Timestamp { get; set; }
+
+            public override string ToString()
+            {
+                return $"{Timestamp:MM/dd/yyyy hh:mm:ss.fff tt} {Type}, {Version} value: {Value}";
+            }
+        }
+
+        /// <summary>
+        /// Define Custom Domain Object Converter
+        /// </summary>
+        private class DomainEntityConverter : IDomainObjectMapper
+        {
+            /// <summary>
+            /// Convert to DomainObject.
+            /// </summary>
+            public T ConvertToEntity<T>(FluxRecord fluxRecord)
+            {
+                if (typeof(T) != typeof(Sensor))
+                {
+                    throw new NotSupportedException($"This converter doesn't supports: {typeof(T)}");
+                }
+
+                var customEntity = new Sensor
+                {
+                    Type = Convert.ToString(fluxRecord.GetValueByKey("type")),
+                    Version = Convert.ToString(fluxRecord.GetValueByKey("version")),
+                    Value = Convert.ToDouble(fluxRecord.GetValueByKey("data")),
+                    Timestamp = fluxRecord.GetTime().GetValueOrDefault().ToDateTimeUtc(),
+                };
+                
+                return (T) Convert.ChangeType(customEntity, typeof(T));
+            }
+
+            /// <summary>
+            /// Convert to Point
+            /// </summary>
+            public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
+            {
+                if (!(entity is Sensor sensor))
+                {
+                    throw new NotSupportedException($"This converter doesn't supports: {entity}");
+                }
+
+                var point = PointData
+                    .Measurement("sensor")
+                    .Tag("type", sensor.Type)
+                    .Tag("version", sensor.Version)
+                    .Field("data", sensor.Value)
+                    .Timestamp(sensor.Timestamp, precision);
+
+                return point;
+            }
+        }
+
+        public static async Task Main(string[] args)
+        {
+            const string host = "http://localhost:9999";
+            const string token = "my-token";
+            const string bucket = "my-bucket";
+            const string organization = "my-org";
+            var options = new InfluxDBClientOptions.Builder()
+                .Url(host)
+                .AuthenticateToken(token.ToCharArray())
+                .Org(organization)
+                .Bucket(bucket)
+                .Build();
+
+            var converter = new DomainEntityConverter();
+            var client = InfluxDBClientFactory.Create(options);
+
+            //
+            // Prepare data to write
+            //
+            var time = new DateTimeOffset(2020, 11, 15, 8, 20, 15,
+                new TimeSpan(3, 0, 0));
+
+            var entity1 = new Sensor
+            {
+                Timestamp = time,
+                Type = "temperature",
+                Version = "v0.0.2",
+                Value = 15
+            };
+            var entity2 = new Sensor
+            {
+                Timestamp = time.AddHours(1),
+                Type = "temperature",
+                Version = "v0.0.2",
+                Value = 15
+            };
+            var entity3 = new Sensor
+            {
+                Timestamp = time.AddHours(2),
+                Type = "humidity",
+                Version = "v0.13",
+                Value = 74
+            };
+            var entity4 = new Sensor
+            {
+                Timestamp = time.AddHours(3),
+                Type = "humidity",
+                Version = "v0.13",
+                Value = 82
+            };
+
+            //
+            // Write data
+            //
+            await client.GetWriteApiAsync(converter)
+                .WriteMeasurementsAsync(WritePrecision.S, entity1, entity2, entity3, entity4);
+
+            //
+            // Query Data to Domain object
+            //
+            var queryApi = client.GetQueryApiSync(converter);
+
+            //
+            // Select ALL
+            //
+            var query = $"from(bucket:\"{bucket}\") " +
+                        "|> range(start: 0) " +
+                        "|> filter(fn: (r) => r[\"_measurement\"] == \"sensor\")" +
+                        "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+           
+            var sensors = queryApi.QuerySync<Sensor>(query);
+            //
+            // Print result
+            //
+            sensors.ForEach(it => Console.WriteLine(it.ToString()));
+
+            client.Dispose();
+        }
+    }
+}

--- a/Examples/InfluxDB18Example.cs
+++ b/Examples/InfluxDB18Example.cs
@@ -7,8 +7,7 @@ namespace Examples
 {
     public class InfluxDB18Example
     {
-        // change name of method to Main
-        public static async Task MainDisabled(string[] args)
+        public static async Task Main(string[] args)
         {
             const string database = "telegraf";
             const string retentionPolicy = "autogen";

--- a/Examples/RunExamples.cs
+++ b/Examples/RunExamples.cs
@@ -48,13 +48,16 @@ namespace Examples
                     case "SynchronousQuery":
                         SynchronousQuery.Main(args);
                         break;
+                    case "CustomDomainMapping":
+                        await CustomDomainMapping.Main(args);
+                        break;
                 }
             }
             else
             {
                 Console.WriteLine("Please specify the name of example. One of: " +
                                   "FluxExample, FluxClientSimpleExample, FluxRawExample, FluxClientFactoryExample, " +
-                                  "FluxClientPocoExample, PlatformExample, WriteApiAsyncExample, " +
+                                  "FluxClientPocoExample, PlatformExample, WriteApiAsyncExample, CustomDomainMapping, " +
                                   "PocoQueryWriteExample, SynchronousQuery, InfluxDB18Example");
             }
         }

--- a/Examples/RunExamples.cs
+++ b/Examples/RunExamples.cs
@@ -42,13 +42,20 @@ namespace Examples
                     case "PocoQueryWriteExample":
                         await PocoQueryWriteExample.Main(args);
                         break;
+                    case "InfluxDB18Example":
+                        await InfluxDB18Example.Main(args);
+                        break;
+                    case "SynchronousQuery":
+                        SynchronousQuery.Main(args);
+                        break;
                 }
             }
             else
             {
                 Console.WriteLine("Please specify the name of example. One of: " +
                                   "FluxExample, FluxClientSimpleExample, FluxRawExample, FluxClientFactoryExample, " +
-                                  "FluxClientPocoExample, PlatformExample, WriteApiAsyncExample, PocoQueryWriteExample");
+                                  "FluxClientPocoExample, PlatformExample, WriteApiAsyncExample, " +
+                                  "PocoQueryWriteExample, SynchronousQuery, InfluxDB18Example");
             }
         }
     }

--- a/Examples/SynchronousQuery.cs
+++ b/Examples/SynchronousQuery.cs
@@ -1,0 +1,32 @@
+using System;
+using InfluxDB.Client;
+
+namespace Examples
+{
+    public class SynchronousQuery
+    {
+        public static void Main(string[] args)
+        {
+            using var client = InfluxDBClientFactory.Create("http://localhost:9999", "my-token");
+
+            const string query = "from(bucket:\"my-bucket\") |> range(start: 0)";
+           
+            //
+            // QueryData
+            //
+            var queryApi = client.GetQueryApiSync();
+            var tables = queryApi.QuerySync(query, "my-org");
+            
+            //
+            // Process results
+            //
+            tables.ForEach(table =>
+            {
+                table.Records.ForEach(record =>
+                {
+                    Console.WriteLine($"{record.GetTime()}: {record.GetValueByKey("_value")}");
+                });
+            });
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ This repository contains the reference C# client for the InfluxDB 2.0.
         - authorizations
         - health check
         - ...
+    
 ## Documentation
 
 The C# clients are implemented for the InfluxDB 2.0 and InfluxDB 1.7+:

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ The C# clients are implemented for the InfluxDB 2.0 and InfluxDB 1.7+:
 
 | Client | Description | Documentation | Compatibility |
 | --- | --- | --- |                                      --- |
-| **[Client](./Client)** | The reference C# client that allows query, write and InfluxDB 2.0 management. | [readme](./Client#influxdbclient)| 2.0 |
-| **[Client.Legacy](./Client.Legacy)**  | The reference C# client that allows you to perform Flux queries against InfluxDB 1.7+. | [readme](./Client.Legacy#influxdbclientflux) | 1.7+ |
+| **[Client](./Client#influxdbclient)** | The reference C# client that allows query, write and InfluxDB 2.0 management. | [readme](./Client#influxdbclient)| 2.0 |
+| **[Client.Legacy](./Client.Legacy#influxdbclientflux)**  | The reference C# client that allows you to perform Flux queries against InfluxDB 1.7+. | [readme](./Client.Legacy#influxdbclientflux) | 1.7+ |
 
 
 ## How To Use 


### PR DESCRIPTION
Related to #146 

## Proposed Changes

- Added `QueryApiSync` for synchronous querying
- Added `IDomainObjectMapper` for custom mapping DomainObject from/to InfluxDB

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
