### PR TITLE
fix: parsing infinite numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.1.0 [unreleased]
 
+### Bug Fixes
+1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing Infinite numbers into `Double`
+
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:
     - RestSharp to 106.12.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2.1.0 [unreleased]
 
 ### Bug Fixes
-1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing Infinite numbers into `Double`
+1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing infinite numbers
 
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:

--- a/Client.Core/Flux/Exceptions/FluxCsvParserException.cs
+++ b/Client.Core/Flux/Exceptions/FluxCsvParserException.cs
@@ -1,3 +1,4 @@
+using System;
 using InfluxDB.Client.Core.Exceptions;
 using InfluxDB.Client.Core.Flux.Domain;
 
@@ -9,6 +10,10 @@ namespace InfluxDB.Client.Core.Flux.Exceptions
     public class FluxCsvParserException : InfluxException
     {
         public FluxCsvParserException(string message) : base(message)
+        {
+        }
+
+        public FluxCsvParserException(string message, Exception exception = null) : base(message, exception)
         {
         }
     }

--- a/Client.Core/Flux/Internal/FluxCsvParser.cs
+++ b/Client.Core/Flux/Internal/FluxCsvParser.cs
@@ -209,9 +209,9 @@ namespace InfluxDB.Client.Core.Flux.Internal
                 {
                     currentId = Convert.ToInt32(state.csv[1 + 1]);
                 }
-                catch (Exception)
+                catch (Exception e)
                 {
-                    throw new FluxCsvParserException("Unable to parse CSV response.");
+                    throw new FluxCsvParserException("Unable to parse CSV response.", e);
                 }
                 if (state.tableId == -1)
                 {
@@ -273,7 +273,12 @@ namespace InfluxDB.Client.Core.Flux.Internal
                     case "long":
                         return Convert.ToInt64(strValue);
                     case "double":
-                        return Convert.ToDouble(strValue, CultureInfo.InvariantCulture);
+                        return strValue switch
+                        {
+                            "+Inf" => double.PositiveInfinity,
+                            "-Inf" => double.NegativeInfinity,
+                            _ => Convert.ToDouble(strValue, CultureInfo.InvariantCulture)
+                        };
                     case "base64Binary":
                         return Convert.FromBase64String(strValue);
                     case "dateTime:RFC3339":
@@ -285,9 +290,9 @@ namespace InfluxDB.Client.Core.Flux.Internal
                         return strValue;
                 }
             }
-            catch (Exception)
+            catch (Exception e)
             {
-                throw new FluxCsvParserException("Unable to parse CSV response.");
+                throw new FluxCsvParserException("Unable to parse CSV response.", e);
             }
         }
 

--- a/Client.Legacy.Test/FluxCsvParserTest.cs
+++ b/Client.Legacy.Test/FluxCsvParserTest.cs
@@ -705,6 +705,35 @@ namespace Client.Legacy.Test
             }
         }
 
+        [Test]
+        public void ParseInfinite()
+        {
+            const string data = @"#group,false,false,true,true,true,true,true,true,true,true,false,false
+#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,double
+#default,_result,,,,,,,,,,,
+,result,table,_start,_stop,_field,_measurement,language,license,name,owner,le,_value
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,0,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,10,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,20,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,30,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,40,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,50,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,60,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,70,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,80,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,90,0
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,+Inf,15
+,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,-Inf,15
+
+";
+            
+            var tables = ParseFluxResponse(data);
+            Assert.AreEqual(1, tables.Count);
+            Assert.AreEqual(12, tables[0].Records.Count);
+            Assert.AreEqual(double.PositiveInfinity, tables[0].Records[10].GetValueByKey("le"));
+            Assert.AreEqual(double.NegativeInfinity, tables[0].Records[11].GetValueByKey("le"));
+        }
+
         private List<FluxTable> ParseFluxResponse(string data)
         {
             var consumer = new FluxCsvParser.FluxResponseConsumerTable();


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/239

## Proposed Changes

Fixed parsing `Inf+` for [histogram() function](https://docs.influxdata.com/influxdb/v2.0/reference/flux/stdlib/built-in/transformations/histogram/).

#### Response example
```csv
#group,false,false,true,true,true,true,true,true,true,true,false,false
#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,string,string,double,double
#default,_result,,,,,,,,,,,
,result,table,_start,_stop,_field,_measurement,language,license,name,owner,le,_value
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,0,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,10,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,20,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,30,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,40,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,50,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,60,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,70,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,80,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,90,0
,,0,2021-06-23T06:50:11.897825012Z,2021-06-25T06:50:11.897825012Z,stars,github_repository,C#,MIT License,influxdb-client-csharp,influxdata,+Inf,15
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
