### PR TITLE
chore(ci): add build for dotnet5, fix code coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,8 @@ commands:
             cp -r Client.Linq.Test/TestResults/*.xml test-results/client-linq || true
             mkdir test-results/client
             cp -r Client.Test/TestResults/*.xml test-results/client || true
+            mkdir test-results/client-core
+            cp -r Client.Core.Test/TestResults/*.xml test-results/client-core || true
       - store_test_results:
           path: test-results
   

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ commands:
     steps:
       - run:
           name: "Running tests"
-          command: ./Scripts/ci-test.sh
+          command: ./Scripts/ci-test.sh << parameters.code-coverage-report >>
       - run:
           name: "Converting test results to Junit format"
           when: on_fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -173,7 +173,10 @@ workflows:
           dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.0"
       - tests-dotnet:
           name: dotnet-3.1
+      - tests-dotnet:
+          name: dotnet-5.0
           code-coverage-report: true
+          dotnet-image: "mcr.microsoft.com/dotnet/sdk:5.0"
       - tests-windows:
           name: dotnet-windows
       - deploy-preview:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,8 +13,9 @@ commands:
       - influxdb-onboarding
   client-test:
     parameters:
-      dotnet-image:
-        type: string
+      code-coverage-report:
+        type: boolean
+        default: false
     steps:
       - run:
           name: "Running tests"
@@ -33,6 +34,8 @@ commands:
             mkdir test-results
             mkdir test-results/client-legacy
             cp -r Client.Legacy.Test/TestResults/*.xml test-results/client-legacy || true
+            mkdir test-results/client-linq
+            cp -r Client.Linq.Test/TestResults/*.xml test-results/client-linq || true
             mkdir test-results/client
             cp -r Client.Test/TestResults/*.xml test-results/client || true
       - store_test_results:
@@ -46,6 +49,7 @@ commands:
             mkdir artifacts
             cp -r Client.Core/bin/Debug/*/*.dll artifacts/
             cp -r Client.Legacy/bin/Debug/*/*.dll artifacts/
+            cp -r Client.Linq/bin/Debug/*/*.dll artifacts/
             cp -r Client/bin/Debug/*/*.dll artifacts/
       - store_artifacts:
           path: artifacts
@@ -62,6 +66,9 @@ jobs:
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
+      code-coverage-report:
+        type: boolean
+        default: false
     docker:
       - image: << parameters.dotnet-image >>
         environment:
@@ -82,12 +89,17 @@ jobs:
     steps:
       - prepare
       - client-test:
-          dotnet-image: << parameters.dotnet-image >>
+          code-coverage-report: << parameters.code-coverage-report >>
       - storing-test-results
       - storing-artifacts
-      - run:
-          name: "Collecting coverage reports"
-          command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+      - when:
+          condition:
+            and:
+              - equal: [ true, << parameters.code-coverage-report >> ]
+          steps:
+            - run:
+                name: "Collecting coverage reports"
+                command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
 
   tests-windows:
     machine:
@@ -161,6 +173,7 @@ workflows:
           dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.0"
       - tests-dotnet:
           name: dotnet-3.1
+          code-coverage-report: true
       - tests-windows:
           name: dotnet-windows
       - deploy-preview:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,2 +1,6 @@
 ignore:
   - "Client/InfluxDB.Client.Api/**/*"
+  - "Client.Core.Test/**/*"
+  - "Client.Test/**/*"
+  - "Client.Legacy.Test/**/*"
+  - "Client.Linq.Test/**/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 ignore:
   - "Client/InfluxDB.Client.Api/**/*"
-  - "Client.Core.Test/**/*"
+  - "Client.Core.Test/*"
   - "Client.Test/**/*"
   - "Client.Legacy.Test/**/*"
   - "Client.Linq.Test/**/*"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,28 +1,34 @@
 ## 1.17.0 [unreleased]
 
 ### Features
