### PR TITLE
feat: add QueryAsync overload with Type parameter (#230)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-
 ## 3.0.0 [unreleased]
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
+## 3.0.0 [unreleased]
+### Breaking Changes
+1. [#232](https://github.com/influxdata/influxdb-client-csharp/pull/232): Adds a `Type` overload for POCOs to `QueryAsync`. This will add `object ConvertToEntity(FluxRecord, Type)` to `IFluxResultMapper`
+
+
 ## 2.1.0 [unreleased]
 
 ### Bug Fixes
 1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing infinite numbers
 2. [#229](https://github.com/influxdata/influxdb-client-csharp/pull/229): Fix cookie handling in session mode
-3. [#230](https://github.com/influxdata/influxdb-client-csharp/issues/230): Adds an `Type` overload for POCOs to `QueryAsync`
 
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Bug Fixes
 1. [#221](https://github.com/influxdata/influxdb-client-csharp/pull/221): Parsing infinite numbers
 2. [#229](https://github.com/influxdata/influxdb-client-csharp/pull/229): Fix cookie handling in session mode
+3. [#230](https://github.com/influxdata/influxdb-client-csharp/issues/230): Adds an `Type` overload for POCOs to `QueryAsync`
 
 ### Dependencies
 1. [#222](https://github.com/influxdata/influxdb-client-csharp/pull/222): Update dependencies:

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -7,7 +7,7 @@
         <Description>InfluxDB Client Core - exceptions, validations, REST client.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Core</AssemblyName>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>3.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
 
         <PackageId>InfluxDB.Client.Core</PackageId>

--- a/Client.Core/Flux/Internal/IFluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/IFluxResultMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using InfluxDB.Client.Core.Flux.Domain;
 
 namespace InfluxDB.Client.Core.Flux.Internal
@@ -14,5 +15,7 @@ namespace InfluxDB.Client.Core.Flux.Internal
         /// <typeparam name="T">Type of DomainObject</typeparam>
         /// <returns>Converted DomainObject</returns>
         T ConvertToEntity<T>(FluxRecord fluxRecord);
+
+        object ConvertToEntity(FluxRecord fluxRecord, Type type);
     }
 }

--- a/Client.Core/Flux/Internal/IFluxResultMapper.cs
+++ b/Client.Core/Flux/Internal/IFluxResultMapper.cs
@@ -16,6 +16,12 @@ namespace InfluxDB.Client.Core.Flux.Internal
         /// <returns>Converted DomainObject</returns>
         T ConvertToEntity<T>(FluxRecord fluxRecord);
 
+        /// <summary>
+        /// Converts FluxRecord to DomainObject specified by Type.
+        /// </summary>
+        /// <param name="fluxRecord">Flux record</param>
+        /// <param name="type">Type of DomainObject</param>
+        /// <returns>Converted DomainObject</returns>
         object ConvertToEntity(FluxRecord fluxRecord, Type type);
     }
 }

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -206,6 +206,29 @@ namespace InfluxDB.Client.Core.Internal
                 }
             }
         }
+        
+        public class FluxResponseConsumerPoco : FluxCsvParser.IFluxResponseConsumer
+        {
+            private readonly Action<ICancellable, object> _onNext;
+            private readonly IFluxResultMapper _converter;
+            private readonly Type _type;
+
+            public FluxResponseConsumerPoco(Action<ICancellable, object> onNext, IFluxResultMapper converter, Type type)
+            {
+                _onNext = onNext;
+                _converter = converter;
+                _type = type;
+            }
+
+            public void Accept(int index, ICancellable cancellable, FluxTable table)
+            {
+            }
+
+            public void Accept(int index, ICancellable cancellable, FluxRecord record)
+            {
+                _onNext(cancellable, _converter.ConvertToEntity(record,_type));
+            }
+        }
 
         public class FluxResponseConsumerPoco<T> : FluxCsvParser.IFluxResponseConsumer
         {

--- a/Client.Legacy.Test/FluxClientQueryTest.cs
+++ b/Client.Legacy.Test/FluxClientQueryTest.cs
@@ -219,7 +219,7 @@ namespace Client.Legacy.Test
             await FluxClient.QueryAsync("from(bucket:\"telegraf\")");
 
             var request= MockServer.LogEntries.Last();
-            StringAssert.StartsWith("influxdb-client-csharp/2.", request.RequestMessage.Headers["User-Agent"].First());
+            StringAssert.StartsWith("influxdb-client-csharp/3.", request.RequestMessage.Headers["User-Agent"].First());
             StringAssert.EndsWith(".0.0", request.RequestMessage.Headers["User-Agent"].First());
         }
 

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -6,7 +6,7 @@
       <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Flux</AssemblyName>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>3.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
 
         <PackageId>InfluxDB.Client.Flux</PackageId>

--- a/Client.Linq/Client.Linq.csproj
+++ b/Client.Linq/Client.Linq.csproj
@@ -6,7 +6,7 @@
       <Description>The library supports querying InfluxDB 2.0 by LINQ expressions.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Linq</AssemblyName>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>3.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
 
         <PackageId>InfluxDB.Client.Linq</PackageId>

--- a/Client.Test/AssemblyHelperTest.cs
+++ b/Client.Test/AssemblyHelperTest.cs
@@ -11,7 +11,7 @@ namespace InfluxDB.Client.Test
         public void GetAssemblyVersion()
         {
             var version = AssemblyHelper.GetVersion(typeof(InfluxDBClient));
-            Assert.AreEqual(2, Version.Parse(version).Major);
+            Assert.AreEqual(3, Version.Parse(version).Major);
             Assert.GreaterOrEqual(Version.Parse(version).Minor, 0);
             Assert.AreEqual(0, Version.Parse(version).Build);
             Assert.AreEqual(0, Version.Parse(version).Revision);

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -156,7 +156,7 @@ namespace InfluxDB.Client.Test
             await _client.GetAuthorizationsApi().FindAuthorizationByIdAsync("id");
 
             var request= MockServer.LogEntries.Last();
-            StringAssert.StartsWith("influxdb-client-csharp/2.", request.RequestMessage.Headers["User-Agent"].First());
+            StringAssert.StartsWith("influxdb-client-csharp/3.", request.RequestMessage.Headers["User-Agent"].First());
             StringAssert.EndsWith(".0.0", request.RequestMessage.Headers["User-Agent"].First());
         }
         

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -413,7 +413,7 @@ namespace InfluxDB.Client.Test
             listener.Get<WriteSuccessEvent>();
             
             var request= MockServer.LogEntries.Last();
-            StringAssert.StartsWith("influxdb-client-csharp/2.", request.RequestMessage.Headers["User-Agent"].First());
+            StringAssert.StartsWith("influxdb-client-csharp/3.", request.RequestMessage.Headers["User-Agent"].First());
             StringAssert.EndsWith(".0.0", request.RequestMessage.Headers["User-Agent"].First());
         }
 

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -7,7 +7,7 @@
       <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.0.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client</AssemblyName>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>3.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
 
         <PackageId>InfluxDB.Client</PackageId>

