### PR TITLE
chore: update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,14 @@ This release introduces a support for new InfluxDB OSS API definitions - [oss.ym
 ### API
 1. [#206](https://github.com/influxdata/influxdb-client-csharp/pull/206): Use InfluxDB OSS API definitions to generated APIs
 
+### Dependencies
+1. [#209](https://github.com/influxdata/influxdb-client-csharp/pull/209): Update dependencies:
+    - CsvHelper to 27.1.0
+    - Newtonsoft.Json 13.0.1
+    - NodaTime to 3.0.5
+    - NodaTime.Serialization.JsonNet to 3.0.0
+    - Microsoft.Extensions.ObjectPool to 5.0.7
+
 ## 1.19.0 [2021-06-04]
 
 ### Features

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -32,10 +32,10 @@
     </ItemGroup>
     
     <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="18.0.0" />
-      <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-      <PackageReference Include="NodaTime" Version="2.4.1" />
-      <PackageReference Include="NodaTime.Serialization.JsonNet" Version="2.0.0" />
+      <PackageReference Include="CsvHelper" Version="27.1.0" />
+      <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+      <PackageReference Include="NodaTime" Version="3.0.5" />
+      <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
       <PackageReference Include="RestSharp" Version="106.11.7" />
     </ItemGroup>
 

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -186,7 +186,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
             }
             else if (AnnotationGroup.Equals(token))
             {
-                state.groups = state.csv.Context.Record;
+                state.groups = state.csv.Parser.Record;
             }
             else if (AnnotationDefault.Equals(token))
             {
@@ -306,7 +306,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
             Arguments.CheckNotNull(table, "table");
             Arguments.CheckNotNull(dataTypes, "dataTypes");
 
-            for (var index = 1; index < dataTypes.Context.Record.Length; index++)
+            for (var index = 1; index < dataTypes.Parser.Record.Length; index++)
             {
                 var dataType = dataTypes[index];
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -34,7 +34,7 @@
 
     <ItemGroup>
         <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.4" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="5.0.7" />
         <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
         <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="5.0.0" />


### PR DESCRIPTION
Closes #208

## Proposed Changes

Update dependencies:

    - CsvHelper to 27.1.0
    - Newtonsoft.Json 13.0.1
    - NodaTime to 3.0.5
    - NodaTime.Serialization.JsonNet to 3.0.0
    - Microsoft.Extensions.ObjectPool to 5.0.7

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
