### PR TITLE
feat(linq): use `group()` function in output Flux query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#184](https://github.com/influxdata/influxdb-client-csharp/pull/184): Add possibility to specify `WebProxy` for Client
+1. [#185](https://github.com/influxdata/influxdb-client-csharp/pull/185): Use `group()` function in output Flux query. See details - [Group function](/Client.Linq/README.md#group-function) [LINQ]
 
 ### Bug Fixes
 1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler
@@ -42,7 +43,7 @@
 
 ### Bug Fixes
 1. [#154](https://github.com/influxdata/influxdb-client-csharp/pull/154): Always use `ConfigureAwait(false)` to avoid unnecessary context switching and potential dead-locks. Avoid unnecessary await overhead.
-1. [#158](https://github.com/influxdata/influxdb-client-csharp/pull/158): Remove Unnecesary dependencies: `System.Net.Http` and `Microsoft.Bcl.AsyncInterfaces`
+1. [#158](https://github.com/influxdata/influxdb-client-csharp/pull/158): Remove unnecessary dependencies: `System.Net.Http` and `Microsoft.Bcl.AsyncInterfaces`
 
 ### CI
 1. [#165](https://github.com/influxdata/influxdb-client-csharp/pull/165): Updated stable image to `influxdb:latest` and nightly to `quay.io/influxdb/influxdb:nightly`

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -26,7 +26,8 @@ namespace Client.Linq.Test
                                          "from(bucket: p1) " +
                                          "|> range(start: time(v: start_shifted)) " +
                                          "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                                         "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+                                         "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                         "|> group()";
 
         private QueryApiSync _queryApi;
 
@@ -414,7 +415,8 @@ namespace Client.Linq.Test
                                "from(bucket: p1) " +
                                $"|> {range} " +
                                "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                               "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+                               "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                               "|> group()";
 
                 Assert.AreEqual(expected, visitor.BuildFluxQuery(),
                     $"Expected Range: {range}, Shift: {shift}, Queryable expression: {queryable.Expression}");
@@ -446,7 +448,8 @@ namespace Client.Linq.Test
                                     "from(bucket: p1) " +
                                     "|> range(start: time(v: start_shifted), stop: time(v: stop_shifted)) " +
                                     "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                                    "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+                                    "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> group()";
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
             var ast = visitor.BuildFluxAST();
@@ -549,7 +552,8 @@ namespace Client.Linq.Test
                                     "|> range(start: time(v: start_shifted)) " +
                                     "|> filter(fn: (r) => (r[\"deployment\"] == p3)) " +
                                     "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                                    "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+                                    "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> group()";
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
 
@@ -678,6 +682,7 @@ namespace Client.Linq.Test
                                     "|> filter(fn: (r) => (r[\"sensor_id\"] == p3)) " +
                                     "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> group() " +
                                     "|> filter(fn: (r) => (r[\"data\"] > p4)) " +
                                     "|> sort(columns: [p7], desc: p8) " +
                                     "|> limit(n: p9, offset: p10)";

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -92,7 +92,7 @@ namespace Client.Linq.Test
 
             var sensors = query.ToList();
 
-            Assert.AreEqual(2*2, sensors.Count);
+            Assert.AreEqual(2, sensors.Count);
         }
 
         [Test]

--- a/Client.Linq.Test/QueryAggregatorTest.cs
+++ b/Client.Linq.Test/QueryAggregatorTest.cs
@@ -76,7 +76,8 @@ namespace Client.Linq.Test
                                "from(bucket: p1) " +
                                $"|> {range} " +
                                "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                               "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
+                               "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                               "|> group()";
 
                 Assert.AreEqual(expected, _aggregator.BuildFluxQuery(), $"Expected Range: {range}, Shift: {shift}");
             }

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -155,6 +155,7 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildFilter(_filterByTags),
                 "drop(columns: [\"_start\", \"_stop\", \"_measurement\"])",
                 "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+                "group()",
                 BuildFilter(_filterByFields)
             };
 

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -118,49 +118,35 @@ sensor,deployment=production,sensor_id=id-1 data=15
 sensor,deployment=testing,sensor_id=id-1 data=28
 ```
 
-and this is also way how following LINQ operators works.
+That is reason why the library have to use [group()](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/) function.
 
-### TD;LR
-
-- [series](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series)
-- [Flux](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#flux)
-- [Query data with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/)
-
-### Client Side Evaluation
-
-The library attempts to evaluate a query on the server as much as possible. 
-The client side evaluations is required for aggregation function if there is more then one time series.
-
-If you want to count your data with following Flux:
+The following query works correctly:
 
 ```flux
 from(bucket: "my-bucket")
   |> range(start: 0)
   |> drop(columns: ["_start", "_stop", "_measurement"])
   |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
-  |> stateCount(fn: (r) => true, column: "linq_result_column") 
-  |> last(column: "linq_result_column") 
-  |> keep(columns: ["linq_result_column"])
+  |> group()
+  |> limit(n:1)
 ```
 
-The result will be one count for each time-series:
-
-```csv
-#group,false,false,false
-#datatype,string,long,long
-#default,_result,,
-,result,table,linq_result_column
-,,0,1
-,,0,1
+and corresponding result:
 
 ```
+sensor,deployment=production,sensor_id=id-1 data=15
+```
 
-and client has to aggregate this multiple results into one scalar value.
+### Group does not guarantee sort order
 
-Operators that could cause client side evaluation:
+**The `group()` [does not guarantee sort order](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/#group-does-not-guarantee-sort-order) of output records. 
+To ensure data is sorted correctly, use `orderby` expression.
 
-- `Count`
-- `CountLong`
+### TD;LR
+
+- [series](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#series)
+- [Flux](https://docs.influxdata.com/influxdb/cloud/reference/glossary/#flux)
+- [Query data with Flux](https://docs.influxdata.com/influxdb/cloud/query-data/flux/)
 
 ## Perform Query
 
@@ -187,6 +173,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["sensor_id"] == "id-1")) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
     |> filter(fn: (r) => (r["data"] > 12)) 
     |> sort(columns: ["_time"], desc: false) 
     |> limit(n: 2, offset: 2)
@@ -239,6 +226,7 @@ from(bucket: "my-bucket")
     |> range(start: 2019-11-16T08:20:15ZZ) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Filter by Tag
@@ -258,6 +246,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["sensor_id"] == "id-1"))  
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Filter by Field
@@ -277,6 +266,7 @@ from(bucket: "my-bucket")
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> filter(fn: (r) => (r["data"] < 28))
+    |> group()
 ```
 
 If we move the `filter()` for **fields** before the `pivot()` then we will gets wrong results:
@@ -295,6 +285,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
 ```
 
 Results:
@@ -314,6 +305,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["_field"] == "f1" and r["_value"] > 0))
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
 ```
 Results:
 
@@ -351,6 +343,7 @@ from(bucket: "my-bucket")
     |> range(start: time(v: start_shifted), stop: 2021-01-10T05:10:00Z) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Example 2:
@@ -372,6 +365,7 @@ from(bucket: "my-bucket")
     |> range(start: 2019-11-16T08:20:15Z, stop: time(v: stop_shifted)) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Example 3:
@@ -390,6 +384,7 @@ from(bucket: "my-bucket")
     |> range(start: 2019-11-16T08:20:15ZZ) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Example 4:
@@ -410,6 +405,7 @@ from(bucket: "my-bucket")
     |> range(start: 0, stop: time(v: stop_shifted)) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 #### Example 5:
@@ -430,6 +426,7 @@ from(bucket: "my-bucket")
     |> range(start: 2019-11-16T08:20:15Z, stop: time(v: stop_shifted)) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 ### TD;LR
@@ -453,6 +450,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["sensor_id"] == "id-1"))  
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 ### Not Equal
@@ -470,6 +468,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["sensor_id"] != "id-1")) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> group()
 ```
 
 ### Less Than
