### PR TITLE
feat(linq): switch pivot() and drop() function to achieve better perf

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ jobs:
           command: /c/influxdata/influxdb-1.8.0-1/influxd.exe -config "Scripts/influxdb.conf"
           background: true
       - run: dotnet nuget locals --clear all
-      - run: dotnet restore --no-cache --force
+      - run: dotnet restore --no-cache --force -s https://api.nuget.org/v3/index.json
       - run: dotnet build
       - run: dotnet test Client.Legacy.Test/Client.Legacy.Test.csproj --no-build
       

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#184](https://github.com/influxdata/influxdb-client-csharp/pull/184): Add possibility to specify `WebProxy` for Client
 1. [#185](https://github.com/influxdata/influxdb-client-csharp/pull/185): Use `group()` function in output Flux query. See details - [Group function](/Client.Linq/README.md#group-function) [LINQ]
 1. [#186](https://github.com/influxdata/influxdb-client-csharp/pull/186): Produce a typed HTTP exception
+1. [#???](https://github.com/influxdata/influxdb-client-csharp/pull/???): Switch `pivot()` and `drop()` function to achieve better performance
 
 ### Bug Fixes
 1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 1. [#184](https://github.com/influxdata/influxdb-client-csharp/pull/184): Add possibility to specify `WebProxy` for Client
 1. [#185](https://github.com/influxdata/influxdb-client-csharp/pull/185): Use `group()` function in output Flux query. See details - [Group function](/Client.Linq/README.md#group-function) [LINQ]
 1. [#186](https://github.com/influxdata/influxdb-client-csharp/pull/186): Produce a typed HTTP exception
-1. [#???](https://github.com/influxdata/influxdb-client-csharp/pull/???): Switch `pivot()` and `drop()` function to achieve better performance
+1. [#188](https://github.com/influxdata/influxdb-client-csharp/pull/188): Switch `pivot()` and `drop()` function to achieve better performance
 
 ### Bug Fixes
 1. [#183](https://github.com/influxdata/influxdb-client-csharp/pull/183): Propagate runtime exception to EventHandler

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -25,8 +25,8 @@ namespace Client.Linq.Test
         private const string FluxStart = "start_shifted = int(v: time(v: p2))\n\n" +
                                          "from(bucket: p1) " +
                                          "|> range(start: time(v: start_shifted)) " +
-                                         "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                          "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                         "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                          "|> group()";
 
         private QueryApiSync _queryApi;
@@ -414,8 +414,8 @@ namespace Client.Linq.Test
                 var expected = shift + 
                                "from(bucket: p1) " +
                                $"|> {range} " +
-                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                "|> group()";
 
                 Assert.AreEqual(expected, visitor.BuildFluxQuery(),
@@ -447,8 +447,8 @@ namespace Client.Linq.Test
                                     "stop_shifted = int(v: time(v: p4)) + 1\n\n" +
                                     "from(bucket: p1) " +
                                     "|> range(start: time(v: start_shifted), stop: time(v: stop_shifted)) " +
-                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> group()";
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
@@ -551,8 +551,8 @@ namespace Client.Linq.Test
                                     "from(bucket: p1) " +
                                     "|> range(start: time(v: start_shifted)) " +
                                     "|> filter(fn: (r) => (r[\"deployment\"] == p3)) " +
-                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> group()";
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
@@ -680,8 +680,8 @@ namespace Client.Linq.Test
                                     "from(bucket: p1) " +
                                     "|> range(start: time(v: start_shifted), stop: time(v: stop_shifted)) " +
                                     "|> filter(fn: (r) => (r[\"sensor_id\"] == p3)) " +
-                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                     "|> group() " +
                                     "|> filter(fn: (r) => (r[\"data\"] > p4)) " +
                                     "|> sort(columns: [p7], desc: p8) " +

--- a/Client.Linq.Test/QueryAggregatorTest.cs
+++ b/Client.Linq.Test/QueryAggregatorTest.cs
@@ -75,8 +75,8 @@ namespace Client.Linq.Test
                 var expected = shift +
                                "from(bucket: p1) " +
                                $"|> {range} " +
-                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
                                "|> group()";
 
                 Assert.AreEqual(expected, _aggregator.BuildFluxQuery(), $"Expected Range: {range}, Shift: {shift}");

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -153,8 +153,8 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildOperator("from", "bucket", _bucketAssignment),
                 BuildRange(transforms),
                 BuildFilter(_filterByTags),
-                "drop(columns: [\"_start\", \"_stop\", \"_measurement\"])",
                 "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
+                "drop(columns: [\"_start\", \"_stop\", \"_measurement\"])",
                 "group()",
                 BuildFilter(_filterByFields)
             };

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -31,7 +31,7 @@ The library supports to use a LINQ expression to query the InfluxDB.
 
 ## Changelog
 ### 1.18.0-dev.???? [????-??-??]
-- switch `pivot()` and `drop()` function to achieve better performance. See details - [#???](https://github.com/influxdata/influxdb-client-csharp/pull/???)
+  - switch `pivot()` and `drop()` function to achieve better performance. See details - [#188](https://github.com/influxdata/influxdb-client-csharp/pull/188)
 ### 1.18.0-dev.2880 [2021-04-12]
   - use `group()` function in output Flux query. See details - [Group function](#group-function)
 ### 1.17.0-dev.linq.17 [2021-03-18]

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -107,8 +107,8 @@ If you query your data with following Flux:
 ```flux
 from(bucket: "my-bucket")
   |> range(start: 0)
-  |> drop(columns: ["_start", "_stop", "_measurement"])
   |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+  |> drop(columns: ["_start", "_stop", "_measurement"])
   |> limit(n:1)
 ```
 
@@ -128,8 +128,8 @@ The following query works correctly:
 ```flux
 from(bucket: "my-bucket")
   |> range(start: 0)
-  |> drop(columns: ["_start", "_stop", "_measurement"])
   |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+  |> drop(columns: ["_start", "_stop", "_measurement"])
   |> group()
   |> limit(n:1)
 ```
@@ -174,8 +174,8 @@ Flux Query:
 from(bucket: "my-bucket") 
     |> range(start: 2019-11-16T08:20:15Z, stop: 2021-01-10T05:10:00Z) 
     |> filter(fn: (r) => (r["sensor_id"] == "id-1")) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["data"] > 12)) 
     |> sort(columns: ["_time"], desc: false) 
@@ -227,8 +227,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 2019-11-16T08:20:15ZZ) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -247,8 +247,8 @@ Flux Query:
 from(bucket: "my-bucket") 
     |> range(start: 0)
     |> filter(fn: (r) => (r["sensor_id"] == "id-1"))  
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -265,9 +265,9 @@ var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org",
 Flux Query:
 ```flux
 from(bucket: "my-bucket") 
-    |> range(start: 0) 
+    |> range(start: 0)
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")  
     |> drop(columns: ["_start", "_stop", "_measurement"])
-    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> filter(fn: (r) => (r["data"] < 28))
     |> group()
 ```
@@ -285,9 +285,9 @@ m1 f1=3,f2=4 2
 
 ```flux
 from(bucket: "my-bucket") 
-    |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
+    |> range(start: 0)
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -306,8 +306,8 @@ Results:
 from(bucket: "my-bucket") 
     |> range(start: 0) 
     |> filter(fn: (r) => (r["_field"] == "f1" and r["_value"] > 0))
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 Results:
@@ -343,9 +343,9 @@ Flux Query:
 start_shifted = int(v: time(v: "2019-11-16T08:20:15Z")) + 1
 
 from(bucket: "my-bucket") 
-    |> range(start: time(v: start_shifted), stop: 2021-01-10T05:10:00Z) 
+    |> range(start: time(v: start_shifted), stop: 2021-01-10T05:10:00Z)
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> drop(columns: ["_start", "_stop", "_measurement"])
-    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
     |> group()
 ```
 
@@ -366,8 +366,8 @@ stop_shifted = int(v: time(v: "2021-01-10T05:10:00Z")) + 1
 
 from(bucket: "my-bucket") 
     |> range(start: 2019-11-16T08:20:15Z, stop: time(v: stop_shifted)) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -385,8 +385,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 2019-11-16T08:20:15ZZ) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -405,9 +405,9 @@ Flux Query:
 stop_shifted = int(v: time(v: "2021-01-10T05:10:00Z")) + 1
 
 from(bucket: "my-bucket") 
-    |> range(start: 0, stop: time(v: stop_shifted)) 
+    |> range(start: 0, stop: time(v: stop_shifted))
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> drop(columns: ["_start", "_stop", "_measurement"])
-    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
     |> group()
 ```
 
@@ -427,8 +427,8 @@ stop_shifted = int(v: time(v: "2019-11-16T08:20:15Z")) + 1
 
 from(bucket: "my-bucket") 
     |> range(start: 2019-11-16T08:20:15Z, stop: time(v: stop_shifted)) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -451,8 +451,8 @@ Flux Query:
 from(bucket: "my-bucket") 
     |> range(start: 0)
     |> filter(fn: (r) => (r["sensor_id"] == "id-1"))  
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -469,8 +469,8 @@ Flux Query:
 from(bucket: "my-bucket") 
     |> range(start: 0)
     |> filter(fn: (r) => (r["sensor_id"] != "id-1")) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
 ```
 
@@ -486,8 +486,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["data"] < 28))
 ```
@@ -504,8 +504,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["data"] <= 28))
 ```
@@ -522,8 +522,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
     |> drop(columns: ["_start", "_stop", "_measurement"])
-    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> group()
     |> filter(fn: (r) => (r["data"] > 28))
 ```
@@ -540,8 +540,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["data"] >= 28))
 ```
@@ -559,8 +559,8 @@ Flux Query:
 from(bucket: "my-bucket") 
     |> range(start: 0) 
     |> filter(fn: (r) => (r["sensor_id"] != "id-1"))
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["data"] >= 28))
 ```
@@ -577,8 +577,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => ((r["data"] >= 28) or (r["data"] <=> 28)))
 ```
@@ -774,8 +774,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket")
     |> range(start: 0)
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> filter(fn: (r) => (r["attribute_quality"] == "good"))
 ```
@@ -795,8 +795,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> limit(n: 10)
 ```
@@ -815,8 +815,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> limit(n: 10, offset: 50)
 ```
@@ -835,8 +835,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> sort(columns: ["deployment"], desc: false)
 ```
@@ -853,8 +853,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> sort(columns: ["_time"], desc: true)
 ```
@@ -874,8 +874,8 @@ Flux Query:
 ```flux
 from(bucket: "my-bucket") 
     |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> stateCount(fn: (r) => true, column: "linq_result_column") 
     |> last(column: "linq_result_column") 
@@ -896,9 +896,9 @@ var sensors = query.LongCount();
 Flux Query:
 ```flux
 from(bucket: "my-bucket") 
-    |> range(start: 0) 
-    |> drop(columns: ["_start", "_stop", "_measurement"])
+    |> range(start: 0)
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
     |> group()
     |> stateCount(fn: (r) => true, column: "linq_result_column") 
     |> last(column: "linq_result_column") 

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -30,6 +30,8 @@ The library supports to use a LINQ expression to query the InfluxDB.
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 
 ## Changelog
+### 1.18.0-dev.???? [????-??-??]
+- switch `pivot()` and `drop()` function to achieve better performance. See details - [#???](https://github.com/influxdata/influxdb-client-csharp/pull/???)
 ### 1.18.0-dev.2880 [2021-04-12]
   - use `group()` function in output Flux query. See details - [Group function](#group-function)
 ### 1.17.0-dev.linq.17 [2021-03-18]


### PR DESCRIPTION
## Proposed Changes

The `pivot()` and `drop()` function was switch to achieve better performance - https://github.com/influxdata/EAR/issues/2182

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
