### PR TITLE
feat: add CancellationToken to QueryApi

### DIFF
--- a/Client.Core/Internal/DefaultCancellable.cs
+++ b/Client.Core/Internal/DefaultCancellable.cs
@@ -1,17 +1,26 @@
+using System.Threading;
+
 namespace InfluxDB.Client.Core.Internal
 {
     public class DefaultCancellable : ICancellable
     {
         private bool _wasCancelled;
+        internal readonly CancellationTokenSource CancellationToken;
+
+        public DefaultCancellable(CancellationToken cancellationToken = default)
+        {
+            CancellationToken = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        }
 
         public void Cancel()
         {
             _wasCancelled = true;
+            CancellationToken.Cancel();
         }
 
         public bool IsCancelled()
         {
-            return _wasCancelled;
+            return _wasCancelled || CancellationToken.IsCancellationRequested;
         }
     }
 }

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -45,83 +45,87 @@ namespace InfluxDB.Client
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to <see cref="FluxTable"/>s.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception})"/>
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception}, CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public Task<List<FluxTable>> QueryAsync(string query)
+        public Task<List<FluxTable>> QueryAsync(string query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryAsync(query, _options.Org);
+            return QueryAsync(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to <see cref="FluxTable"/>s.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception})"/>
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception}, CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public Task<List<FluxTable>> QueryAsync(string query, string org)
+        public Task<List<FluxTable>> QueryAsync(string query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryAsync(CreateQuery(query, DefaultDialect), org);
+            return QueryAsync(CreateQuery(query, DefaultDialect), org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to <see cref="FluxTable"/>s.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception})"/>
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception}, CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public Task<List<FluxTable>> QueryAsync(Query query)
+        public Task<List<FluxTable>> QueryAsync(Query query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryAsync(query, _options.Org);
+            return QueryAsync(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to <see cref="FluxTable"/>s.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception})"/>
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception}, CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>FluxTables that are matched the query</returns>
-        public async Task<List<FluxTable>> QueryAsync(Query query, string org)
+        public async Task<List<FluxTable>> QueryAsync(Query query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
             var consumer = new FluxCsvParser.FluxResponseConsumerTable();
 
-            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
+            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction, cancellationToken).ConfigureAwait(false);
 
             return consumer.Tables;
         }
@@ -129,43 +133,45 @@ namespace InfluxDB.Client
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to list of object with given type.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public Task<List<T>> QueryAsync<T>(string query)
+        public Task<List<T>> QueryAsync<T>(string query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryAsync<T>(query, _options.Org);
+            return QueryAsync<T>(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to list of object with given type.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public Task<List<T>> QueryAsync<T>(string query, string org)
+        public Task<List<T>> QueryAsync<T>(string query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryAsync<T>(CreateQuery(query), org);
+            return QueryAsync<T>(CreateQuery(query), org, cancellationToken);
         }
 
         /// <summary>
@@ -209,38 +215,40 @@ namespace InfluxDB.Client
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to list of object with given type.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public Task<List<T>> QueryAsync<T>(Query query)
+        public Task<List<T>> QueryAsync<T>(Query query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryAsync<T>(query, _options.Org);
+            return QueryAsync<T>(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
         /// to list of object with given type.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryAsync{T}(string,string,System.Action{InfluxDB.Client.Core.ICancellable,T},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
-        public async Task<List<T>> QueryAsync<T>(Query query, string org)
+        public async Task<List<T>> QueryAsync<T>(Query query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -249,7 +257,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>((cancellable, poco) => { measurements.Add(poco); }, Mapper);
 
-            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
+            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction, cancellationToken).ConfigureAwait(false);
 
             return measurements;
         }
@@ -261,13 +269,14 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
-        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext, cancellationToken);
         }
 
         /// <summary>
@@ -278,13 +287,14 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
-        public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -294,13 +304,14 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
-        public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext, cancellationToken);
         }
 
         /// <summary>
@@ -311,13 +322,14 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
-        public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext)
+        public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -327,14 +339,15 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext, cancellationToken);
         }
 
         /// <summary>
@@ -345,14 +358,15 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -362,14 +376,15 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, _options.Org, onNext);
+            return QueryAsync(query, _options.Org, onNext, cancellationToken);
         }
 
         /// <summary>
@@ -380,14 +395,15 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
-        public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext)
+        public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
 
-            return QueryAsync(query, org, onNext, ErrorConsumer);
+            return QueryAsync(query, org, onNext, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -397,15 +413,16 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError, cancellationToken);
         }
 
         /// <summary>
@@ -416,15 +433,16 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -434,15 +452,16 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError, cancellationToken);
         }
 
         /// <summary>
@@ -453,15 +472,16 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken"></param>
         /// <returns>async task</returns>
         public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -472,16 +492,17 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError, cancellationToken);
         }
 
         /// <summary>
