### PR TITLE
feat: Add support for deserialization of POCO column property types with a "Parse" method, such as Guid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#239](https://github.com/influxdata/influxdb-client-csharp/pull/239): Add support for Asynchronous queries [LINQ]
 1. [#240](https://github.com/influxdata/influxdb-client-csharp/pull/240): Add IsMeasurement option to Column attribute for dynamic measurement names in POCO classes
+1. [#246](https://github.com/influxdata/influxdb-client-csharp/pull/246): Add support for deserialization of POCO column property types with a "Parse" method, such as Guid
 
 ## 3.0.0 [2021-09-17]
 

--- a/Client.Legacy.Test/FluxResultMapperTest.cs
+++ b/Client.Legacy.Test/FluxResultMapperTest.cs
@@ -99,5 +99,37 @@ namespace Client.Legacy.Test
             [Column("avg")] public Double Average { get; set; }
             [Column(IsTimestamp = true)] public DateTime Timestamp { get; set; }
         }
+
+        [Test]
+        public void ParseableProperty()
+        {
+            string expectedTag = "test";
+            Guid expectedValue = Guid.NewGuid();
+            Instant expectedTime = Instant.FromDateTimeUtc(DateTime.UtcNow);
+
+            var record = new FluxRecord(0);
+            record.Values["tag"] = expectedTag;
+            record.Values["value"] = expectedValue.ToString();
+            record.Values["_time"] = expectedTime;
+
+            var poco = _parser.ToPoco<ParseablePoco>(record);
+
+            Assert.AreEqual(expectedTag, poco.Tag);
+            Assert.AreEqual(expectedValue, poco.Value);
+            Assert.AreEqual(expectedTime, Instant.FromDateTimeUtc(poco.Timestamp));
+        }
+
+        [Measurement("poco")]
+        private class ParseablePoco
+        {
+            [Column("tag", IsTag = true)]
+            public string Tag { get; set; }
+
+            [Column("value")]
+            public Guid Value { get; set; }
+
+            [Column(IsTimestamp = true)]
+            public DateTime Timestamp { get; set; }
+        }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Adds support to the FluxResultMapper to deserialize any column where the type exposes a static Parse method. This enables the use of POCO properties for many common data types, including Guid.

These types were already supported for serialization since most values are being ToString()'ed and written to influx.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
