### PR TITLE
feat: supports aggregateWindow in LINQ expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 ## 3.4.0 [unreleased]
 
-## 3.3.0 [2022-02-04]
-
 ### Breaking Changes
 Changed type of `Duration.magnitude` from `int?` to `long?`.
 
 ### Features
 1. [#282](https://github.com/influxdata/influxdb-client-csharp/pull/282): Add support for AggregateWindow function [LINQ]
+
+## 3.3.0 [2022-02-04]
 
 ### Bug Fixes
 1. [#277](https://github.com/influxdata/influxdb-client-csharp/pull/277): Add missing PermissionResources from Cloud API definition

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## 3.3.0 [2022-02-04]
 
+### Breaking Changes
+Changed type of `Duration.magnitude` from `int?` to `long?`.
+
+### Features
+1. [#282](https://github.com/influxdata/influxdb-client-csharp/pull/282): Add support for AggregateWindow function [LINQ]
+
 ### Bug Fixes
 1. [#277](https://github.com/influxdata/influxdb-client-csharp/pull/277): Add missing PermissionResources from Cloud API definition
 1. [#281](https://github.com/influxdata/influxdb-client-csharp/pull/281): Serialization query response into POCO with optional DateTime

--- a/Client.Linq.Test/DomainObjects.cs
+++ b/Client.Linq.Test/DomainObjects.cs
@@ -86,4 +86,12 @@ namespace Client.Linq.Test
     {
         public long EndWithTicks { get; set; }
     }
+    
+    class SensorDateTimeAsField
+    {
+        [Column("data")]
+        public int Value { get; set; }
+
+        [Column( "dataTime")] public DateTime DateTimeField { get; set; }
+    }
 }

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -454,6 +454,23 @@ namespace Client.Linq.Test
 
             Assert.AreEqual(8, count);
         }
+        
+        [Test]
+        public void QueryAggregateWindow()
+        {
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApiSync())
+                where s.Timestamp.AggregateWindow(TimeSpan.FromDays(4), null, "mean")
+                where s.Timestamp > new DateTime(2020, 11, 15, 0, 0, 0, DateTimeKind.Utc)
+                where s.Timestamp < new DateTime(2020, 11, 18, 0, 0, 0, DateTimeKind.Utc)
+                select s;
+
+            var sensors = query.ToList();
+
+            Assert.AreEqual(2, sensors.Count);
+            // (28 + 12 + 89) / 3 = 43
+            Assert.AreEqual(43, sensors[0].Value);
+            Assert.AreEqual(43, sensors.Last().Value);
+        }
 
         [TearDown]
         protected void After()

--- a/Client.Linq.Test/VariableAggregatorTest.cs
+++ b/Client.Linq.Test/VariableAggregatorTest.cs
@@ -1,0 +1,44 @@
+using System;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Test;
+using InfluxDB.Client.Linq.Internal;
+using NUnit.Framework;
+
+namespace Client.Linq.Test
+{
+    [TestFixture]
+    public class VariableAggregatorTest : AbstractTest
+    {
+        [Test]
+        public void TimeStamp()
+        {
+            var data = new[]
+            {
+                (
+                    TimeSpan.FromMilliseconds(1),
+                    1000
+                ),
+                (
+                    TimeSpan.FromMilliseconds(-1),
+                    -1000
+                ),
+                (
+                    TimeSpan.FromDays(2 * 365),
+                    63072000000000
+                )
+            };
+
+            foreach (var (timeSpan, expected) in data)
+            {
+                var aggregator = new VariableAggregator();
+                aggregator.AddNamedVariable(timeSpan);
+
+                var duration =
+                    (((aggregator.GetStatements()[0] as OptionStatement)?.Assignment as VariableAssignment)?.Init as
+                        DurationLiteral)?.Values[0];
+                Assert.NotNull(duration);
+                Assert.AreEqual(expected, duration.Magnitude);
+            }
+        }
+    }
+}

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -237,5 +237,30 @@ namespace InfluxDB.Client.Linq
 
             return queryable;
         }
+        
+        /// <summary>
+        /// The extension to use Flux window operator. For more info see https://docs.influxdata.com/flux/v0.x/stdlib/universe/aggregatewindow/
+        ///
+        /// <example>
+        /// <code>
+        /// var query = from s in InfluxDBQueryable&lt;Sensor&gt;.Queryable("my-bucket", "my-org", _queryApi)
+        ///     where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40))
+        ///     where s.Value == 5
+        ///     select s;
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="timestamp">The entity value which is market as a Timestamp.</param>
+        /// <param name="every">Duration of time between windows.</param>
+        /// <param name="period">Duration of the window.</param>
+        /// <param name="fn">Aggregate or selector function used to operate on each window of time.</param>
+        /// <returns>NotSupportedException if it's called outside LINQ expression.</returns>
+        /// <exception cref="NotSupportedException">Caused by calling outside of LINQ expression.</exception>
+        // ReSharper disable UnusedParameter.Global
+        public static bool AggregateWindow(this DateTime timestamp, TimeSpan every, TimeSpan? period = null, string fn = "mean")
+        {
+            throw new NotSupportedException("This should be used only in LINQ expression. " +
+                                            "Something like: 'where s.Timestamp.AggregateWindow(\"20s\", \"40s\")'.");
+        }
     }
 }

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -244,7 +244,7 @@ namespace InfluxDB.Client.Linq
         /// <example>
         /// <code>
         /// var query = from s in InfluxDBQueryable&lt;Sensor&gt;.Queryable("my-bucket", "my-org", _queryApi)
