### PR TITLE
feat(linq): optimize Flux Query for querying one time-series

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#194](https://github.com/influxdata/influxdb-client-csharp/pull/194): Add possibility to handle HTTP response from InfluxDB server [write]
+1. [#197](https://github.com/influxdata/influxdb-client-csharp/pull/197): Optimize Flux Query for querying one time-series [LINQ]
 
 ### Bug Fixes
 1. [#193](https://github.com/influxdata/influxdb-client-csharp/pull/193): Create services without API implementation

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -92,6 +92,18 @@ namespace Client.Linq.Test
 
             var sensors = query.ToList();
 
+            Assert.AreEqual(2*2, sensors.Count);
+        }
+
+        [Test]
+        public void QueryTakeMultipleTimeSeries()
+        {
+            var query = (from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApiSync(),
+                    new QueryableOptimizerSettings {QueryMultipleTimeSeries = true})
+                select s).Take(2);
+
+            var sensors = query.ToList();
+
             Assert.AreEqual(2, sensors.Count);
         }
 

--- a/Client.Linq.Test/QueryAggregatorTest.cs
+++ b/Client.Linq.Test/QueryAggregatorTest.cs
@@ -1,4 +1,5 @@
 using InfluxDB.Client.Core.Test;
+using InfluxDB.Client.Linq;
 using InfluxDB.Client.Linq.Internal;
 using NUnit.Framework;
 
@@ -76,10 +77,10 @@ namespace Client.Linq.Test
                                "from(bucket: p1) " +
                                $"|> {range} " +
                                "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
-                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"]) " +
-                               "|> group()";
+                               "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])";
 
-                Assert.AreEqual(expected, _aggregator.BuildFluxQuery(), $"Expected Range: {range}, Shift: {shift}");
+                var settings = new QueryableOptimizerSettings();
+                Assert.AreEqual(expected, _aggregator.BuildFluxQuery(settings), $"Expected Range: {range}, Shift: {shift}");
             }
         }
     }

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -9,6 +9,27 @@ using Remotion.Linq.Parsing.Structure;
 namespace InfluxDB.Client.Linq
 {
     /// <summary>
+    /// The settings for a Query optimization.
+    /// </summary>
+    public class QueryableOptimizerSettings
+    {
+        public QueryableOptimizerSettings()
+        {
+            QueryMultipleTimeSeries = false;
+        }
+        
+        /// <summary>
+        /// Gets or sets whether the drive is used to query multiple time series.
+        /// Setting this variable to true will change how the produced Flux Query looks like:
+        /// <list type="bullet">
+        /// <item>appends <a href="http://stackoverflow.com">group operator</a></item>
+        /// <item>enable use default sorting: <i>sort(columns: ["_time"], desc: false)</i></item>
+        /// </list>
+        /// </summary>
+        public bool QueryMultipleTimeSeries { get; set; }
+    }
+
+    /// <summary>
     /// Main entry point to query InfluxDB by LINQ
     /// </summary>
     public class InfluxDBQueryable<T> : QueryableBase<T>
@@ -19,12 +40,14 @@ namespace InfluxDB.Client.Linq
         /// <param name="bucket">Specifies the source bucket.</param>
         /// <param name="org">Specifies the source organization.</param>
         /// <param name="queryApi">The underlying API to execute Flux Query.</param>
+        /// <param name="queryableOptimizerSettings">Settings for a Query optimization</param>
         /// <returns>new instance for of Queryable</returns>
-        public static InfluxDBQueryable<T> Queryable(string bucket, string org, QueryApiSync queryApi)
+        public static InfluxDBQueryable<T> Queryable(string bucket, string org, QueryApiSync queryApi,
+            QueryableOptimizerSettings queryableOptimizerSettings = default)
         {
-            return Queryable(bucket, org, queryApi, new DefaultMemberNameResolver());
+            return Queryable(bucket, org, queryApi, new DefaultMemberNameResolver(), queryableOptimizerSettings);
         }
-        
+
         /// <summary>
         /// Create a new instance of IQueryable.
         /// </summary>
@@ -32,12 +55,14 @@ namespace InfluxDB.Client.Linq
         /// <param name="org">Specifies the source organization.</param>
         /// <param name="queryApi">The underlying API to execute Flux Query.</param>
         /// <param name="memberResolver">Resolver for customized names.</param>
+        /// <param name="queryableOptimizerSettings">Settings for a Query optimization</param>
         /// <returns>new instance for of Queryable</returns>
-        public static InfluxDBQueryable<T> Queryable(string bucket, string org, QueryApiSync queryApi, IMemberNameResolver memberResolver)
+        public static InfluxDBQueryable<T> Queryable(string bucket, string org, QueryApiSync queryApi,
+            IMemberNameResolver memberResolver, QueryableOptimizerSettings queryableOptimizerSettings = default)
         {
-            return new InfluxDBQueryable<T>(bucket, org, queryApi, memberResolver);
+            return new InfluxDBQueryable<T>(bucket, org, queryApi, memberResolver, queryableOptimizerSettings);
         }
-        
+
         /// <summary>
         /// Create a new instance of IQueryable.
         /// </summary>
@@ -45,8 +70,10 @@ namespace InfluxDB.Client.Linq
         /// <param name="org">Specifies the source organization.</param>
         /// <param name="queryApi">The underlying API to execute Flux Query.</param>
         /// <param name="memberResolver">Resolver for customized names.</param>
-        public InfluxDBQueryable(string bucket, string org, QueryApiSync queryApi, IMemberNameResolver memberResolver) : base(CreateQueryParser(),
-            CreateExecutor(bucket, org, queryApi, memberResolver))
+        /// <param name="queryableOptimizerSettings">Settings for a Query optimization</param>
+        public InfluxDBQueryable(string bucket, string org, QueryApiSync queryApi, IMemberNameResolver memberResolver,
+            QueryableOptimizerSettings queryableOptimizerSettings = default) : base(CreateQueryParser(),
+            CreateExecutor(bucket, org, queryApi, memberResolver, queryableOptimizerSettings))
         {
         }
 
@@ -77,13 +104,15 @@ namespace InfluxDB.Client.Linq
             return generateQuery;
         }
 
