### PR TITLE
feat(write): add possibility to handle HTTP response from InfluxDB server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.19.0 [unreleased]
 
+### Features
+1. [#194](https://github.com/influxdata/influxdb-client-csharp/pull/194): Add possibility to handle HTTP response from InfluxDB server [write]
+
 ### Bug Fixes
 1. [#193](https://github.com/influxdata/influxdb-client-csharp/pull/193): Create services without API implementation
 

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -8,6 +8,7 @@ using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Writes;
+using RestSharp;
 
 namespace InfluxDB.Client
 {
@@ -17,6 +18,9 @@ namespace InfluxDB.Client
         private readonly InfluxDBClientOptions _options;
         private readonly WriteService _service;
         private readonly IDomainObjectMapper _mapper;
+        private const string PostHeaderAccept = "application/json";
+        private const string PostHeaderEncoding = "identity";
+        private const string PostHeaderContentType = "text/plain; charset=utf-8";
 
         protected internal WriteApiAsync(InfluxDBClientOptions options, WriteService service,
             IDomainObjectMapper mapper,
@@ -167,6 +171,28 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
+        /// Write Line Protocols records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="bucket">specifies the destination bucket for writes.
+        /// If the bucket is not specified than is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes.
+        /// If the org is not specified than is used config from <see cref="InfluxDBClientOptions.Org" />.
+        /// </param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <returns>Write Task with IRestResponse</returns>
+        public Task<IRestResponse> WriteRecordsAsyncWithIRestResponse(IEnumerable<string> records, string bucket = null,
+            string org = null, WritePrecision precision = WritePrecision.Ns,
+            CancellationToken cancellationToken = default)
+        {
+            var batch = records
+                .Select(it => new BatchWriteRecord(new BatchWriteOptions(bucket, org, precision), it));
+
+            return WriteDataAsyncWithIRestResponse(batch, bucket, org, precision, cancellationToken);
+        }
+
+        /// <summary>
         /// Write a Data point into specified bucket.
         /// </summary>
         /// <param name="point">specifies the Data point to write into bucket</param>
@@ -275,6 +301,34 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes.
+        /// If the bucket is not specified than is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes.
+        /// If the org is not specified than is used config from <see cref="InfluxDBClientOptions.Org" />.
+        /// </param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <returns>Write Tasks with IRestResponses.</returns>
+        public Task<IRestResponse[]> WritePointsAsyncWithIRestResponse(IEnumerable<PointData> points,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default)
+        {
+            var tasks = new List<Task<IRestResponse>>();
+            foreach (var grouped in points.GroupBy(it => it.Precision))
+            {
+                var options = new BatchWriteOptions(bucket, org, grouped.Key);
+                var groupedPoints = grouped
+                    .Select(it => new BatchWritePoint(options, _options, it))
+                    .ToList();
+
+                tasks.Add(WriteDataAsyncWithIRestResponse(groupedPoints, bucket, org, grouped.Key, cancellationToken));
+            }
+
+            return Task.WhenAll(tasks);
+        }
+
+        /// <summary>
         /// Write a Measurement into specified bucket.
         /// </summary>
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
@@ -340,10 +394,9 @@ namespace InfluxDB.Client
             
             var list = new List<BatchWriteData>();
 
+            var options = new BatchWriteOptions(bucket, org, precision);
             foreach (var measurement in measurements)
             {
-                var options = new BatchWriteOptions(bucket, org, precision);
-
                 BatchWriteData data = new BatchWriteMeasurement<TM>(options, _options, measurement, _mapper);
                 list.Add(data);
             }
@@ -414,12 +467,69 @@ namespace InfluxDB.Client
 
             return WriteMeasurementsAsync(bucket, org, precision, measurements.ToList(), cancellationToken);
         }
+        
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes.
+        /// If the bucket is not specified than is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes.
+        /// If the org is not specified than is used config from <see cref="InfluxDBClientOptions.Org" />.
+        /// </param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        /// <returns>Write Task with IRestResponse</returns>
+        public Task<IRestResponse> WriteMeasurementsAsyncWithIRestResponse<TM>(IEnumerable<TM> measurements, string bucket = null,
+            string org = null, WritePrecision precision = WritePrecision.Ns,
+            CancellationToken cancellationToken = default)
+        {
+            
+            var options = new BatchWriteOptions(bucket, org, precision);
+            var batch = measurements
+                .Select(it => new BatchWriteMeasurement<TM>(options, _options, it, _mapper));
+
+            return WriteDataAsyncWithIRestResponse(batch, bucket, org, precision, cancellationToken);
+        }
+
 
         private Task WriteData(string org, string bucket, WritePrecision precision, IEnumerable<BatchWriteData> data, 
             CancellationToken cancellationToken)
         {
-            var sb = new StringBuilder("");
+            var sb = ToLineProtocolBody(data);
+            if (sb.Length == 0)
+            {
+                Trace.WriteLine($"The writes: {data} doesn't contains any Line Protocol, skipping");
+                return Task.CompletedTask;
+            }
+
+            return _service.PostWriteAsync(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null,
+                PostHeaderEncoding, PostHeaderContentType, null, PostHeaderAccept, null, precision,
+                cancellationToken);
+        }
+
+        private Task<IRestResponse> WriteDataAsyncWithIRestResponse(IEnumerable<BatchWriteData> batch,string bucket = null, string org = null,
+            WritePrecision precision = WritePrecision.Ns, CancellationToken cancellationToken = default)
+        {
+            var localBucket = bucket ?? _options.Bucket;
+            var localOrg = org ?? _options.Org;
             
+            Arguments.CheckNonEmptyString(localBucket, nameof(bucket));
+            Arguments.CheckNonEmptyString(localOrg, nameof(org));
+            Arguments.CheckNotNull(precision, nameof(precision));
+            
+            var sb = ToLineProtocolBody(batch);
+
+            return _service.PostWriteAsyncWithIRestResponse(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null,
+                PostHeaderEncoding, PostHeaderContentType, null, PostHeaderAccept, null, precision,
+                cancellationToken);
+        }
+
+        private static StringBuilder ToLineProtocolBody(IEnumerable<BatchWriteData> data)
+        {
+            var sb = new StringBuilder("");
+
             foreach (var item in data)
             {
                 var lineProtocol = item.ToLineProtocol();
@@ -428,23 +538,18 @@ namespace InfluxDB.Client
                 {
                     continue;
                 }
-                
+
                 sb.Append(lineProtocol);
                 sb.Append("\n");
             }
-            
-            if (sb.Length == 0)
-            {
-                Trace.WriteLine($"The writes: {data} doesn't contains any Line Protocol, skipping");
-                return Task.CompletedTask;
-            }
-            
-            // remove last \n
-            sb.Remove(sb.Length - 1, 1);
 
-            return _service.PostWriteAsync(org, bucket, Encoding.UTF8.GetBytes(sb.ToString()), null , 
-                            "identity", "text/plain; charset=utf-8", null, "application/json", null, precision, 
-                            cancellationToken);
+            if (sb.Length != 0)
+            {
+                // remove last \n
+                sb.Remove(sb.Length - 1, 1);
+            }
+
+            return sb;
         }
     }
 }


### PR DESCRIPTION
Closes #107
Closes #109

## Proposed Changes

Added possibility to handle HTTP response from InfluxDB server when user uses `WriteApiAsync`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