-        ///     where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40))
+        ///     where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40), "mean")
         ///     where s.Value == 5
         ///     select s;
         /// </code>
@@ -260,7 +260,7 @@ namespace InfluxDB.Client.Linq
         public static bool AggregateWindow(this DateTime timestamp, TimeSpan every, TimeSpan? period = null, string fn = "mean")
         {
             throw new NotSupportedException("This should be used only in LINQ expression. " +
-                                            "Something like: 'where s.Timestamp.AggregateWindow(\"20s\", \"40s\")'.");
+                                            "Something like: 'where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40), \"mean\")'.");
         }
     }
 }

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -94,7 +94,7 @@ namespace InfluxDB.Client.Linq.Internal
             _rangeStopExpression = expressionType;
         }
         
-        public void AddAggregateWindow(string everyVariable, string periodVariable, string fnVariable)
+        internal void AddAggregateWindow(string everyVariable, string periodVariable, string fnVariable)
         {
             _aggregateWindow = (everyVariable, periodVariable, fnVariable);
         }

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -65,6 +65,7 @@ namespace InfluxDB.Client.Linq.Internal
         private readonly List<string> _filterByTags;
         private readonly List<string> _filterByFields;
         private readonly List<(string, string, bool, string)> _orders;
+        private (string Every, string Period, string Fn)? _aggregateWindow;
 
         internal QueryAggregator()
         {
@@ -73,6 +74,7 @@ namespace InfluxDB.Client.Linq.Internal
             _filterByTags = new List<string>();
             _filterByFields = new List<string>();
             _orders = new List<(string, string, bool, string)>();
+            _aggregateWindow = null;
         }
 
         internal void AddBucket(string bucket)
@@ -91,6 +93,12 @@ namespace InfluxDB.Client.Linq.Internal
             _rangeStopAssignment = rangeStop;
             _rangeStopExpression = expressionType;
         }
+        
+        public void AddAggregateWindow(string everyVariable, string periodVariable, string fnVariable)
+        {
+            _aggregateWindow = (everyVariable, periodVariable, fnVariable);
+        }
+
 
         internal void AddLimitN(string limitNAssignment)
         {
@@ -155,6 +163,7 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildOperator("from", "bucket", _bucketAssignment),
                 BuildRange(transforms),
                 BuildFilter(_filterByTags),
+                BuildAggregateWindow(_aggregateWindow),
                 "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
             };
 
@@ -207,6 +216,25 @@ namespace InfluxDB.Client.Linq.Internal
             query.Append(JoinList(parts, " |> "));
 
             return query.ToString();
+        }
+
+        private string BuildAggregateWindow((string Every, string Period, string Fn)? aggregateWindow)
+        {
+            if (aggregateWindow == null)
+            {
+                return null;
+            }
+
+            var (every, period, fn) = aggregateWindow.Value;
+            var list = new List<string>
+            {
+                $"every: {every}",
+                period != null ? $"period: {period}" : null, 
+                $"fn: {fn}"
+            };
+
+
+            return $"aggregateWindow({JoinList(list, ", ")})";
         }
 
         private string BuildDrop(QueryableOptimizerSettings settings)

--- a/Client.Linq/Internal/VariableAggregator.cs
+++ b/Client.Linq/Internal/VariableAggregator.cs
@@ -73,11 +73,17 @@ namespace InfluxDB.Client.Linq.Internal
                 {
                     var expressions =
                         e.Cast<object>()
-                         .Select(o => new NamedVariable { Value = o, IsTag = variable.IsTag })
-                         .Select(CreateExpression)
-                         .ToList();
+                            .Select(o => new NamedVariable { Value = o, IsTag = variable.IsTag })
+                            .Select(CreateExpression)
+                            .ToList();
                     return new ArrayExpression("ArrayExpression", expressions);
                 }