-        private static IQueryExecutor CreateExecutor(string bucket, string org, QueryApiSync queryApi, IMemberNameResolver memberResolver)
+        private static IQueryExecutor CreateExecutor(string bucket, string org, QueryApiSync queryApi,
+            IMemberNameResolver memberResolver, QueryableOptimizerSettings queryableOptimizerSettings = default)
         {
             Arguments.CheckNonEmptyString(bucket, nameof(bucket));
             Arguments.CheckNonEmptyString(org, nameof(org));
             Arguments.CheckNotNull(queryApi, nameof(queryApi));
-                
-            return new InfluxDBQueryExecutor(bucket, org, queryApi, memberResolver);
+
+            return new InfluxDBQueryExecutor(bucket, org, queryApi, memberResolver,
+                queryableOptimizerSettings ?? new QueryableOptimizerSettings());
         }
 
         private static QueryParser CreateQueryParser()

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -22,7 +22,7 @@ namespace InfluxDB.Client.Linq
         /// Gets or sets whether the drive is used to query multiple time series.
         /// Setting this variable to true will change how the produced Flux Query looks like:
         /// <list type="bullet">
-        /// <item>appends <a href="http://stackoverflow.com">group operator</a></item>
+        /// <item>appends <a href="https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/group/">group operator</a></item>
         /// <item>enable use default sorting: <i>sort(columns: ["_time"], desc: false)</i></item>
         /// </list>
         /// </summary>

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -64,7 +64,7 @@ namespace InfluxDB.Client.Linq.Internal
         private ResultFunction _resultFunction;
         private readonly List<string> _filterByTags;
         private readonly List<string> _filterByFields;
-        private readonly List<(string, string)> _orders;
+        private readonly List<(string, string, bool, string)> _orders;
 
         internal QueryAggregator()
         {
@@ -72,7 +72,7 @@ namespace InfluxDB.Client.Linq.Internal
             _limitNOffsetAssignments = new List<LimitOffsetAssignment>();
             _filterByTags = new List<string>();
             _filterByFields = new List<string>();
-            _orders = new List<(string, string)>();
+            _orders = new List<(string, string, bool, string)>();
         }
 
         internal void AddBucket(string bucket)
@@ -133,9 +133,9 @@ namespace InfluxDB.Client.Linq.Internal
             _orders.AddRange(aggregator._orders);
         }
 
-        internal void AddOrder(string orderPart, string desc)
+        internal void AddOrder(string column, string columnVariable, bool descending, string descendingVariable)
         {
-            _orders.Add((orderPart, desc));
+            _orders.Add((column, columnVariable, descending, descendingVariable));
         }
 
         internal void AddResultFunction(ResultFunction resultFunction)
@@ -145,8 +145,10 @@ namespace InfluxDB.Client.Linq.Internal
             _resultFunction = resultFunction;
         }
 
