### PR TITLE
fix: cookie handling in normal requests and signout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing infinite numbers
-2. (https://github.com/influxdata/influxdb-client-csharp/pull/229): Fixed cookie handling in session mode
+2. [#229](https://github.com/influxdata/influxdb-client-csharp/pull/229): Fix cookie handling in session mode
 
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing infinite numbers
+2. (https://github.com/influxdata/influxdb-client-csharp/pull/229): Fixed cookie handling in session mode
 
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -148,7 +149,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual("1h", task.Every);
             Assert.AreEqual("testing task", task.Description);
             Assert.IsNull(task.Cron);
-            Assert.IsTrue(task.Flux.Equals(flux, StringComparison.OrdinalIgnoreCase));
+            Assert.That(task.Flux, Is.EqualTo(flux).IgnoreCase);
         }
 
         [Test]
@@ -599,7 +600,10 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(TaskStatusType.Inactive, updatedTask.Status);
             Assert.AreEqual("3m", updatedTask.Every);
             Assert.IsNull(updatedTask.Cron);
-            Assert.AreEqual(updatedTask.Flux, flux);
+            Assert.AreEqual(0, CultureInfo.CurrentCulture.CompareInfo.Compare(
+                updatedTask.Flux, flux, CompareOptions.IgnoreSymbols),
+                $"Queries are not same: '{updatedTask.Flux}', '{flux}'.");
+
             Assert.IsNotNull(updatedTask.UpdatedAt);
         }
     }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -64,7 +64,7 @@ namespace InfluxDB.Client.Api.Client
             {
                 InitToken();
 
-                if (_sessionToken != null) request.AddHeader("Cookie", "session=" + new string(_sessionToken));
+                if (_sessionToken != null) request.AddCookie("session", new string(_sessionToken)); 
             }
             
             _loggingHandler.BeforeIntercept(request);
@@ -125,9 +125,12 @@ namespace InfluxDB.Client.Api.Client
             }
 
             _signout = true;
+
+            var signOutSessionToken = _sessionToken;
             _sessionToken = null;
 
             var request = new RestRequest("/api/v2/signout", Method.POST);
+            if (signOutSessionToken != null) request.AddCookie("session", new string(signOutSessionToken)); 
             RestClient.Execute(request);
         }
     }


### PR DESCRIPTION
Closes #

## Proposed Changes

I changed the way the session cookie is set in the request because the way it was done before didn't work (the "Cookie" header is overwritten somewhere).

I also added the session cookie to the signout-Request as it was missing there.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

[x] Rebased/mergeable
[x] dotnet test completes successfully
[x] Commit messages are in semantic format
[x] Sign CLA (if not already signed)