### PR TITLE
chore: update RestSharp to 107.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -221,6 +221,7 @@ This release also uses new version of InfluxDB OSS API definitions - [oss.yml](h
 [#283](https://github.com/influxdata/influxdb-client-csharp/pull/283): Update dependencies:
  
 #### Build:
+    - RestSharp to 107.3.0
     - CsvHelper to 27.2.1
     - NodaTime to 3.0.9
     - Microsoft.Extensions.ObjectPool to 6.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0.rc1 [unreleased]
+## 4.0.0-rc1 [unreleased]
 
 ### Breaking Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 4.0.0 [unreleased]
+## 4.0.0.rc1 [unreleased]
 
 ### Breaking Changes
 

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="NodaTime" Version="3.0.9" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="RestSharp" Version="107.2.1" />
+      <PackageReference Include="RestSharp" Version="107.3.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Proposed Changes

1. Updated RestSharp to `107.3.0`.
2. Set upcoming client version to `4.0.0-rc1`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