+                case TimeSpan timeSpan:
+                    var timeSpanTotalMilliseconds = 1000.0 * timeSpan.TotalMilliseconds;
+                    var duration = new Duration("Duration", (long)timeSpanTotalMilliseconds, "us");
+                    return new DurationLiteral("DurationLiteral", new List<Duration> { duration });
+                case Expression e:
+                    return e;
                 default:
                     return CreateStringLiteral(variable);
             }

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -955,6 +955,29 @@ from(bucket: "my-bucket")
     |> filter(fn: (r) => contains(value: r["data"], set: [15, 28]))
 ```
 
+## Custom LINQ operators
+
+### AggregateWindow
+
+The `AggregateWindow` applies an aggregate function to fixed windows of time. 
+Can be used only for field which is defined as `timestamp` - `[Column(IsTimestamp = true)]`. 
+For more info about `aggregateWindow() function` see Flux's documentation - https://docs.influxdata.com/flux/v0.x/stdlib/universe/aggregatewindow/.
+
+```c#
+var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi)
+    where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40), "mean")
+    select s;
+```
+
+Flux Query:
+```flux
+from(bucket: "my-bucket") 
+    |> range(start: 0) 
+    |> aggregateWindow(every: 20s, period: 40s, fn: mean) 
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
+```
+
 ## Domain Converter
 
 There is also possibility to use custom domain converter to transform data from/to your `DomainObject`.

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -37,6 +37,8 @@ This section contains links to the client library documentation.
     - [Count](#count)
     - [LongCount](#longcount)
     - [Contains](#contains)
+- [Custom LINQ operators](#custom-linq-operators)
+    - [AggregateWindow](#aggregatewindow)
 - [Domain Converter](#domain-converter)
 - [How to debug output Flux Query](#how-to-debug-output-flux-query)
 - [How to filter by Measurement](#how-to-filter-by-measurement)
@@ -960,7 +962,7 @@ from(bucket: "my-bucket")
 ### AggregateWindow
 
 The `AggregateWindow` applies an aggregate function to fixed windows of time. 
-Can be used only for field which is defined as `timestamp` - `[Column(IsTimestamp = true)]`. 
+Can be used only for a field which is defined as `timestamp` - `[Column(IsTimestamp = true)]`. 
 For more info about `aggregateWindow() function` see Flux's documentation - https://docs.influxdata.com/flux/v0.x/stdlib/universe/aggregatewindow/.
 
 ```c#

--- a/Client/InfluxDB.Client.Api/Domain/Duration.cs
+++ b/Client/InfluxDB.Client.Api/Domain/Duration.cs
@@ -35,7 +35,7 @@ namespace InfluxDB.Client.Api.Domain
         /// <param name="type">Type of AST node.</param>
         /// <param name="magnitude">magnitude.</param>
         /// <param name="unit">unit.</param>
-        public Duration(string type = default(string), int? magnitude = default(int?), string unit = default(string))
+        public Duration(string type = default(string), long magnitude = default(long), string unit = default(string))
         {
             this.Type = type;
             this.Magnitude = magnitude;
@@ -53,7 +53,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Gets or Sets Magnitude
         /// </summary>
         [DataMember(Name="magnitude", EmitDefaultValue=false)]
-        public int? Magnitude { get; set; }
+        public long Magnitude { get; set; }
 
         /// <summary>
         /// Gets or Sets Unit

--- a/Client/InfluxDB.Client.Api/Domain/Duration.cs
+++ b/Client/InfluxDB.Client.Api/Domain/Duration.cs
@@ -35,7 +35,7 @@ namespace InfluxDB.Client.Api.Domain
         /// <param name="type">Type of AST node.</param>
         /// <param name="magnitude">magnitude.</param>
         /// <param name="unit">unit.</param>
-        public Duration(string type = default(string), long magnitude = default(long), string unit = default(string))
+        public Duration(string type = default(string), long? magnitude = default(long?), string unit = default(string))
         {
             this.Type = type;
             this.Magnitude = magnitude;
@@ -53,7 +53,7 @@ namespace InfluxDB.Client.Api.Domain
         /// Gets or Sets Magnitude
         /// </summary>
         [DataMember(Name="magnitude", EmitDefaultValue=false)]
-        public long Magnitude { get; set; }
+        public long? Magnitude { get; set; }
 
         /// <summary>
         /// Gets or Sets Unit


### PR DESCRIPTION
Closes #278 

## Proposed Changes

Add support to use `aggregateWindow` in LINQ expression:

```c#
var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi)
    where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40), "mean")
    where s.Value == 5
    select s;
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
