### PR TITLE
feat: produce a typed HTTP exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#184](https://github.com/influxdata/influxdb-client-csharp/pull/184): Add possibility to specify `WebProxy` for Client
 1. [#185](https://github.com/influxdata/influxdb-client-csharp/pull/185): Use `group()` function in output Flux query. See details - [Group function](/Client.Linq/README.md#group-function) [LINQ]
+1. [#186](https://github.com/influxdata/influxdb-client-csharp/pull/186): Produce a typed HTTP exception
 
 ### Bug Fixes
 1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler

--- a/Client.Core.Test/AbstractMockServerTest.cs
+++ b/Client.Core.Test/AbstractMockServerTest.cs
@@ -38,11 +38,11 @@ namespace InfluxDB.Client.Core.Test
             MockServer?.Stop();
         }
 
-        protected IResponseBuilder CreateErrorResponse(string influxDbError)
+        protected IResponseBuilder CreateErrorResponse(string influxDbError, int statusCode = 500)
         {
             var body = "{\"error\":\"" + influxDbError + "\"}";
 
-            return Response.Create().WithStatusCode(500)
+            return Response.Create().WithStatusCode(statusCode)
                 .WithHeader("X-Influx-Error", influxDbError)
                 .WithBody(body);
         }

--- a/Client.Core.Test/HttpExceptionTest.cs
+++ b/Client.Core.Test/HttpExceptionTest.cs
@@ -1,0 +1,39 @@
+using System.Net;
+using InfluxDB.Client.Core.Exceptions;
+using NUnit.Framework;
+using RestSharp;
+
+namespace InfluxDB.Client.Core.Test
+{
+    [TestFixture]
+    public class HttpExceptionTest
+    {
+        [Test]
+        public void ExceptionTypes()
+        {
+            Assert.IsInstanceOf(typeof(BadRequestException), HttpException.Create(Response(400), ""));
+            Assert.IsInstanceOf(typeof(UnauthorizedException), HttpException.Create(Response(401), ""));
+            Assert.IsInstanceOf(typeof(PaymentRequiredException), HttpException.Create(Response(402), ""));
+            Assert.IsInstanceOf(typeof(ForbiddenException), HttpException.Create(Response(403), ""));
+            Assert.IsInstanceOf(typeof(NotFoundException), HttpException.Create(Response(404), ""));
+            Assert.IsInstanceOf(typeof(MethodNotAllowedException), HttpException.Create(Response(405), ""));
+            Assert.IsInstanceOf(typeof(NotAcceptableException), HttpException.Create(Response(406), ""));
+            Assert.IsInstanceOf(typeof(ProxyAuthenticationRequiredException), HttpException.Create(Response(407), ""));
+            Assert.IsInstanceOf(typeof(RequestTimeoutException), HttpException.Create(Response(408), ""));
+            Assert.IsInstanceOf(typeof(RequestEntityTooLargeException), HttpException.Create(Response(413), ""));
+            Assert.IsInstanceOf(typeof(UnprocessableEntityException), HttpException.Create(Response(422), ""));
+            Assert.IsInstanceOf(typeof(TooManyRequestsException), HttpException.Create(Response(429), ""));
+            Assert.IsInstanceOf(typeof(InternalServerErrorException), HttpException.Create(Response(500), ""));
+            Assert.IsInstanceOf(typeof(HttpNotImplementedException), HttpException.Create(Response(501), ""));
+            Assert.IsInstanceOf(typeof(BadGatewayException), HttpException.Create(Response(502), ""));
+            Assert.IsInstanceOf(typeof(ServiceUnavailableException), HttpException.Create(Response(503), ""));
+            Assert.IsInstanceOf(typeof(HttpException), HttpException.Create(Response(550), ""));
+            Assert.IsInstanceOf(typeof(HttpException), HttpException.Create(Response(390), ""));
+        }
+
+        private static HttpResponse Response(int statusCode)
+        {
+            return new HttpResponse {StatusCode = (HttpStatusCode) statusCode};
+        }
+    }
+}

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -126,8 +126,191 @@ namespace InfluxDB.Client.Core.Exceptions
             if (string.IsNullOrEmpty(errorMessage)) errorMessage = ErrorMessage;
             if (string.IsNullOrEmpty(errorMessage)) errorMessage = stringBody;
 
-            return new HttpException(errorMessage, (int) statusCode, exception)
-                {ErrorBody = errorBody, RetryAfter = retryAfter};
+            var err = (int) statusCode switch
+            {
+                400 => new BadRequestException(errorMessage, exception),
+                401 => new UnauthorizedException(errorMessage, exception),
+                402 => new PaymentRequiredException(errorMessage, exception),
+                403 => new ForbiddenException(errorMessage, exception),
+                404 => new NotFoundException(errorMessage, exception),
+                405 => new MethodNotAllowedException(errorMessage, exception),
+                406 => new NotAcceptableException(errorMessage, exception),
+                407 => new ProxyAuthenticationRequiredException(errorMessage, exception),
+                408 => new RequestTimeoutException(errorMessage, exception),
+                413 => new RequestEntityTooLargeException(errorMessage, exception),
+                422 => new UnprocessableEntityException(errorMessage, exception),
+                429 => new TooManyRequestsException(errorMessage, exception),
+                500 => new InternalServerErrorException(errorMessage, exception),
+                501 => new HttpNotImplementedException(errorMessage, exception),
+                502 => new BadGatewayException(errorMessage, exception),
+                503 => new ServiceUnavailableException(errorMessage, exception),
+                _ => new HttpException(errorMessage, (int) statusCode, exception)
+            };
+
+            err.ErrorBody = errorBody;
+            err.RetryAfter = retryAfter;
+
+            return err;
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 400 - Bad Request.
+    /// </summary>
+    public class BadRequestException : HttpException
+    {
+        public BadRequestException(string message, Exception exception = null) : base(message, 400, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 401 - Unauthorized.
+    /// </summary>
+    public class UnauthorizedException : HttpException
+    {
+        public UnauthorizedException(string message, Exception exception = null) : base(message, 401, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 402 - Payment Required.
+    /// </summary>
+    public class PaymentRequiredException : HttpException
+    {
+        public PaymentRequiredException(string message, Exception exception = null) : base(message, 402, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 403 - Forbidden.
+    /// </summary>
+    public class ForbiddenException : HttpException
+    {
+        public ForbiddenException(string message, Exception exception = null) : base(message, 403, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 404 - Not Found.
+    /// </summary>
+    public class NotFoundException : HttpException
+    {
+        public NotFoundException(string message, Exception exception = null) : base(message, 404, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 405 - Method Not Allowed.
+    /// </summary>
+    public class MethodNotAllowedException : HttpException
+    {
+        public MethodNotAllowedException(string message, Exception exception = null) : base(message, 405, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 406 - Not Acceptable.
+    /// </summary>
+    public class NotAcceptableException : HttpException
+    {
+        public NotAcceptableException(string message, Exception exception = null) : base(message, 406, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 407 - Proxy Authentication Required.
+    /// </summary>
+    public class ProxyAuthenticationRequiredException : HttpException
+    {
+        public ProxyAuthenticationRequiredException(string message, Exception exception = null) : base(message, 407, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 408 - Request Timeout.
+    /// </summary>
+    public class RequestTimeoutException : HttpException
+    {
+        public RequestTimeoutException(string message, Exception exception = null) : base(message, 408, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 413 - Request Entity Too Large.
+    /// </summary>
+    public class RequestEntityTooLargeException : HttpException
+    {
+        public RequestEntityTooLargeException(string message, Exception exception = null) : base(message, 413, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 422 - Unprocessable Entity.
+    /// </summary>
+    public class UnprocessableEntityException : HttpException
+    {
+        public UnprocessableEntityException(string message, Exception exception = null) : base(message, 422, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 429 - Too Many Requests.
+    /// </summary>
+    public class TooManyRequestsException : HttpException
+    {
+        public TooManyRequestsException(string message, Exception exception = null) : base(message, 429, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 500 - Internal Server Error.
+    /// </summary>
+    public class InternalServerErrorException : HttpException
+    {
+        public InternalServerErrorException(string message, Exception exception = null) : base(message, 500, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 501 - Not Implemented.
+    /// </summary>
+    public class HttpNotImplementedException : HttpException
+    {
+        public HttpNotImplementedException(string message, Exception exception = null) : base(message, 501, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 502 - Bad Gateway.
+    /// </summary>
+    public class BadGatewayException : HttpException
+    {
+        public BadGatewayException(string message, Exception exception = null) : base(message, 502, exception)
+        {
+        }
+    }
+
+    /// <summary>
+    /// The exception for response: HTTP 503 - Service Unavailable.
+    /// </summary>
+    public class ServiceUnavailableException : HttpException
+    {
+        public ServiceUnavailableException(string message, Exception exception = null) : base(message, 503, exception)
+        {
         }
     }
 }

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using InfluxDB.Client.Api.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
+using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Core.Test;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
@@ -221,6 +222,19 @@ namespace InfluxDB.Client.Test
             {
                 StringAssert.StartsWith(MockServerUrl + "/api/v2/", logEntry.RequestMessage.AbsoluteUrl);
             }
+        }
+        
+        [Test]
+        public void ProduceTypedException()
+        {
+            MockServer
+                .Given(Request.Create().UsingGet())
+                .RespondWith(CreateErrorResponse("unauthorized", 401));
+
+            var ioe = Assert.ThrowsAsync<UnauthorizedException>(async () =>
+                await _client.GetAuthorizationsApi().FindAuthorizationByIdAsync("id"));
+
+            Assert.AreEqual("unauthorized", ioe.Message);
         }
     }
 }

--- a/Client.Test/ItAuthorizationsApiTest.cs
+++ b/Client.Test/ItAuthorizationsApiTest.cs
@@ -136,7 +136,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindAuthorizationsByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _authorizationsApi.FindAuthorizationByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("authorization not found", ioe.Message);
@@ -154,7 +154,7 @@ namespace InfluxDB.Client.Test
             // delete authorization
             await _authorizationsApi.DeleteAuthorizationAsync(createdAuthorization);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _authorizationsApi.FindAuthorizationByIdAsync(createdAuthorization.Id));
 
             Assert.AreEqual("authorization not found", ioe.Message);
@@ -206,11 +206,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneAuthorizationNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _authorizationsApi.CloneAuthorizationAsync("020f755c3c082000"));
 
             Assert.AreEqual("authorization not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         private List<Permission> NewPermissions()

--- a/Client.Test/ItBucketsApiTest.cs
+++ b/Client.Test/ItBucketsApiTest.cs
@@ -65,7 +65,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneBucketNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _bucketsApi.CloneBucketAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.AreEqual("bucket not found", ioe.Message);
@@ -117,7 +117,7 @@ namespace InfluxDB.Client.Test
             // delete task
             await _bucketsApi.DeleteBucketAsync(createBucket);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _bucketsApi.FindBucketByIdAsync(createBucket.Id));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _bucketsApi.FindBucketByIdAsync(createBucket.Id));
 
             Assert.AreEqual("bucket not found", ioe.Message);
         }
@@ -142,7 +142,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindBucketByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _bucketsApi.FindBucketByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("bucket not found", ioe.Message);

--- a/Client.Test/ItChecksApiTest.cs
+++ b/Client.Test/ItChecksApiTest.cs
@@ -174,7 +174,7 @@ namespace InfluxDB.Client.Test
             var update = new CheckPatch(name: "not exits name", description: "not exists update",
                 status: CheckPatch.StatusEnum.Active);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _checksApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _checksApi
                 .UpdateCheckAsync("020f755c3c082000", update));
 
             Assert.AreEqual("check not found for key \"020f755c3c082000\"", ioe.Message);
@@ -198,7 +198,7 @@ namespace InfluxDB.Client.Test
 
             await _checksApi.DeleteCheckAsync(found);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _checksApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _checksApi
                 .FindCheckByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("check not found for key \"020f755c3c082000\"", ioe.Message);
@@ -207,7 +207,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void DeleteCheckNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _checksApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _checksApi
                 .DeleteCheckAsync("020f755c3c082000"));
 
             Assert.AreEqual("check not found for key \"020f755c3c082000\"", ioe.Message);
@@ -235,7 +235,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindCheckByIdNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _checksApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _checksApi
                 .FindCheckByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("check not found for key \"020f755c3c082000\"", ioe.Message);

--- a/Client.Test/ItInfluxDBClientTest.cs
+++ b/Client.Test/ItInfluxDBClientTest.cs
@@ -98,7 +98,7 @@ namespace InfluxDB.Client.Test
         {
             var onboarding = new OnboardingRequest("admin", "11111111", "Testing", "test");
 
-            var ex = Assert.ThrowsAsync<HttpException>(async () => await Client.OnboardingAsync(onboarding));
+            var ex = Assert.ThrowsAsync<UnprocessableEntityException>(async () => await Client.OnboardingAsync(onboarding));
 
             Assert.AreEqual("onboarding has already been completed", ex.Message);
             Assert.AreEqual(422, ex.Status);

--- a/Client.Test/ItLabelsApiTest.cs
+++ b/Client.Test/ItLabelsApiTest.cs
@@ -46,10 +46,10 @@ namespace InfluxDB.Client.Test
         public void CloneLabelNotFound()
         {
             var exception =
-                Assert.ThrowsAsync<HttpException>(async () => await _labelsApi.CloneLabelAsync(GenerateName("bucket"), "020f755c3c082000"));
+                Assert.ThrowsAsync<NotFoundException>(async () => await _labelsApi.CloneLabelAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.IsNotNull(exception);
-            Assert.AreEqual(typeof(HttpException), exception.GetType());
+            Assert.AreEqual(typeof(NotFoundException), exception.GetType());
             Assert.AreEqual("label not found", exception.Message);
         }
 
@@ -98,11 +98,11 @@ namespace InfluxDB.Client.Test
             // delete user
             await _labelsApi.DeleteLabelAsync(createdLabel);
 
-            var exception = Assert.ThrowsAsync<HttpException>(async () => await _labelsApi.FindLabelByIdAsync(createdLabel.Id));
+            var exception = Assert.ThrowsAsync<NotFoundException>(async () => await _labelsApi.FindLabelByIdAsync(createdLabel.Id));
 
             Assert.IsNotNull(exception);
             Assert.AreEqual("label not found", exception.Message);
-            Assert.AreEqual(typeof(HttpException), exception.GetType());
+            Assert.AreEqual(typeof(NotFoundException), exception.GetType());
         }
 
         [Test]
@@ -121,11 +121,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindLabelByIdNull()
         {
-            var exception = Assert.ThrowsAsync<HttpException>(async () => await _labelsApi.FindLabelByIdAsync("020f755c3c082000"));
+            var exception = Assert.ThrowsAsync<NotFoundException>(async () => await _labelsApi.FindLabelByIdAsync("020f755c3c082000"));
 
             Assert.IsNotNull(exception);
             Assert.AreEqual("label not found", exception.Message);
-            Assert.AreEqual(typeof(HttpException), exception.GetType());
+            Assert.AreEqual(typeof(NotFoundException), exception.GetType());
         }
 
         [Test]

--- a/Client.Test/ItNotificationEndpointsApiTest.cs
+++ b/Client.Test/ItNotificationEndpointsApiTest.cs
@@ -260,7 +260,7 @@ namespace InfluxDB.Client.Test
             var update = new NotificationEndpointUpdate("not exists name",
                 "not exists description", status: NotificationEndpointUpdate.StatusEnum.Active);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .UpdateEndpointAsync("020f755c3c082000", update));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
@@ -278,7 +278,7 @@ namespace InfluxDB.Client.Test
 
             await _notificationEndpointsApi.DeleteNotificationEndpointAsync(found);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .FindNotificationEndpointByIdAsync(found.Id));
 
             Assert.AreEqual($"notification endpoint not found for key \"{found.Id}\"", ioe.Message);
@@ -287,7 +287,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void DeleteEndpointNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .DeleteNotificationEndpointAsync("020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
@@ -309,7 +309,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindNotificationEndpointByIdNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .FindNotificationEndpointByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
@@ -428,27 +428,27 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .CloneSlackEndpointAsync("not-found-cloned", "token", "020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .ClonePagerDutyEndpointAsync("not-found-cloned", "token", "020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointAsync("not-found-cloned", "020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointBearerAsync("not-found-cloned", "token", "020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);
 
-            ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationEndpointsApi
+            ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationEndpointsApi
                 .CloneHttpEndpointBasicAuthAsync("not-found-cloned", "username", "password", "020f755c3c082000"));
 
             Assert.AreEqual("notification endpoint not found for key \"020f755c3c082000\"", ioe.Message);

--- a/Client.Test/ItNotificationRulesApiTest.cs
+++ b/Client.Test/ItNotificationRulesApiTest.cs
@@ -218,7 +218,7 @@ namespace InfluxDB.Client.Test
             var update = new NotificationRuleUpdate(name: "not exists name", description: "not exists update",
                 status: NotificationRuleUpdate.StatusEnum.Active);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationRulesApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationRulesApi
                 .UpdateNotificationRuleAsync("020f755c3c082000", update));
 
             Assert.AreEqual("notification rule not found", ioe.Message);
@@ -242,7 +242,7 @@ namespace InfluxDB.Client.Test
 
             await _notificationRulesApi.DeleteNotificationRuleAsync(created);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationRulesApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationRulesApi
                 .FindNotificationRuleByIdAsync(created.Id));
 
             Assert.AreEqual("notification rule not found", ioe.Message);
@@ -251,7 +251,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void DeleteRuleNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationRulesApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationRulesApi
                 .DeleteNotificationRuleAsync("020f755c3c082000"));
 
             Assert.AreEqual("notification rule not found", ioe.Message);
@@ -282,7 +282,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindRuleByIdNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _notificationRulesApi
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _notificationRulesApi
                 .FindNotificationRuleByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("notification rule not found", ioe.Message);

--- a/Client.Test/ItOrganizationsApiTest.cs
+++ b/Client.Test/ItOrganizationsApiTest.cs
@@ -36,11 +36,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneOrganizationNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _organizationsApi.CloneOrganizationAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.AreEqual("organization not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         [Test]
@@ -82,7 +82,7 @@ namespace InfluxDB.Client.Test
             // delete task
             await _organizationsApi.DeleteOrganizationAsync(createdOrganization);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _organizationsApi.FindOrganizationByIdAsync(createdOrganization.Id));
 
             Assert.AreEqual("organization not found", ioe.Message);
@@ -116,7 +116,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindOrganizationByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _organizationsApi.FindOrganizationByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("organization not found", ioe.Message);

--- a/Client.Test/ItScraperTargetsApiTest.cs
+++ b/Client.Test/ItScraperTargetsApiTest.cs
@@ -55,11 +55,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneScraperNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _scraperTargetsApi.CloneScraperTargetAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.AreEqual("scraper target is not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         [Test]
@@ -96,7 +96,7 @@ namespace InfluxDB.Client.Test
             // delete scraper
             await _scraperTargetsApi.DeleteScraperTargetAsync(createdScraper);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _scraperTargetsApi.FindScraperTargetByIdAsync(createdScraper.Id));
 
             Assert.AreEqual("scraper target is not found", ioe.Message);
@@ -119,7 +119,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindScraperByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _scraperTargetsApi.FindScraperTargetByIdAsync("020f755c3c082000"));
 
             Assert.AreEqual("scraper target is not found", ioe.Message);

--- a/Client.Test/ItSourcesApiTest.cs
+++ b/Client.Test/ItSourcesApiTest.cs
@@ -58,11 +58,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneSourceNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _sourcesApi.CloneSourceAsync(GenerateName("bucket"), "020f755c3d082000"));
 
             Assert.AreEqual("source not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         [Test]
@@ -116,7 +116,7 @@ namespace InfluxDB.Client.Test
             // delete source
             await _sourcesApi.DeleteSourceAsync(createdSource);
 
-            var nfe = Assert.ThrowsAsync<HttpException>(async () =>
+            var nfe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _sourcesApi.FindSourceByIdAsync(createdSource.Id));
 
             Assert.IsNotNull(nfe);
@@ -137,12 +137,12 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindBucketsBySourceByUnknownSource()
         {
-            var nfe = Assert.ThrowsAsync<HttpException>(async () =>
+            var nfe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _sourcesApi.FindBucketsBySourceIdAsync("020f755c3d082000"));
 
             Assert.IsNotNull(nfe);
             Assert.AreEqual("source not found", nfe.Message);
-            Assert.AreEqual(typeof(HttpException), nfe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), nfe.GetType());
         }
 
         [Test]
@@ -164,7 +164,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindSourceByIdNull()
         {
-            var nfe = Assert.ThrowsAsync<HttpException>(
+            var nfe = Assert.ThrowsAsync<NotFoundException>(
                 async () => await _sourcesApi.FindSourceByIdAsync("020f755c3d082000"));
 
             Assert.IsNotNull(nfe);

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -80,7 +80,7 @@ namespace InfluxDB.Client.Test
             var runs = await _tasksApi.GetRunsAsync(task, null, null, null);
             Assert.IsNotEmpty(runs);
 
-            var message = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.CancelRunAsync(runs.First()))
+            var message = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.CancelRunAsync(runs.First()))
                 .Message;
 
             Assert.AreEqual("failed to cancel run: run not found", message);
@@ -89,7 +89,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CancelRunTaskNotExist()
         {
-            var message = Assert.ThrowsAsync<HttpException>(async () =>
+            var message = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.CancelRunAsync("020f755c3c082000", "020f755c3c082000")).Message;
 
             Assert.AreEqual("failed to cancel run: task not found", message);
@@ -123,7 +123,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneTaskNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.CloneTaskAsync("020f755c3c082000"));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.CloneTaskAsync("020f755c3c082000"));
 
             Assert.AreEqual("failed to find task: task not found", ioe.Message);
         }
@@ -213,7 +213,7 @@ namespace InfluxDB.Client.Test
 
             await _tasksApi.DeleteTaskAsync(task);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.FindTaskByIdAsync(task.Id));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.FindTaskByIdAsync(task.Id));
 
             Assert.AreEqual("failed to find task: task not found", ioe.Message);
         }
@@ -242,7 +242,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindTaskByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.FindTaskByIdAsync("020f755c3d082000"));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.FindTaskByIdAsync("020f755c3d082000"));
 
             Assert.AreEqual("failed to find task: task not found", ioe.Message);
         }
@@ -330,7 +330,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void GetLogsNotExist()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.GetLogsAsync("020f755c3c082000"));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.GetLogsAsync("020f755c3c082000"));
 
             Assert.NotNull(ioe, "ioe.InnerException != null");
             Assert.AreEqual("failed to find task logs: task not found", ioe.Message);
@@ -371,7 +371,7 @@ namespace InfluxDB.Client.Test
         {
             var task = await _tasksApi.CreateTaskEveryAsync(GenerateName("it task"), TaskFlux, "1s", _organization);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _tasksApi.GetRunLogsAsync(task.Id, "020f755c3c082000"));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.GetRunLogsAsync(task.Id, "020f755c3c082000"));
 
             Assert.NotNull(ioe, "ioe.InnerException != null");
             Assert.AreEqual("failed to find task logs: run not found", ioe.Message);
@@ -494,7 +494,7 @@ namespace InfluxDB.Client.Test
         {
             var task = await _tasksApi.CreateTaskEveryAsync(GenerateName("it task"), TaskFlux, "1s", _organization);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.RetryRunAsync(task.Id, "020f755c3c082000"));
 
             Assert.AreEqual("failed to retry run: run not found", ioe.Message);
@@ -505,7 +505,7 @@ namespace InfluxDB.Client.Test
         {
             var task = await _tasksApi.CreateTaskEveryAsync(GenerateName("it task"), TaskFlux, "1s", _organization);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.GetRunAsync(task.Id, "020f755c3c082000"));
 
             Assert.AreEqual("failed to find run: run not found", ioe.Message);
@@ -569,7 +569,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void RunsNotExist()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.GetRunsAsync("020f755c3c082000", _organization.Id));
 
             Assert.NotNull(ioe, "ioe.InnerException != null");

--- a/Client.Test/ItTelegrafsApiTest.cs
+++ b/Client.Test/ItTelegrafsApiTest.cs
@@ -81,10 +81,10 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneTelegrafNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _telegrafsApi.CloneTelegrafAsync(GenerateName("tc"), "020f755c3c082000"));
 
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
             Assert.AreEqual("telegraf configuration not found", ioe.Message);
         }
 