-1. [#146](https://github.com/influxdata/influxdb-client-csharp/pull/146): Added support for querying by `LINQ`
-1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Added `QueryApiSync` for synchronous querying
-1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Added `IDomainObjectMapper` for custom mapping DomainObject from/to InfluxDB
-1. [#180](https://github.com/influxdata/influxdb-client-csharp/pull/180): Added a mutable `PointData.Builder` to optimize building of immutable `PointData`
+1. [#146](https://github.com/influxdata/influxdb-client-csharp/pull/146): Add support for querying by `LINQ`
+1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Add `QueryApiSync` for synchronous querying
+1. [#171](https://github.com/influxdata/influxdb-client-csharp/pull/171): Add `IDomainObjectMapper` for custom mapping DomainObject from/to InfluxDB
+1. [#180](https://github.com/influxdata/influxdb-client-csharp/pull/180): Add a mutable `PointData.Builder` to optimize building of immutable `PointData`
 
 ### API
-1. [#174](https://github.com/influxdata/influxdb-client-csharp/pull/174): Added possibility to use `CancellationToken` in REST API
-1. [#179](https://github.com/influxdata/influxdb-client-csharp/pull/179): Added possibility to use `CancellationToken` in the async write API (WriteApiAsync)
+1. [#174](https://github.com/influxdata/influxdb-client-csharp/pull/174): Add possibility to use `CancellationToken` in REST API
+1. [#179](https://github.com/influxdata/influxdb-client-csharp/pull/179): Add possibility to use `CancellationToken` in the async write API (WriteApiAsync)
 
 ### Bug Fixes
 1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
-1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fixed domain structure for Flux AST
-1. [#181](https://github.com/influxdata/influxdb-client-csharp/pull/181): Removed download overhead for Queries
+1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fix domain structure for Flux AST
+1. [#181](https://github.com/influxdata/influxdb-client-csharp/pull/181): Remove download overhead for Queries
 
 ### Dependencies
-1. [#175](https://github.com/influxdata/influxdb-client-csharp/pull/175): Updated dependencies of `InfluxDB.Client`:
+1. [#175](https://github.com/influxdata/influxdb-client-csharp/pull/175): Update dependencies of `InfluxDB.Client`:
     - JsonSubTypes to 1.8.0
     - Microsoft.Extensions.ObjectPool to 5.0.4
     - Microsoft.Net.Http.Headers to 2.2.8
     - System.Collections.Immutable to 5.0.0
     - System.Configuration.ConfigurationManager to 5.0.0
     - System.Reactive to 5.0.0
+1. [#182](https://github.com/influxdata/influxdb-client-csharp/pull/182): Update test dependencies:
+    - Microsoft.NET.Test.Sdk to 16.5.0
+
+### CI
+1. [#182](https://github.com/influxdata/influxdb-client-csharp/pull/182): Add build for `dotnet5`, Fix code coverage report
+
 
 ## 1.16.0 [2021-03-05]
 

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -27,10 +27,6 @@
         <PackageReference Include="coverlet.collector" Version="3.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -13,7 +13,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="NUnit" Version="3.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
         <PackageReference Include="WireMock.Net" Version="1.4.6" />

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -23,4 +23,15 @@
       <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp5.0' ">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     </ItemGroup>
 

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -20,4 +20,15 @@
       <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp5.0' ">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -24,10 +24,6 @@
         <PackageReference Include="coverlet.collector" Version="3.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -25,10 +25,6 @@
         <PackageReference Include="coverlet.collector" Version="3.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
     

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="Moq" Version="4.15.2" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     </ItemGroup>

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -21,4 +21,15 @@
       <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp5.0' ">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    
 </Project>

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -12,7 +12,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
         <PackageReference Include="Moq" Version="4.11.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
         <PackageReference Include="Tomlyn.Signed" Version="0.1.2" />

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -27,10 +27,6 @@
         <PackageReference Include="coverlet.collector" Version="3.0.3">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
     </ItemGroup>
 

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -23,4 +23,15 @@
       <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
+    <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp5.0' ">
+        <PackageReference Include="coverlet.collector" Version="3.0.3">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.msbuild" Version="3.0.3">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
 </Project>

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1</TargetFrameworks>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
         <VersionPrefix>1.17.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -2,6 +2,15 @@
 
 set -e
 
+if [[ "$*" == *true* ]]
+then
+    CODE_COVERAGE_REPORT=true
+else
+    CODE_COVERAGE_REPORT=false 
+fi
+
+echo "Test configuration: $*, generate coverage report: $CODE_COVERAGE_REPORT"
+
 #
 # Prepare compatible version
 #

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -32,14 +32,12 @@ sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Linq/Client.Linq.csproj
 
 TRX2JUNIT_VERSION=""
-BUILD_PARAMS=""
-TEST_PARAMS=""
+TEST_PARAMS=()
 
 if [[ "$CODE_COVERAGE_REPORT" = true ]]
 then
   TRX2JUNIT_VERSION="1.5.0"
-  BUILD_PARAMS="/p:ContinuousIntegrationBuild=true"
-  TEST_PARAMS="/p:CollectCoverage=true /p:CoverletOutputFormat=opencover"
+  TEST_PARAMS=(--collect:"XPlat Code Coverage")
 else
   TRX2JUNIT_VERSION="1.3.2"
 fi
@@ -53,15 +51,15 @@ dotnet tool install --tool-path="./trx2junit/" trx2junit --version ${TRX2JUNIT_V
 # Build
 #
 dotnet restore
-dotnet build --no-restore ${BUILD_PARAMS}
+dotnet build --no-restore
 
 #
 # Test
 #
-dotnet test Client.Core.Test/Client.Core.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
-dotnet test Client.Test/Client.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
-dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
-dotnet test Client.Linq.Test/Client.Linq.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
+dotnet test Client.Core.Test/Client.Core.Test.csproj --no-build --verbosity normal --logger trx "${TEST_PARAMS[@]}"
+dotnet test Client.Test/Client.Test.csproj --no-build --verbosity normal --logger trx "${TEST_PARAMS[@]}"
+dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build --verbosity normal --logger trx "${TEST_PARAMS[@]}"
+dotnet test Client.Linq.Test/Client.Linq.Test.csproj --no-build --verbosity normal --logger trx "${TEST_PARAMS[@]}"
 
 #
 # Convert test results to Junit format

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -20,11 +20,11 @@ echo "$NET_TEST_VERSION"
 DEFAULT_NET_TARGET_VERSION="netstandard2.1"
 NET_TARGET_VERSION="${NET_TARGET_VERSION:-$DEFAULT_NET_TARGET_VERSION}"
 
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Linq.Test/Client.Linq.Test.csproj
-sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Examples/Examples.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Test/Client.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Client.Linq.Test/Client.Linq.Test.csproj
+sed -i '/<TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TEST_VERSION}"'<\/TargetFramework>' Examples/Examples.csproj
 
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client/Client.csproj

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -58,8 +58,9 @@ dotnet build --no-restore ${BUILD_PARAMS}
 #
 # Test
 #
-dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
+dotnet test Client.Core.Test/Client.Core.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
 dotnet test Client.Test/Client.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
+dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
 dotnet test Client.Linq.Test/Client.Linq.Test.csproj --no-build --verbosity normal --logger trx ${TEST_PARAMS}
 
 #

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -9,7 +9,7 @@ else
     CODE_COVERAGE_REPORT=false 
 fi
 
-echo "Test configuration: $*, generate coverage report: $CODE_COVERAGE_REPORT"
+echo "Configuration: $*, Coverage Report: $CODE_COVERAGE_REPORT"
 
 #
 # Prepare compatible version
@@ -34,8 +34,13 @@ sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<
 #
 # Install testing tools
 #
-dotnet tool install --tool-path="./Coverlet/" coverlet.console --version 1.7.2
-dotnet tool install --tool-path="./trx2junit/" trx2junit --version 1.3.2
+if [[ "$CODE_COVERAGE_REPORT" = true ]]
+then
+  dotnet tool install --tool-path="./Coverlet/" coverlet.console --version 1.7.2
+  dotnet tool install --tool-path="./trx2junit/" trx2junit --version 1.3.2
+else
+  dotnet tool install --tool-path="./trx2junit/" trx2junit --version 1.3.2
+fi
 
 #
 # Build
@@ -46,9 +51,17 @@ dotnet build
 #
 # Test
 #
-./Coverlet/coverlet Client.Legacy.Test/bin/Debug/"$NET_VERSION"/Client.Legacy.Test.dll --target "dotnet" --targetargs "test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build  --logger trx" --format opencover --output "./Client.Legacy.Test/"
-./Coverlet/coverlet Client.Test/bin/Debug/"$NET_VERSION"/Client.Test.dll --target "dotnet"  --targetargs "test Client.Test/Client.Test.csproj --no-build --logger trx" --format opencover --output "./Client.Test/"
-./Coverlet/coverlet Client.Linq.Test/bin/Debug/"$NET_VERSION"/Client.Linq.Test.dll --target "dotnet" --targetargs "test Client.Linq.Test/Client.Linq.Test.csproj --no-build  --logger trx" --format opencover --output "./Client.Linq.Test/"
+if [[ "$CODE_COVERAGE_REPORT" = true ]]
+then
+  ./Coverlet/coverlet Client.Legacy.Test/bin/Debug/"$NET_VERSION"/Client.Legacy.Test.dll --target "dotnet" --targetargs "test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build  --logger trx" --format opencover --output "./Client.Legacy.Test/"
+  ./Coverlet/coverlet Client.Test/bin/Debug/"$NET_VERSION"/Client.Test.dll --target "dotnet"  --targetargs "test Client.Test/Client.Test.csproj --no-build --logger trx" --format opencover --output "./Client.Test/"
+  ./Coverlet/coverlet Client.Linq.Test/bin/Debug/"$NET_VERSION"/Client.Linq.Test.dll --target "dotnet" --targetargs "test Client.Linq.Test/Client.Linq.Test.csproj --no-build  --logger trx" --format opencover --output "./Client.Linq.Test/"
+
+else
+  dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build  --logger trx
+  dotnet test Client.Test/Client.Test.csproj --no-build --logger trx
+  dotnet test Client.Linq.Test/Client.Linq.Test.csproj --no-build  --logger trx
+fi
 
 #
 # Convert test results to Junit format


### PR DESCRIPTION
## Proposed Changes

- added build for `dotnet5`
- fixed code coverage report: https://codecov.io/gh/influxdata/influxdb-client-csharp/branch/fix%2Fci-coverage

![image](https://user-images.githubusercontent.com/455137/112470773-59a5fe80-8d6b-11eb-870b-ead7d4f76ad9.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