--- a/Client/Internal/DefaultDomainObjectMapper.cs
+++ b/Client/Internal/DefaultDomainObjectMapper.cs
@@ -6,27 +6,27 @@ using InfluxDB.Client.Writes;
 
 namespace InfluxDB.Client.Internal
 {
-	/// <summary>
-	/// Default implementation of DomainObject mapper.
-	/// </summary>
-	internal class DefaultDomainObjectMapper : IDomainObjectMapper
-	{
-		private readonly FluxResultMapper _resultMapper = new FluxResultMapper();
-		private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
+    /// <summary>
+    /// Default implementation of DomainObject mapper.
+    /// </summary>
+    internal class DefaultDomainObjectMapper : IDomainObjectMapper
+    {
+        private readonly FluxResultMapper _resultMapper = new FluxResultMapper();
+        private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
 
-		public T ConvertToEntity<T>(FluxRecord fluxRecord)
-		{
-			return _resultMapper.ToPoco<T>(fluxRecord);
-		}
+        public T ConvertToEntity<T>(FluxRecord fluxRecord)
+        {
+            return _resultMapper.ToPoco<T>(fluxRecord);
+        }
 
-		public object ConvertToEntity(FluxRecord fluxRecord, Type type)
-		{
-			return _resultMapper.ToPoco(fluxRecord, type);
-		}
+        public object ConvertToEntity(FluxRecord fluxRecord, Type type)
+        {
+            return _resultMapper.ToPoco(fluxRecord, type);
+        }
 
-		public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
-		{
-			return _measurementMapper.ToPoint(entity, precision);
-		}
-	}
+        public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
+        {
+            return _measurementMapper.ToPoint(entity, precision);
+        }
+    }
 }