@@ -151,17 +151,17 @@ namespace InfluxDB.Client.Test
             // delete source
             await _telegrafsApi.DeleteTelegrafAsync(createdConfig);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _telegrafsApi.FindTelegrafByIdAsync(createdConfig.Id));
 
             Assert.AreEqual("telegraf configuration not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         [Test]
         public void DeleteTelegrafNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _telegrafsApi.DeleteTelegrafAsync("020f755c3d082000"));
 
             Assert.AreEqual("telegraf configuration not found", ioe.Message);
@@ -192,11 +192,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindTelegrafByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _telegrafsApi.FindTelegrafByIdAsync("020f755c3d082000"));
 
             Assert.AreEqual("telegraf configuration not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
 
         [Test]
@@ -249,7 +249,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void GetTomlNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _telegrafsApi.GetTOMLAsync("020f755c3d082000"));
 
             Assert.AreEqual("telegraf configuration not found", ioe.Message);

--- a/Client.Test/ItUsersApiTest.cs
+++ b/Client.Test/ItUsersApiTest.cs
@@ -49,7 +49,7 @@ namespace InfluxDB.Client.Test
             // delete user
             await _usersApi.DeleteUserAsync(createdUser);
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _usersApi.FindUserByIdAsync(createdUser.Id));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _usersApi.FindUserByIdAsync(createdUser.Id));
             Assert.IsNotNull(ioe);
             Assert.AreEqual("user not found", ioe.Message);
         }