@@ -486,6 +485,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["data"] < 28))
 ```
 
@@ -503,6 +503,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["data"] <= 28))
 ```
 
@@ -520,6 +521,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["data"] > 28))
 ```
 
@@ -537,6 +539,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["data"] >= 28))
 ```
 
@@ -555,6 +558,7 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => (r["sensor_id"] != "id-1"))
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["data"] >= 28))
 ```
 
@@ -572,6 +576,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => ((r["data"] >= 28) or (r["data"] <=> 28)))
 ```
 
@@ -768,6 +773,7 @@ from(bucket: "my-bucket")
     |> range(start: 0)
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> filter(fn: (r) => (r["attribute_quality"] == "good"))
 ```
 
@@ -788,6 +794,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> limit(n: 10)
 ```
 
@@ -807,6 +814,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> limit(n: 10, offset: 50)
 ```
 
@@ -826,6 +834,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> sort(columns: ["deployment"], desc: false)
 ```
 
@@ -843,6 +852,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> sort(columns: ["_time"], desc: true)
 ```
 
@@ -863,6 +873,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> stateCount(fn: (r) => true, column: "linq_result_column") 
     |> last(column: "linq_result_column") 
     |> keep(columns: ["linq_result_column"])
@@ -885,6 +896,7 @@ from(bucket: "my-bucket")
     |> range(start: 0) 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> group()
     |> stateCount(fn: (r) => true, column: "linq_result_column") 
     |> last(column: "linq_result_column") 
     |> keep(columns: ["linq_result_column"])

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -30,7 +30,8 @@ The library supports to use a LINQ expression to query the InfluxDB.
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 
 ## Changelog
-
+### 1.18.0 [unreleased]
+  - use `group()` function in output Flux query. See details - [Group function](#group-function)
 ### 1.17.0-dev.linq.17 [2021-03-18]
   - Optimize filtering by tag - [see more](#filtering)
   - rebased with `master` branch
@@ -118,7 +119,9 @@ sensor,deployment=production,sensor_id=id-1 data=15
 sensor,deployment=testing,sensor_id=id-1 data=28
 ```
 
-That is reason why the library have to use [group()](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/) function.
+### Group function
+
+That is reason why the library **have to use [group()](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/) function**.
 
 The following query works correctly:
 
@@ -137,9 +140,9 @@ and corresponding result:
 sensor,deployment=production,sensor_id=id-1 data=15
 ```
 
-### Group does not guarantee sort order
+#### Group does not guarantee sort order
 
-**The `group()` [does not guarantee sort order](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/#group-does-not-guarantee-sort-order) of output records. 
+The `group()` [does not guarantee sort order](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/group/#group-does-not-guarantee-sort-order) of output records. 
 To ensure data is sorted correctly, use `orderby` expression.
 
 ### TD;LR


### PR DESCRIPTION
## Proposed Changes

The LINQ driver always use `group()` function to achieve of producing only one output table.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