@@ -493,16 +514,17 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -513,16 +535,17 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, _options.Org, onNext, onError);
+            return QueryAsync(query, _options.Org, onNext, onError, cancellationToken);
         }
 
         /// <summary>
@@ -534,16 +557,17 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the mapped Measurements with capability
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
 
-            return QueryAsync(query, org, onNext, onError, EmptyAction);
+            return QueryAsync(query, org, onNext, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -554,17 +578,19 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(string query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -576,10 +602,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(string query, string org, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
@@ -588,7 +616,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerRecord(onNext);
 
-            return QueryAsync(CreateQuery(query, DefaultDialect), org, consumer, onError, onComplete);
+            return QueryAsync(CreateQuery(query, DefaultDialect), org, consumer, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -599,17 +627,19 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(Query query, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -621,10 +651,12 @@ namespace InfluxDB.Client
         /// <param name="onNext">the callback to consume the FluxRecord result with capability</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns>async task</returns>
         public Task QueryAsync(Query query, string org, Action<ICancellable, FluxRecord> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
@@ -633,7 +665,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerRecord(onNext);
 
-            return QueryAsync(query, org, consumer, onError, onComplete);
+            return QueryAsync(query, org, consumer, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -645,18 +677,20 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(string query, Action<ICancellable, T> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -669,11 +703,13 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(string query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -683,7 +719,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(onNext, Mapper);
 
-            return QueryAsync(CreateQuery(query, DefaultDialect), org, consumer, onError, onComplete);
+            return QueryAsync(CreateQuery(query, DefaultDialect), org, consumer, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -695,18 +731,19 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(Query query, Action<ICancellable, T> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryAsync(query, _options.Org, onNext, onError, onComplete);
+            return QueryAsync(query, _options.Org, onNext, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -719,11 +756,12 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query</param>
         /// <param name="onError">the callback to consume any error notification</param>
         /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>async task</returns>
         public Task QueryAsync<T>(Query query, string org, Action<ICancellable, T> onNext,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNotNull(onNext, nameof(onNext));
@@ -732,82 +770,86 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(onNext, Mapper);
 
-            return QueryAsync(query, org, consumer, onError, onComplete);
+            return QueryAsync(query, org, consumer, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public Task<string> QueryRawAsync(string query)
+        public Task<string> QueryRawAsync(string query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org);
+            return QueryRawAsync(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public Task<string> QueryRawAsync(string query, string org)
+        public Task<string> QueryRawAsync(string query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, DefaultDialect);
+            return QueryRawAsync(query, org, DefaultDialect, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
         /// </summary>
         /// <param name="query">the flux query to execute</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public Task<string> QueryRawAsync(Query query)
+        public Task<string> QueryRawAsync(Query query, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org);
+            return QueryRawAsync(query, _options.Org, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
         /// </summary>
         /// <param name="query">the flux query to execute</param>
         /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public async Task<string> QueryRawAsync(Query query, string org)
+        public async Task<string> QueryRawAsync(Query query, string org, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -816,17 +858,17 @@ namespace InfluxDB.Client
 
             void Consumer(ICancellable cancellable, string row) => rows.Add(row);
 
-            await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
+            await QueryRawAsync(query, org, Consumer, ErrorConsumer, EmptyAction, cancellationToken).ConfigureAwait(false);
 
             return string.Join("\n", rows);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
@@ -834,20 +876,21 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="dialect">Dialect is an object defining the options to use when encoding the response.
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public Task<string> QueryRawAsync(string query, Dialect dialect)
+        public Task<string> QueryRawAsync(string query, Dialect dialect, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, dialect);
+            return QueryRawAsync(query, _options.Org, dialect, cancellationToken);
         }
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
-        ///
+        /// 
         /// <para>
         /// NOTE: This method is not intended for large query results.
-        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action)"/>
+        /// Use <see cref="QueryRawAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,string},System.Action{System.Exception},System.Action,CancellationToken)"/>
         /// for large data streaming.
         /// </para>
         /// 
@@ -856,13 +899,14 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="dialect">Dialect is an object defining the options to use when encoding the response.
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
+        /// <param name="cancellationToken">cancellation token</param>
         /// <returns>the raw response that matched the query</returns>
-        public Task<string> QueryRawAsync(string query, string org, Dialect dialect)
+        public Task<string> QueryRawAsync(string query, string org, Dialect dialect, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(CreateQuery(query, dialect), org);
+            return QueryRawAsync(CreateQuery(query, dialect), org, cancellationToken);
         }
 
         /// <summary>
@@ -872,13 +916,14 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
-        public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse
-        )
+        public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, onResponse);
+            return QueryRawAsync(query, _options.Org, onResponse, cancellationToken);
         }
 
         /// <summary>
@@ -889,14 +934,14 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
-        public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse
-        )
+        public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, onResponse, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -906,12 +951,13 @@ namespace InfluxDB.Client
         /// <param name="query">the flux query to execute</param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
-        public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse)
+        public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, onResponse);
+            return QueryRawAsync(query, _options.Org, onResponse, cancellationToken);
         }
 
         /// <summary>
@@ -922,14 +968,14 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the source organization</param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
-        public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse
-        )
+        public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, onResponse, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -941,12 +987,14 @@ namespace InfluxDB.Client
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
-        public Task QueryRawAsync(string query, Dialect dialect, Action<ICancellable, string> onResponse)
+        public Task QueryRawAsync(string query, Dialect dialect, Action<ICancellable, string> onResponse, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, dialect, onResponse);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse, cancellationToken);
         }
 
         /// <summary>
@@ -959,15 +1007,15 @@ namespace InfluxDB.Client
         /// <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, string org, Dialect dialect,
-            Action<ICancellable, string> onResponse
-        )
+            Action<ICancellable, string> onResponse, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, dialect, onResponse, ErrorConsumer);
+            return QueryRawAsync(query, org, dialect, onResponse, ErrorConsumer, cancellationToken);
         }
 
         /// <summary>
@@ -978,13 +1026,14 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, null, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, null, onResponse, onError, cancellationToken);
         }
 
         /// <summary>
@@ -996,14 +1045,15 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, null, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, null, onResponse, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -1014,15 +1064,16 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, onResponse, onError, cancellationToken);
         }