@@ -71,7 +71,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void FindUserByIdNull()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _usersApi.FindUserByIdAsync("020f755c3c082000"));
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _usersApi.FindUserByIdAsync("020f755c3c082000"));
 
             Assert.IsNotNull(ioe);
             Assert.AreEqual("user not found", ioe.Message);
@@ -103,7 +103,7 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () => await _usersApi.MeAsync());
+            var ioe = Assert.ThrowsAsync<UnauthorizedException>(async () => await _usersApi.MeAsync());
 
             Assert.IsNotNull(ioe);
             Assert.AreEqual("unauthorized access", ioe.Message);
@@ -122,12 +122,12 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<UnauthorizedException>(async () =>
                 await _usersApi.MeUpdatePasswordAsync("my-password-wrong", "my-password"));
 
             Assert.IsNotNull(ioe);
             Assert.AreEqual("unauthorized access", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(UnauthorizedException), ioe.GetType());
         }
 
         [Test]
@@ -159,7 +159,7 @@ namespace InfluxDB.Client.Test
 
             Assert.IsNotNull(ioe);
             Assert.AreEqual("user not found", ioe.InnerException.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.InnerException.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.InnerException.GetType());
         }
 
         [Test]
@@ -191,11 +191,11 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CloneUserNotFound()
         {
-            var ioe = Assert.ThrowsAsync<HttpException>(async () =>
+            var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _usersApi.CloneUserAsync(GenerateName("bucket"), "020f755c3c082000"));
 
             Assert.AreEqual("user not found", ioe.Message);
-            Assert.AreEqual(typeof(HttpException), ioe.GetType());
+            Assert.AreEqual(typeof(NotFoundException), ioe.GetType());
         }
     }
 }

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -187,7 +187,7 @@ namespace InfluxDB.Client.Test
             var error = listener.Get<WriteErrorEvent>();
 
             Assert.IsNotNull(error);
