### PR TITLE
Using the cookie name that InfluxDB 2.1 returns instead of assuming "session"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 1. [#257](https://github.com/influxdata/influxdb-client-csharp/pull/257): Add `PingService` to check status of OSS and Cloud instance
 2. [#260](https://github.com/influxdata/influxdb-client-csharp/pull/260): Changed `internal` to `public` visiblity of `InfluxDBClientOptions.Builder.ConnectionString`
 
+### Bug Fixes
+1. [#262](https://github.com/influxdata/influxdb-client-csharp/issues/262): InfluxDB 2.1 Incompatibility with Session Cookie
+
 ## 3.1.0 [2021-10-22]
 
 ### Features

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -153,7 +153,13 @@ namespace InfluxDB.Client.Api.Domain
             /// Enum Annotations for value: annotations
             /// </summary>
             [EnumMember(Value = "annotations")]
-            Annotations = 20
+            Annotations = 20,
+
+            /// <summary>
+            /// Enum Annotations for value: remotes
+            /// </summary>
+            [EnumMember(Value = "remotes")]
+            Remotes = 20
 
         }
 

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -159,7 +159,13 @@ namespace InfluxDB.Client.Api.Domain
             /// Enum Annotations for value: remotes
             /// </summary>
             [EnumMember(Value = "remotes")]
-            Remotes = 20
+            Remotes = 21,
+
+            /// <summary>
+            /// Enum Annotations for value: remotes
+            /// </summary>
+            [EnumMember(Value = "replications")]
+            Replications = 22
 
         }
 

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -162,7 +162,7 @@ namespace InfluxDB.Client.Api.Domain
             Remotes = 21,
 
             /// <summary>
-            /// Enum Annotations for value: remotes
+            /// Enum Annotations for value: replications
             /// </summary>
             [EnumMember(Value = "replications")]
             Replications = 22


### PR DESCRIPTION
Closes #262 

## Proposed Changes

Use the returned session cookie name instead of assuming "session". InfluxDB 2.1 has changed the name of the cookie; for OSS in particular, it returns _influxdb-oss-session_ instead.

Please discard the PR if it's not satisfactory, but this fix did work for me.

## Checklist

- [X] Rebased/mergeable
- [X] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
