### PR TITLE
fix: propagate runtime exception to EventHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.18.0 [unreleased]
 
+### Bug Fixes
+1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler
+
 ## 1.17.0 [2021-04-01]
 
 ### Features
@@ -16,7 +19,6 @@
 1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
 1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fix domain structure for Flux AST
 1. [#181](https://github.com/influxdata/influxdb-client-csharp/pull/181): Remove download overhead for Queries
-1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler
 
 ### Dependencies
 1. [#175](https://github.com/influxdata/influxdb-client-csharp/pull/175): Update dependencies of `InfluxDB.Client`:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 1. [#168](https://github.com/influxdata/influxdb-client-csharp/pull/168): DateTime is always serialized into UTC
 1. [#169](https://github.com/influxdata/influxdb-client-csharp/pull/169): Fix domain structure for Flux AST
 1. [#181](https://github.com/influxdata/influxdb-client-csharp/pull/181): Remove download overhead for Queries
+1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler
 
 ### Dependencies
 1. [#175](https://github.com/influxdata/influxdb-client-csharp/pull/175): Update dependencies of `InfluxDB.Client`:

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -463,7 +463,7 @@ namespace InfluxDB.Client.Test
             var error = listener.Get<WriteRuntimeExceptionEvent>();
             
             Assert.IsNotNull(error);
-            Assert.AreEqual("Timestamps must be specified as UTC (Parameter 'timestamp')", error.Exception.Message);
+            StringAssert.StartsWith("Timestamps must be specified as UTC", error.Exception.Message);
             
             Assert.AreEqual(0, MockServer.LogEntries.Count());
         }

--- a/Client/README.md
+++ b/Client/README.md
@@ -352,9 +352,10 @@ For writing data we use [WriteApi](https://github.com/influxdata/influxdb-client
 1. writing data using [InfluxDB Line Protocol](https://docs.influxdata.com/influxdb/v1.6/write_protocols/line_protocol_tutorial/), Data Point, POCO 
 2. use batching for writes
 4. produces events that allow user to be notified and react to this events
-    - `WriteSuccessEvent` - published when arrived the success response from Platform server
-    - `WriteErrorEvent` - published when occurs a unhandled exception
-    - `WriteRetriableErrorEvent` - published when occurs a retriable error
+    - `WriteSuccessEvent` - published when arrived the success response from server
+    - `WriteErrorEvent` - published when occurs a unhandled exception from server
+    - `WriteRetriableErrorEvent` - published when occurs a retriable error from server
+    - `WriteRuntimeExceptionEvent` - published when occurs a runtime exception in background batch processing
 5. use GZIP compression for data
 
 The writes are processed in batches which are configurable by `WriteOptions`:

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -204,6 +204,7 @@ namespace InfluxDB.Client
                     },
                     exception =>
                     {
+                        Publish(new WriteRuntimeExceptionEvent(exception));
                         _disposed = true;
                         Trace.WriteLine($"The unhandled exception occurs: {exception}");
                     },

--- a/Client/Writes/Events.cs
+++ b/Client/Writes/Events.cs
@@ -72,6 +72,27 @@ namespace InfluxDB.Client.Writes
         }
     }
 
+    /// <summary>
+    /// Published when occurs a runtime exception in background batch processing.
+    /// </summary>
+    public class WriteRuntimeExceptionEvent : InfluxDBEventArgs
+    {
+        /// <summary>
+        /// The Runtime Exception that was throw.
+        /// </summary>
+        public Exception Exception { get; }
+
+        internal WriteRuntimeExceptionEvent(Exception exception)
+        {
+            Exception = exception;
+        }
+
+        internal override void LogEvent()
+        {
+            Trace.TraceError($"The unhandled exception occurs: {Exception}");
+        }
+    }
+
     public abstract class AbstractWriteEvent : InfluxDBEventArgs
     {
         /// <summary>


### PR DESCRIPTION
Closes #176 

## Proposed Changes

Propagate runtime exception to `EventHandler`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