--- a/Client/Internal/DefaultDomainObjectMapper.cs
+++ b/Client/Internal/DefaultDomainObjectMapper.cs
@@ -1,3 +1,4 @@
+using System;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Flux.Domain;
 using InfluxDB.Client.Core.Flux.Internal;
@@ -5,22 +6,27 @@ using InfluxDB.Client.Writes;
 
 namespace InfluxDB.Client.Internal
 {
-    /// <summary>
-    /// Default implementation of DomainObject mapper.
-    /// </summary>
-    internal class DefaultDomainObjectMapper : IDomainObjectMapper
-    {
-        private readonly FluxResultMapper _resultMapper = new FluxResultMapper();
-        private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
+	/// <summary>
+	/// Default implementation of DomainObject mapper.
+	/// </summary>
+	internal class DefaultDomainObjectMapper : IDomainObjectMapper
+	{
+		private readonly FluxResultMapper _resultMapper = new FluxResultMapper();
+		private readonly MeasurementMapper _measurementMapper = new MeasurementMapper();
 
-        public T ConvertToEntity<T>(FluxRecord fluxRecord)
-        {
-            return _resultMapper.ToPoco<T>(fluxRecord);
-        }
+		public T ConvertToEntity<T>(FluxRecord fluxRecord)
+		{
+			return _resultMapper.ToPoco<T>(fluxRecord);
+		}
 
-        public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
-        {
-            return _measurementMapper.ToPoint(entity, precision);
-        }
-    }
+		public object ConvertToEntity(FluxRecord fluxRecord, Type type)
+		{
+			return _resultMapper.ToPoco(fluxRecord, type);
+		}
+
+		public PointData ConvertToPointData<T>(T entity, WritePrecision precision)
+		{
+			return _measurementMapper.ToPoint(entity, precision);
+		}
+	}
 }

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -736,6 +736,116 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,object},System.Action{System.Exception},System.Action,System.Type)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>Measurements which are matched the query</returns>
+        public Task<List<object>> QueryAsync(string query, Type pocoType)
+        {
+            return QueryAsync(query, _options.Org, pocoType);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,object},System.Action{System.Exception},System.Action,System.Type)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">the organization</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>Measurements which are matched the query</returns>
+        public Task<List<object>> QueryAsync(string query, string org, Type pocoType) 
+        {   
+            return QueryAsync(CreateQuery(query),org, pocoType);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,object},System.Action{System.Exception},System.Action,System.Type)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>Measurements which are matched the query</returns>
+        public Task<List<object>> QueryAsync(Query query, Type pocoType)
+        {
+            return QueryAsync(query, _options.Org, pocoType);
+        }
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryAsync(string,string,System.Action{InfluxDB.Client.Core.ICancellable,object},System.Action{System.Exception},System.Action,System.Type)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">the organization</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>Measurements which are matched the query</returns>
+        public async Task<List<object>> QueryAsync(Query query, string org, Type pocoType) 
+        {   
+            var measurements = new List<object>();
+            var consumer = new FluxResponseConsumerPoco((cancellable, poco) => { measurements.Add(poco); }, Mapper, pocoType);
+            await QueryAsync(query, org, consumer, ErrorConsumer, EmptyAction).ConfigureAwait(false);
+            return measurements;
+        }
+
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements with capability
+        /// to discontinue a streaming query</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>async task</returns>
+        public Task QueryAsync(string query, string org, Action<ICancellable, object> onNext, Action<Exception> onError,
+            Action onComplete, Type pocoType)
+        {
+            return QueryAsync(CreateQuery(query, DefaultDialect), org, onNext, onError, onComplete, pocoType);
+        }
+
+        public Task QueryAsync(Query query, string org, Action<ICancellable, object> onNext, Action<Exception> onError,
+            Action onComplete, Type pocoType)
+        {
+            Arguments.CheckNotNull(query, nameof(query));
+            Arguments.CheckNotNull(onNext, nameof(onNext));
+            Arguments.CheckNotNull(onError, nameof(onError));
+            Arguments.CheckNotNull(onComplete, nameof(onComplete));
+            
+            var consumer = new FluxResponseConsumerPoco(onNext, Mapper, pocoType);
+
+            return QueryAsync(query, org, consumer, onError, onComplete);
+            
+        }
+
+        /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
         ///
         /// <para>

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -831,6 +831,18 @@ namespace InfluxDB.Client
             return QueryAsync(CreateQuery(query, DefaultDialect), org, onNext, onError, onComplete, pocoType);
         }
 
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.0 and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements with capability
+        /// to discontinue a streaming query</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <returns>async task</returns>
         public Task QueryAsync(Query query, string org, Action<ICancellable, object> onNext, Action<Exception> onError,
             Action onComplete, Type pocoType)
         {

--- a/Examples/CustomDomainMapping.cs
+++ b/Examples/CustomDomainMapping.cs
@@ -46,10 +46,13 @@ namespace Examples
             /// Convert to DomainObject.
             /// </summary>
             public T ConvertToEntity<T>(FluxRecord fluxRecord)
+                => (T)ConvertToEntity(fluxRecord, typeof(T));
+
+            public object ConvertToEntity(FluxRecord fluxRecord, Type type)
             {
-                if (typeof(T) != typeof(Sensor))
+                if (type != typeof(Sensor))
                 {
-                    throw new NotSupportedException($"This converter doesn't supports: {typeof(T)}");
+                    throw new NotSupportedException($"This converter doesn't supports: {type}");
                 }
 
                 var customEntity = new Sensor
@@ -59,8 +62,7 @@ namespace Examples
                     Value = Convert.ToDouble(fluxRecord.GetValueByKey("data")),
                     Timestamp = fluxRecord.GetTime().GetValueOrDefault().ToDateTimeUtc(),
                 };
-                
-                return (T) Convert.ChangeType(customEntity, typeof(T));
+                return Convert.ChangeType(customEntity, type);
             }
 
             /// <summary>

