### PR TITLE
fix: add missing PermissionResources from Cloud API definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 3.3.0 [unreleased]
 
+### Bug Fixes
+1. [#277](https://github.com/influxdata/influxdb-client-csharp/pull/277): Add missing PermissionResources from Cloud API definition
+
+
 ## 3.2.0 [2021-11-26]
 
 ### Deprecates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### Bug Fixes
 1. [#277](https://github.com/influxdata/influxdb-client-csharp/pull/277): Add missing PermissionResources from Cloud API definition
 
-
 ## 3.2.0 [2021-11-26]
 
 ### Deprecates

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -156,16 +156,28 @@ namespace InfluxDB.Client.Api.Domain
             Annotations = 20,
 
             /// <summary>
-            /// Enum Annotations for value: remotes
+            /// Enum Remotes for value: remotes
             /// </summary>
             [EnumMember(Value = "remotes")]
             Remotes = 21,
 
             /// <summary>
-            /// Enum Annotations for value: replications
+            /// Enum Replications for value: replications
             /// </summary>
             [EnumMember(Value = "replications")]
-            Replications = 22
+            Replications = 22,
+
+            /// <summary>
+            /// Enum Flows for value: flows
+            /// </summary>
+            [EnumMember(Value = "flows")]
+            Flows = 23,
+
+            /// <summary>
+            /// Enum Functions for value: functions
+            /// </summary>
+            [EnumMember(Value = "functions")]
+            Functions = 24
 
         }
 


### PR DESCRIPTION
## Proposed Changes

Added missing `PermissionResource` types.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
