### PR TITLE
fix(linq): Flux AST for Tag parameters which are not `String`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bug Fixes
 1. [#193](https://github.com/influxdata/influxdb-client-csharp/pull/193): Create services without API implementation
+1. [#202](https://github.com/influxdata/influxdb-client-csharp/pull/202): Flux AST for Tag parameters which are not `String` [LINQ]
 
 ## 1.18.0 [2021-04-30]
 

--- a/Client.Linq.Test/DomainObjects.cs
+++ b/Client.Linq.Test/DomainObjects.cs
@@ -53,4 +53,20 @@ namespace Client.Linq.Test
         public string Name { get; set; }
         public string Value { get; set; }
     }
+    
+    [Measurement(nameof(TagIsNotDefinedAsString))]
+    class TagIsNotDefinedAsString
+    {
+        [Column(IsTag = true)]
+        public int Id { get; set; }
+
+        [Column(IsTag = true)]
+        public string Tag { get; set; }
+
+        [Column(nameof(Energy))]
+        public decimal Energy { get; set; }
+
+        [Column(IsTimestamp = true)]
+        public DateTime Timestamp { get; set; }
+    }
 }

--- a/Client.Linq/Internal/Expressions/AssignmentValue.cs
+++ b/Client.Linq/Internal/Expressions/AssignmentValue.cs
@@ -5,16 +5,16 @@ namespace InfluxDB.Client.Linq.Internal.Expressions
     internal class AssignmentValue: IExpressionPart
     {
         internal readonly object Value;
-        private readonly string _assignment;
+        internal readonly string Assignment;
         internal AssignmentValue(object value, string assignment)
         {
             Value = value;
-            _assignment = assignment;
+            Assignment = assignment;
         }
 
         public void AppendFlux(StringBuilder builder)
         {
-            builder.Append(_assignment);
+            builder.Append(Assignment);
         }
     }
 }

--- a/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
+++ b/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
@@ -268,7 +268,6 @@ namespace InfluxDB.Client.Linq.Internal
             }
         }
 
-
         /// <summary>
         /// Normalize generated expression.
         /// </summary>

--- a/Client.Linq/Internal/QueryVisitor.cs
+++ b/Client.Linq/Internal/QueryVisitor.cs
@@ -109,6 +109,7 @@ namespace InfluxDB.Client.Linq.Internal
             
             QueryExpressionTreeVisitor.NormalizeExpressions(rangeFilter);
             QueryExpressionTreeVisitor.NormalizeExpressions(tagFilter);
+            QueryExpressionTreeVisitor.NormalizeTagsAssignments(tagFilter, _context);
             QueryExpressionTreeVisitor.NormalizeExpressions(fieldFilter);
             
             Debug.WriteLine("--- normalized LINQ expressions: ---");

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -32,6 +32,8 @@ The library supports to use a LINQ expression to query the InfluxDB.
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 
 ## Changelog
+### 1.19.0-dev.??? [???]
+  - Fix Flux AST for Tag parameters which are not `String`. See details - [#202](https://github.com/influxdata/influxdb-client-csharp/pull/202)
 ### 1.19.0-dev.3084 [2021-05-07]
   - optimize Flux Query for querying one time-series. See details - [#197](https://github.com/influxdata/influxdb-client-csharp/pull/197)
 ### 1.18.0-dev.2973 [2021-04-27]

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -141,7 +141,13 @@ namespace InfluxDB.Client.Api.Domain
             /// Enum Dbrp for value: dbrp
             /// </summary>
             [EnumMember(Value = "dbrp")]
-            Dbrp = 18
+            Dbrp = 18,
+
+            /// <summary>
+            /// Enum Notebooks for value: notebooks
+            /// </summary>
+            [EnumMember(Value = "notebooks")]
+            Notebooks = 19
 
         }
 


### PR DESCRIPTION
Closes #201 

## Proposed Changes

Create correct Flux AST if property type of Entity is `tag` and isn't `string`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