-        internal string BuildFluxQuery()
+        internal string BuildFluxQuery(QueryableOptimizerSettings settings)
         {
+            Arguments.CheckNotNull(settings, nameof(settings));
+            
             var transforms = new List<string>();
             var parts = new List<string>
             {
@@ -155,14 +157,20 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildFilter(_filterByTags),
                 "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")",
                 "drop(columns: [\"_start\", \"_stop\", \"_measurement\"])",
-                "group()",
+                settings.QueryMultipleTimeSeries ? "group()" : "",
                 BuildFilter(_filterByFields)
             };
 
             // https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/sort/
-            foreach (var (column, desc) in _orders)
+            foreach (var (column, columnVariable, descending, descendingVariable) in _orders)
             {
-                parts.Add(BuildOperator("sort", "columns", new List<string> {column}, "desc", desc));
+                // skip default sorting if don't query to multiple time series
+                if (!settings.QueryMultipleTimeSeries && _orders.Count == 1 && column == "_time" && !descending)
+                {
+                    continue;
+                }
+                
+                parts.Add(BuildOperator("sort", "columns", new List<string> {columnVariable}, "desc", descendingVariable));
             }
 
             // https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/limit/

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -162,10 +162,10 @@ namespace InfluxDB.Client.Linq.Internal
             };
 
             // https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/sort/
-            foreach (var (column, columnVariable, descending, descendingVariable) in _orders)
+            foreach (var ((column, columnVariable, descending, descendingVariable), index) in _orders.Select((value, i) => (value, i)))
             {
                 // skip default sorting if don't query to multiple time series
-                if (!settings.QueryMultipleTimeSeries && _orders.Count == 1 && column == "_time" && !descending)
+                if (!settings.QueryMultipleTimeSeries && index == 0 && column == "_time" && !descending)
                 {
                     continue;
                 }

--- a/Client.Linq/Internal/QueryGenerationContext.cs
+++ b/Client.Linq/Internal/QueryGenerationContext.cs
@@ -5,18 +5,23 @@ namespace InfluxDB.Client.Linq.Internal
         internal readonly QueryAggregator QueryAggregator;
         internal readonly IMemberNameResolver MemberResolver;
         internal readonly VariableAggregator Variables;
+        internal readonly QueryableOptimizerSettings QueryableOptimizerSettings;
 
-        internal QueryGenerationContext(QueryAggregator queryAggregator, VariableAggregator variableAggregator,
-            IMemberNameResolver memberResolver)
+        internal QueryGenerationContext(
+            QueryAggregator queryAggregator, 
+            VariableAggregator variableAggregator,
+            IMemberNameResolver memberResolver, 
+            QueryableOptimizerSettings queryableOptimizerSettings)
         {
             QueryAggregator = queryAggregator;
             Variables = variableAggregator;
             MemberResolver = memberResolver;
+            QueryableOptimizerSettings = queryableOptimizerSettings;
         }
 
         internal QueryGenerationContext Clone(QueryAggregator queryAggregator)
         {
-            return new QueryGenerationContext(queryAggregator, Variables, MemberResolver);
+            return new QueryGenerationContext(queryAggregator, Variables, MemberResolver, QueryableOptimizerSettings);
         }
     }
 }

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -32,6 +32,8 @@ The library supports to use a LINQ expression to query the InfluxDB.
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 
 ## Changelog
+### 1.19.0-dev.???? [2021-05-??]
+  - optimize Flux Query for querying one time-series. See details - [#197](https://github.com/influxdata/influxdb-client-csharp/pull/197)
 ### 1.18.0-dev.2973 [2021-04-27]
   - switch `pivot()` and `drop()` function to achieve better performance. See details - [#188](https://github.com/influxdata/influxdb-client-csharp/pull/188)
 ### 1.18.0-dev.2880 [2021-04-12]
@@ -123,9 +125,11 @@ sensor,deployment=production,sensor_id=id-1 data=15
 sensor,deployment=testing,sensor_id=id-1 data=28
 ```
 
-and this is also way how this LINQ driver works. **The driver supposes that you are querying over one time-series.** 
+and this is also way how this LINQ driver works. 
 
-There is a way how to change this configuration - see following section.
+**The driver supposes that you are querying over one time-series.** 
+
+There is a way how to change this configuration:
 
 ### Enable querying multiple time-series
 
@@ -154,7 +158,7 @@ and corresponding result:
 sensor,deployment=production,sensor_id=id-1 data=15
 ```
 
-Do not used this functionality if it is not required because it brings a performance costs caused by sorting: 
+Do not used this functionality if it is not required because **it brings a performance** costs caused by sorting: 
 
 #### Group does not guarantee sort order
 


### PR DESCRIPTION
Closes #196 

## Proposed Changes

The LINQ driver produces Flux Query optimized for querying one time series.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
