### PR TITLE
feat:  add option to accept self-signed certificates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Features
 1. [#257](https://github.com/influxdata/influxdb-client-csharp/pull/257): Add `PingService` to check status of OSS and Cloud instance
 1. [#260](https://github.com/influxdata/influxdb-client-csharp/pull/260): Changed `internal` to `public` visibility of `InfluxDBClientOptions.Builder.ConnectionString`
+1. [#266](https://github.com/influxdata/influxdb-client-csharp/pull/266): Add option to accept self-signed certificates
 
 ### CI
 1. [#264](https://github.com/influxdata/influxdb-client-csharp/pull/264): Add build for `dotnet6`

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -30,6 +30,17 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        public void CreateInstanceVerifySsl()
+        {
+            var client = InfluxDBClientFactory.Create("http://localhost:9999");
+
+            Assert.IsNotNull(client);
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(client.GetType(), client, "_options");
+            Assert.AreEqual(true, options.VerifySsl);
+        }
+
+        [Test]
         public void CreateInstanceUsername() {
 
             var client = InfluxDBClientFactory.Create("http://localhost:9999", "user", "secret".ToCharArray());

--- a/Client/Configurations/Influx2.cs
+++ b/Client/Configurations/Influx2.cs
@@ -85,6 +85,16 @@ namespace InfluxDB.Client.Configurations
             set => base["allowHttpRedirects"] = value;
         }
 
+        /// <summary>
+        /// Ignore Certificate Validation Errors when false
+        /// </summary>
+        [ConfigurationProperty("verifySsl", IsKey = true, IsRequired = false)]
+        public bool VerifySsl
+        {
+            get => (bool)base["verifySsl"];
+            set => base["verifySsl"] = value;
+        }
+
         [ConfigurationProperty("tags", IsRequired = false)]
         public TagCollection Tags
         {

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -40,6 +40,8 @@ namespace InfluxDB.Client
 
         public PointSettings PointSettings { get; }
 
+        public bool VerifySsl { get; }
+
         private InfluxDBClientOptions(Builder builder)
         {
             Arguments.CheckNotNull(builder, nameof(builder));
@@ -61,6 +63,8 @@ namespace InfluxDB.Client
             AllowHttpRedirects = builder.AllowHttpRedirects;
 
             PointSettings = builder.PointSettings;
+
+            VerifySsl = builder.VerifySslCertificates;
         }
 
         /// <summary>
@@ -104,6 +108,7 @@ namespace InfluxDB.Client
 
             internal IWebProxy WebProxy;
             internal bool AllowHttpRedirects;
+            internal bool VerifySslCertificates = true;
 
             internal PointSettings PointSettings = new PointSettings();
 
@@ -290,6 +295,20 @@ namespace InfluxDB.Client
             }
 
             /// <summary>
+            /// Ignore Certificate Validation Errors when false
+            /// </summary>
+            /// <param name="verifySsl">validates Certificates</param>
+            /// <returns><see cref="Builder"/></returns>
+            public Builder VerifySsl(bool verifySsl)
+            {
+                Arguments.CheckNotNull(verifySsl, nameof(verifySsl));
+
+                VerifySslCertificates = verifySsl;
+
+                return this;
+            }
+
+            /// <summary>
             /// Configure Builder via App.config.
             /// </summary>
             /// <param name="sectionName">Name of configuration section. Useful for tests.</param>
@@ -315,6 +334,7 @@ namespace InfluxDB.Client
                 var timeout = config.Timeout;
                 var readWriteTimeout = config.ReadWriteTimeout;
                 var allowHttpRedirects = config.AllowHttpRedirects;
+                var verifySsl = config.VerifySsl;
 
                 var tags = config.Tags;
                 if (tags != null)
@@ -325,7 +345,7 @@ namespace InfluxDB.Client
                     }
                 }
 
-                return Configure(url, org, bucket, token, logLevel, timeout, readWriteTimeout, allowHttpRedirects);
+                return Configure(url, org, bucket, token, logLevel, timeout, readWriteTimeout, allowHttpRedirects, verifySsl);
             }
 
             /// <summary>
@@ -354,7 +374,7 @@ namespace InfluxDB.Client
             }
 
             private Builder Configure(string url, string org, string bucket, string token, string logLevel,
-                string timeout, string readWriteTimeout, bool allowHttpRedirects = false)
+                string timeout, string readWriteTimeout, bool allowHttpRedirects = false, bool verifySsl = true)
             {
                 Url(url);
                 Org(org);
@@ -381,6 +401,8 @@ namespace InfluxDB.Client
                 }
 
                 AllowRedirects(allowHttpRedirects);
+
+                VerifySsl(verifySsl);
 
                 return this;
             }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -32,6 +32,10 @@ namespace InfluxDB.Client.Api.Client
 
             RestClient = new RestClient(options.Url);
             RestClient.FollowRedirects = options.AllowHttpRedirects;
+            if (!options.VerifySsl)
+            {
+                RestClient.RemoteCertificateValidationCallback = (sender, certificate, chain, sslPolicyErrors) => true;
+            }
             RestClient.AutomaticDecompression = false;
             Configuration = new Configuration
             {


### PR DESCRIPTION
## Proposed Changes

Add option to accept self-signed certificates like in influx client libraries for other languages e.g. https://github.com/influxdata/influxdb-client-python 

## Checklist

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