--- a/Examples/CustomDomainMappingAndLinq.cs
+++ b/Examples/CustomDomainMappingAndLinq.cs
@@ -56,9 +56,13 @@ namespace Examples
             /// <summary>
             /// Convert to DomainObject.
             /// </summary>
-            public T ConvertToEntity<T>(FluxRecord fluxRecord)
+            public T ConvertToEntity<T>(FluxRecord fluxRecord) 
+                => (T)ConvertToEntity(fluxRecord, typeof(T));
+            
+
+            public object ConvertToEntity(FluxRecord fluxRecord, Type type)
             {
-                if (typeof(T) != typeof(DomainEntity))
+                if (type != typeof(DomainEntity))
                 {
                     throw new NotSupportedException($"This converter doesn't supports: {typeof(DomainEntity)}");
                 }
@@ -84,7 +88,7 @@ namespace Examples
                     }
                 }
 
-                return (T) Convert.ChangeType(customEntity, typeof(T));
+                return Convert.ChangeType(customEntity, type);
             }
 
             /// <summary>

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -4,7 +4,7 @@
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp2.2;netcoreapp3.1;netcoreapp5.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
-        <VersionPrefix>2.1.0</VersionPrefix>
+        <VersionPrefix>3.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
         <IsPackable>false</IsPackable>
         

--- a/Examples/PocoQueryWriteExample.cs
+++ b/Examples/PocoQueryWriteExample.cs
@@ -84,6 +84,8 @@ namespace Examples
                         "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")";
 
             var list = await client.GetQueryApi().QueryAsync<Sensor>(query);
+            //or as an alternative:
+            // var list = await client.GetQueryApi().QueryAsync(query, typeof(Sensor));
             
             //
             // Print result

--- a/Examples/QueryLinqCloud.cs
+++ b/Examples/QueryLinqCloud.cs
@@ -58,8 +58,11 @@ namespace Examples
             /// Convert to DomainObject.
             /// </summary>
             public T ConvertToEntity<T>(FluxRecord fluxRecord)
+                => (T)ConvertToEntity(fluxRecord, typeof(T));
+
+            public object ConvertToEntity(FluxRecord fluxRecord, Type type)
             {
-                if (typeof(T) != typeof(DomainEntity))
+                if (type != typeof(DomainEntity))
                 {
                     throw new NotSupportedException($"This converter doesn't supports: {typeof(DomainEntity)}");
                 }
@@ -85,7 +88,7 @@ namespace Examples
                     }
                 }
 
-                return (T) Convert.ChangeType(customEntity, typeof(T));
+                return Convert.ChangeType(customEntity, type);
             }
 
             public PointData ConvertToPointData<T>(T entity, WritePrecision precision)


### PR DESCRIPTION
Closes #230 

## Proposed Changes

This commit will add an overload to `QueryAsync` to allow a `Type` as parameter for the POCO object.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
