### PR TITLE
feat: Add support for LINQ Contains subqueries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 1. [#239](https://github.com/influxdata/influxdb-client-csharp/pull/239): Add support for Asynchronous queries [LINQ]
 1. [#240](https://github.com/influxdata/influxdb-client-csharp/pull/240): Add IsMeasurement option to Column attribute for dynamic measurement names in POCO classes
 1. [#246](https://github.com/influxdata/influxdb-client-csharp/pull/246), [#251](https://github.com/influxdata/influxdb-client-csharp/pull/251): Add support for deserialization of POCO column property types with a "Parse" method, such as Guid
+1. [#249](https://github.com/influxdata/influxdb-client-csharp/pull/249): Add support for LINQ Contains subqueries [LINQ]
 
 ## 3.0.0 [2021-09-17]
 

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -350,6 +350,34 @@ namespace Client.Linq.Test
         }
 
         [Test]
+        public void QueryContainsField()
+        {
+            int[] values = {15, 28};
+
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApiSync())
+                where values.Contains(s.Value)
+                select s;
+
+            var sensors = query.Count();
+
+            Assert.AreEqual(4, sensors);
+        }
+
+        [Test]
+        public void QueryContainsTag()
+        {
+            string[] deployment = { "production", "testing" };
+
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApiSync())
+                        where deployment.Contains(s.Deployment)
+                        select s;
+
+            var sensors = query.Count();
+
+            Assert.AreEqual(8, sensors);
+        }
+
+        [Test]
         public void SyncQueryConfiguration()
         {
             var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApi())

--- a/Client.Linq/Internal/Expressions/IExpressionPart.cs
+++ b/Client.Linq/Internal/Expressions/IExpressionPart.cs
@@ -5,7 +5,7 @@ namespace InfluxDB.Client.Linq.Internal.Expressions
     internal interface IExpressionPart
     {
         /// <summary>
-        /// Append Flux Query to buiilder
+        /// Append Flux Query to builder.
         /// </summary>
         /// <param name="builder">Flux query builder</param>
         void AppendFlux(StringBuilder builder);

--- a/Client.Linq/Internal/Expressions/LeftParenthesis.cs
+++ b/Client.Linq/Internal/Expressions/LeftParenthesis.cs
@@ -1,6 +1,6 @@
 namespace InfluxDB.Client.Linq.Internal.Expressions
 {
-    internal class LeftParenthesis: AbstractExpressionPart
+    internal class LeftParenthesis : AbstractExpressionPart
     {
         internal LeftParenthesis() : base("(")
         {

--- a/Client.Linq/Internal/Expressions/RightParenthesis.cs
+++ b/Client.Linq/Internal/Expressions/RightParenthesis.cs
@@ -1,6 +1,6 @@
 namespace InfluxDB.Client.Linq.Internal.Expressions
 {
-    internal class RightParenthesis: AbstractExpressionPart
+    internal class RightParenthesis : AbstractExpressionPart
     {
         internal RightParenthesis() : base(")")
         {

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -167,7 +167,7 @@ namespace InfluxDB.Client.Linq.Internal
             parts.Add(settings.QueryMultipleTimeSeries ? "group()" : "");
             parts.Add(BuildFilter(_filterByFields));
 
-            // https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/sort/
+            // https://docs.influxdata.com/flux/v0.x/stdlib/universe/sort/
             foreach (var ((column, columnVariable, descending, descendingVariable), index) in _orders.Select((value, i) => (value, i)))
             {
                 // skip default sorting if don't query to multiple time series
@@ -179,7 +179,7 @@ namespace InfluxDB.Client.Linq.Internal
                 parts.Add(BuildOperator("sort", "columns", new List<string> {columnVariable}, "desc", descendingVariable));
             }
 
-            // https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/limit/
+            // https://docs.influxdata.com/flux/v0.x/stdlib/universe/limit/
             foreach (var limitNOffsetAssignment in _limitNOffsetAssignments)
             {
                 if (limitNOffsetAssignment.N != null)

--- a/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
+++ b/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
@@ -50,7 +50,8 @@ namespace InfluxDB.Client.Linq.Internal
 
         protected override Expression VisitSubQuery(SubQueryExpression subQuery)
         {
-            if (subQuery.QueryModel.ResultOperators.All(p => p is AnyResultOperator))
+            if (subQuery.QueryModel.ResultOperators.All(p => p is AnyResultOperator) ||
+                subQuery.QueryModel.ResultOperators.All(p => p is ContainsResultOperator))
             {
                 var query = new QueryAggregator();
 
@@ -98,7 +99,7 @@ namespace InfluxDB.Client.Linq.Internal
 
         protected override Expression VisitMember(MemberExpression expression)
         {
-            if (_clause is WhereClause)
+            if (_clause is WhereClause || _clause is MainFromClause)
             {
                 switch (_context.MemberResolver.ResolveMemberType(expression.Member))
                 {

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -36,6 +36,7 @@ This section contains links to the client library documentation.
     - [OrderBy](#orderby)
     - [Count](#count)
     - [LongCount](#longcount)
+    - [Contains](#contains)
 - [Domain Converter](#domain-converter)
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 - [How to filter by Measurement](#how-to-filter-by-measurement)
@@ -931,6 +932,27 @@ from(bucket: "my-bucket")
     |> stateCount(fn: (r) => true, column: "linq_result_column") 
     |> last(column: "linq_result_column") 
     |> keep(columns: ["linq_result_column"])
+```
+
+### Contains
+
+```c#
+int[] values = {15, 28};
+
+var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi)
+    where values.Contains(s.Value)
+    select s;
+
+var sensors = query.Count();
+```
+
+Flux Query:
+```flux
+from(bucket: "my-bucket")
+    |> range(start: 0)
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value")
+    |> drop(columns: ["_start", "_stop", "_measurement"])
+    |> filter(fn: (r) => contains(value: r["data"], set: [15, 28]))
 ```
 
 ## Domain Converter


### PR DESCRIPTION
Closes #247

## Proposed Changes

Add support for "Contains" subqueries:

```
int[] values = { 15, 28 };

var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi)
    where values.Contains(s.Value)
    select s;
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