-            Assert.AreEqual(typeof(HttpException), error.Exception.GetType());
+            Assert.AreEqual(typeof(BadRequestException), error.Exception.GetType());
             Assert.AreEqual("line protocol poorly formed and no points were written", error.Exception.Message);
             Assert.AreEqual(400, ((HttpException) error.Exception).Status);
 
@@ -208,11 +208,11 @@ namespace InfluxDB.Client.Test
             error = listener.Get<WriteErrorEvent>();
 
             Assert.IsNotNull(error);
-            Assert.AreEqual(typeof(HttpException), error.Exception.GetType());
+            Assert.AreEqual(typeof(UnauthorizedException), error.Exception.GetType());
             Assert.AreEqual(
                 "token does not have sufficient permissions to write to this organization and bucket or the organization and bucket do not exist",
                 error.Exception.Message);
-            Assert.AreEqual(401, ((HttpException) error.Exception).Status);
+            Assert.AreEqual(401, ((UnauthorizedException) error.Exception).Status);
 
             //
             // 403
@@ -229,9 +229,9 @@ namespace InfluxDB.Client.Test
             error = listener.Get<WriteErrorEvent>();
 
             Assert.IsNotNull(error);
-            Assert.AreEqual(typeof(HttpException), error.Exception.GetType());
+            Assert.AreEqual(typeof(ForbiddenException), error.Exception.GetType());
             Assert.AreEqual("no token was sent and they are required", error.Exception.Message);
-            Assert.AreEqual(403, ((HttpException) error.Exception).Status);
+            Assert.AreEqual(403, ((ForbiddenException) error.Exception).Status);
 
             //
             // 413
@@ -250,11 +250,11 @@ namespace InfluxDB.Client.Test
             error = listener.Get<WriteErrorEvent>();
 
             Assert.IsNotNull(error);
-            Assert.AreEqual(typeof(HttpException), error.Exception.GetType());
+            Assert.AreEqual(typeof(RequestEntityTooLargeException), error.Exception.GetType());
             Assert.AreEqual(
                 "write has been rejected because the payload is too large. Error message returns max size supported. All data in body was rejected and not written",
                 error.Exception.Message);
-            Assert.AreEqual(413, ((HttpException) error.Exception).Status);
+            Assert.AreEqual(413, ((RequestEntityTooLargeException) error.Exception).Status);
         }
 
         [Test]


### PR DESCRIPTION
Closes #114

## Proposed Changes

The client produce concrete exception e.g. `UnauthorizedException` instead of generic `HttpException`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
