### PR TITLE
fix: mapping long type into AST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Adds a `Type` overload for POCOs to `QueryAsync`. This will add `object ConvertT
 ### Features
 1. [#232](https://github.com/influxdata/influxdb-client-csharp/pull/232): Adds a `Type` overload for POCOs to `QueryAsync`.
 
+### Bug Fixes
+1. [#236](https://github.com/influxdata/influxdb-client-csharp/pull/236): Mapping `long` type into Flux AST [LINQ]
+
 ## 2.1.0 [2021-08-20]
 
 ### Bug Fixes

--- a/Client.Linq.Test/DomainObjects.cs
+++ b/Client.Linq.Test/DomainObjects.cs
@@ -69,4 +69,9 @@ namespace Client.Linq.Test
         [Column(IsTimestamp = true)]
         public DateTime Timestamp { get; set; }
     }
+    
+    public class DataEntityWithLong
+    {
+        public long EndWithTicks { get; set; }
+    }
 }

--- a/Client.Linq/Internal/VariableAggregator.cs
+++ b/Client.Linq/Internal/VariableAggregator.cs
@@ -46,6 +46,10 @@ namespace InfluxDB.Client.Linq.Internal
                 {
                     literal = new IntegerLiteral("IntegerLiteral", Convert.ToString(i));
                 }
+                else if (variable.Value is long l)
+                {
+                    literal = new IntegerLiteral("IntegerLiteral", Convert.ToString(l));
+                }
                 else if (variable.Value is bool b)
                 {
                     literal = new BooleanLiteral("BooleanLiteral", b);


### PR DESCRIPTION
Closes #235

## Proposed Changes

Fixed mapping `long` type in LINQ expressions.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