-        
+
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
         /// (line by line) to <see cref="onResponse"/>.
@@ -1032,14 +1083,15 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, onResponse, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -1052,16 +1104,17 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, Dialect dialect,
             Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError, cancellationToken);
         }
-        
+
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
         /// (line by line) to <see cref="onResponse"/>.
@@ -1073,15 +1126,16 @@ namespace InfluxDB.Client
         /// <param name="onResponse">the callback to consume the response line by line with capability
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, string org, Dialect dialect,
             Action<ICancellable, string> onResponse,
-            Action<Exception> onError)
+            Action<Exception> onError, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, dialect, onResponse, onError, EmptyAction);
+            return QueryRawAsync(query, org, dialect, onResponse, onError, EmptyAction, cancellationToken);
         }
 
         /// <summary>
@@ -1093,16 +1147,17 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete, cancellationToken);
         }
-        
+
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream response
         /// (line by line) to <see cref="onResponse"/>.
@@ -1113,15 +1168,16 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
-            return QueryRawAsync(query, org, null, onResponse, onError, onComplete);
+            return QueryRawAsync(query, org, null, onResponse, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -1133,14 +1189,15 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(Query query, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
-            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, onResponse, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -1153,17 +1210,18 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(Query query, string org, Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
 
             var requestMessage = CreateRequest(query, org);
 
-            return QueryRaw(requestMessage, onResponse, onError, onComplete);
+            return QueryRaw(requestMessage, onResponse, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -1177,18 +1235,20 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNotNull(onResponse, nameof(onResponse));
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError, onComplete);
+            return QueryRawAsync(query, _options.Org, dialect, onResponse, onError, onComplete, cancellationToken);
         }
 
         /// <summary>
@@ -1203,11 +1263,13 @@ namespace InfluxDB.Client
         /// to discontinue a streaming query.</param>
         /// <param name="onError">callback to consume any error notification</param>
         /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="cancellationToken">cancellation token, useful for cancellation a request before parsing response from server</param>
         /// <returns></returns>
         public Task QueryRawAsync(string query, string org, Dialect dialect,
             Action<ICancellable, string> onResponse,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(query, nameof(query));
             Arguments.CheckNonEmptyString(org, nameof(org));
@@ -1215,7 +1277,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(onError, nameof(onError));
             Arguments.CheckNotNull(onComplete, nameof(onComplete));
 
-            return QueryRawAsync(CreateQuery(query, dialect), org, onResponse, onError, onComplete);
+            return QueryRawAsync(CreateQuery(query, dialect), org, onResponse, onError, onComplete, cancellationToken);
         }
 
         protected override void BeforeIntercept(RestRequest request)
@@ -1230,7 +1292,8 @@ namespace InfluxDB.Client
 
         private Task QueryAsync(Query query, string org, FluxCsvParser.IFluxResponseConsumer consumer,
             Action<Exception> onError,
-            Action onComplete)
+            Action onComplete, 
+            CancellationToken cancellationToken = default)
 
         {
             Arguments.CheckNotNull(query, nameof(query));
@@ -1241,7 +1304,7 @@ namespace InfluxDB.Client
 
             var requestMessage = CreateRequest(query, org);
 
-            return Query(requestMessage, consumer, onError, onComplete);
+            return Query(requestMessage, consumer, onError, onComplete, cancellationToken);
         }
 
         private RestRequest CreateRequest(Query query, string org)


### PR DESCRIPTION
Closes #228

## Proposed Changes

Add support for `CancellationToken` - it is useful to cancel query before parsing records

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
