### PR TITLE
feat: uses `CancellationToken` in all async methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,23 @@
 ## 4.0.0-rc2 [unreleased]
 
+### Migration Notice
+
+- New versions of `QueryApi`, `QueryApiSync`, `WriteApi`, `WriteApiAsync` and `FluxClient` methods uses default named argument values so you are able to easily migrate by:
+
+```diff
+- _client.GetQueryApi().QueryAsyncEnumerable<T>(fluxQuery, token);
++ _client.GetQueryApi().QueryAsyncEnumerable<T>(fluxQuery, cancellationToken: token);
+```
+
+### Breaking Changes
+
+#### API
+
+- Removed `orgId` argument from `TelegrafsApi.GetRunsAsync` methods
+
 ### Features
 1. [#291](https://github.com/influxdata/influxdb-client-csharp/pull/291): Add possibility to generate Flux query without `pivot()` function [LINQ]
+1. [#289](https://github.com/influxdata/influxdb-client-csharp/pull/289): `TasksApi` uses `CancellationToken` in all `async` methods
 
 ### CI
 1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage
@@ -195,6 +211,7 @@
 - Rename `TelegrafPlugin` types:
   - from `TelegrafPlugin.TypeEnum.Inputs` to `TelegrafPlugin.TypeEnum.Input`
   - from `TelegrafPlugin.TypeEnum.Outputs` to `TelegrafPlugin.TypeEnum.Output`
+- `TasksApi.FindTasksByOrganizationIdAsync(string orgId)` requires pass Organization `ID` as a parameter. For find Tasks by Organization name you can use: `_tasksApi.FindTasksAsync(org: "my-org")`.
 
 #### Services
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Features
 1. [#291](https://github.com/influxdata/influxdb-client-csharp/pull/291): Add possibility to generate Flux query without `pivot()` function [LINQ]
-1. [#289](https://github.com/influxdata/influxdb-client-csharp/pull/289): `TasksApi` uses `CancellationToken` in all `async` methods
+1. [#289](https://github.com/influxdata/influxdb-client-csharp/pull/289): Async APIs uses `CancellationToken` in all `async` methods
 
 ### CI
 1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -187,10 +187,11 @@ namespace InfluxDB.Client.Flux
         /// <summary>
         /// Check the status of InfluxDB Server.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>true if server is healthy otherwise return false</returns>
-        public async Task<bool> PingAsync()
+        public async Task<bool> PingAsync(CancellationToken cancellationToken = default)
         {
-            var request = ExecuteAsync(PingRequest());
+            var request = ExecuteAsync(PingRequest(), cancellationToken);
 
             return await PingAsync(request);
         }
@@ -198,11 +199,12 @@ namespace InfluxDB.Client.Flux
         /// <summary>
         ///  Return the version of the connected InfluxDB Server.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the version String, otherwise unknown</returns>
         /// <exception cref="InfluxException">throws when request did not succesfully ends</exception>
-        public async Task<string> VersionAsync()
+        public async Task<string> VersionAsync(CancellationToken cancellationToken = default)
         {
-            var request = ExecuteAsync(PingRequest());
+            var request = ExecuteAsync(PingRequest(), cancellationToken);
 
             return await VersionAsync(request);
         }
@@ -248,11 +250,12 @@ namespace InfluxDB.Client.Flux
                 cancellationToken);
         }
 
-        private async Task<RestResponse> ExecuteAsync(RestRequest request)
+        private async Task<RestResponse> ExecuteAsync(RestRequest request,
+            CancellationToken cancellationToken = default)
         {
             BeforeIntercept(request);
 
-            var response = await RestClient.ExecuteAsync(request).ConfigureAwait(false);
+            var response = await RestClient.ExecuteAsync(request, cancellationToken).ConfigureAwait(false);
 
             RaiseForInfluxError(response, response.Content);
 

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -83,7 +83,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().UsingGet())
                 .RespondWith(CreateResponse(data, "application/json"));
 
-            var runs = await _client.GetTasksApi().GetRunsAsync("taskId", "runId");
+            var runs = await _client.GetTasksApi().GetRunsAsync("taskId");
             Assert.AreEqual(20, runs.Count);
             foreach (var run in runs) Assert.IsNotNull(run.StartedAt);
         }

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -84,7 +84,7 @@ namespace InfluxDB.Client.Test
 
             var message = Assert
                 .ThrowsAsync<NotFoundException>(async () => await _tasksApi.CancelRunAsync(runs.First()))
-                .Message;
+                ?.Message;
 
             Assert.AreEqual("failed to cancel run: run not found", message);
         }
@@ -93,7 +93,8 @@ namespace InfluxDB.Client.Test
         public void CancelRunTaskNotExist()
         {
             var message = Assert.ThrowsAsync<NotFoundException>(async () =>
-                await _tasksApi.CancelRunAsync("020f755c3c082000", "020f755c3c082000")).Message;
+                    await _tasksApi.CancelRunAsync("020f755c3c082000", "020f755c3c082000"))
+                ?.Message;
 
             Assert.AreEqual("failed to cancel run: task not found", message);
         }
@@ -129,7 +130,7 @@ namespace InfluxDB.Client.Test
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.CloneTaskAsync("020f755c3c082000"));
 
-            Assert.AreEqual("failed to find task: task not found", ioe.Message);
+            Assert.AreEqual("failed to find task: task not found", ioe?.Message);
         }
 
         [Test]
@@ -220,7 +221,7 @@ namespace InfluxDB.Client.Test
 
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () => await _tasksApi.FindTaskByIdAsync(task.Id));
 
-            Assert.AreEqual("failed to find task: task not found", ioe.Message);
+            Assert.AreEqual("failed to find task: task not found", ioe?.Message);
         }
 
         [Test]
@@ -250,7 +251,7 @@ namespace InfluxDB.Client.Test
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.FindTaskByIdAsync("020f755c3d082000"));
 
-            Assert.AreEqual("failed to find task: task not found", ioe.Message);
+            Assert.AreEqual("failed to find task: task not found", ioe?.Message);
         }
 
         [Test]
@@ -498,7 +499,7 @@ namespace InfluxDB.Client.Test
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.RetryRunAsync(task.Id, "020f755c3c082000"));
 
-            Assert.AreEqual("failed to retry run: run not found", ioe.Message);
+            Assert.AreEqual("failed to retry run: run not found", ioe?.Message);
         }
 
         [Test]
@@ -509,7 +510,7 @@ namespace InfluxDB.Client.Test
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
                 await _tasksApi.GetRunAsync(task.Id, "020f755c3c082000"));
 
-            Assert.AreEqual("failed to find run: run not found", ioe.Message);
+            Assert.AreEqual("failed to find run: run not found", ioe?.Message);
         }
 
         [Test]
@@ -571,7 +572,7 @@ namespace InfluxDB.Client.Test
         public void RunsNotExist()
         {
             var ioe = Assert.ThrowsAsync<NotFoundException>(async () =>
-                await _tasksApi.GetRunsAsync("020f755c3c082000", _organization.Id));
+                await _tasksApi.GetRunsAsync("020f755c3c082000"));
 
             Assert.NotNull(ioe, "ioe.InnerException != null");
             Assert.AreEqual("failed to find runs: task not found", ioe.Message);

--- a/Client/AuthorizationsApi.cs
+++ b/Client/AuthorizationsApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -24,13 +25,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="organization">the owner of the authorization</param>
         /// <param name="permissions">the permissions for the authorization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the created authorization</returns>
-        public Task<Authorization> CreateAuthorizationAsync(Organization organization, List<Permission> permissions)
+        public Task<Authorization> CreateAuthorizationAsync(Organization organization, List<Permission> permissions,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, "organization");
             Arguments.CheckNotNull(permissions, "permissions");
 
-            return CreateAuthorizationAsync(organization.Id, permissions);
+            return CreateAuthorizationAsync(organization.Id, permissions, cancellationToken);
         }
 
         /// <summary>
@@ -38,8 +41,10 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">the owner id of the authorization</param>
         /// <param name="permissions">the permissions for the authorization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the created authorization</returns>
-        public Task<Authorization> CreateAuthorizationAsync(string orgId, List<Permission> permissions)
+        public Task<Authorization> CreateAuthorizationAsync(string orgId, List<Permission> permissions,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, "orgId");
             Arguments.CheckNotNull(permissions, "permissions");
@@ -47,16 +52,18 @@ namespace InfluxDB.Client
             var authorization =
                 new AuthorizationPostRequest(orgId, null, permissions, AuthorizationUpdateRequest.StatusEnum.Active);
 
-            return CreateAuthorizationAsync(authorization);
+            return CreateAuthorizationAsync(authorization, cancellationToken);
         }
 
         /// <summary>
         /// Create an authorization with defined permissions.
         /// </summary>
         /// <param name="authorization">authorization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the created authorization</returns>
         [Obsolete("This method is obsolete. Call 'CreateAuthorizationAsync(AuthorizationPostRequest)' instead.", false)]
-        public Task<Authorization> CreateAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> CreateAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
@@ -65,78 +72,89 @@ namespace InfluxDB.Client
                     authorization.UserID,
                     authorization.Permissions, description: authorization.Description);
 
-            return CreateAuthorizationAsync(request);
+            return CreateAuthorizationAsync(request, cancellationToken);
         }
 
         /// <summary>
         /// Create an authorization with defined permissions.
         /// </summary>
         /// <param name="authorization">authorization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the created authorization</returns>
-        public Task<Authorization> CreateAuthorizationAsync(AuthorizationPostRequest authorization)
+        public Task<Authorization> CreateAuthorizationAsync(AuthorizationPostRequest authorization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
-            return _service.PostAuthorizationsAsync(authorization);
+            return _service.PostAuthorizationsAsync(authorization, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Updates the status of the authorization. Useful for setting an authorization to inactive or active.
         /// </summary>
         /// <param name="authorization">the authorization with updated status</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the updated authorization</returns>
-        public Task<Authorization> UpdateAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> UpdateAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
             var request = new AuthorizationUpdateRequest(authorization.Status, authorization.Description);
 
-            return _service.PatchAuthorizationsIDAsync(authorization.Id, request);
+            return _service.PatchAuthorizationsIDAsync(authorization.Id, request, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete an authorization.
         /// </summary>
         /// <param name="authorization">authorization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>authorization deleted</returns>
-        public Task DeleteAuthorizationAsync(Authorization authorization)
+        public Task DeleteAuthorizationAsync(Authorization authorization, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
-            return DeleteAuthorizationAsync(authorization.Id);
+            return DeleteAuthorizationAsync(authorization.Id, cancellationToken);
         }
 
         /// <summary>
         /// Delete an authorization.
         /// </summary>
         /// <param name="authorizationId">ID of authorization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>authorization deleted</returns>
-        public Task DeleteAuthorizationAsync(string authorizationId)
+        public Task DeleteAuthorizationAsync(string authorizationId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            return _service.DeleteAuthorizationsIDAsync(authorizationId);
+            return _service.DeleteAuthorizationsIDAsync(authorizationId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Clone an authorization.
         /// </summary>
         /// <param name="authorizationId">ID of authorization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned authorization</returns>
-        public async Task<Authorization> CloneAuthorizationAsync(string authorizationId)
+        public async Task<Authorization> CloneAuthorizationAsync(string authorizationId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            var authorization = await FindAuthorizationByIdAsync(authorizationId).ConfigureAwait(false);
-            return await CloneAuthorizationAsync(authorization).ConfigureAwait(false);
+            var authorization =
+                await FindAuthorizationByIdAsync(authorizationId, cancellationToken).ConfigureAwait(false);
+            return await CloneAuthorizationAsync(authorization, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Clone an authorization.
         /// </summary>
         /// <param name="authorization">authorization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned authorization</returns>
-        public Task<Authorization> CloneAuthorizationAsync(Authorization authorization)
+        public Task<Authorization> CloneAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(authorization, nameof(authorization));
 
@@ -144,69 +162,81 @@ namespace InfluxDB.Client
                 authorization.Permissions,
                 authorization.Status, authorization.Description);
 
-            return CreateAuthorizationAsync(cloned);
+            return CreateAuthorizationAsync(cloned, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve an authorization.
         /// </summary>
         /// <param name="authorizationId">ID of authorization to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>authorization details</returns>
-        public Task<Authorization> FindAuthorizationByIdAsync(string authorizationId)
+        public Task<Authorization> FindAuthorizationByIdAsync(string authorizationId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(authorizationId, nameof(authorizationId));
 
-            return _service.GetAuthorizationsIDAsync(authorizationId);
+            return _service.GetAuthorizationsIDAsync(authorizationId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all authorizations.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List all authorizations.</returns>
-        public Task<List<Authorization>> FindAuthorizationsAsync()
+        public Task<List<Authorization>> FindAuthorizationsAsync(CancellationToken cancellationToken = default)
         {
-            return FindAuthorizationsByAsync(null, null);
+            return FindAuthorizationsByAsync(null, null, cancellationToken);
         }
 
         /// <summary>
         /// List all authorizations belonging to specified user.
         /// </summary>
         /// <param name="user">user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of authorizations</returns>
-        public Task<List<Authorization>> FindAuthorizationsByUserAsync(User user)
+        public Task<List<Authorization>> FindAuthorizationsByUserAsync(User user,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, "user");
 
-            return FindAuthorizationsByUserIdAsync(user.Id);
+            return FindAuthorizationsByUserIdAsync(user.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all authorizations belonging to specified user.
         /// </summary>
         /// <param name="userId">ID of user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of authorizations</returns>
-        public Task<List<Authorization>> FindAuthorizationsByUserIdAsync(string userId)
+        public Task<List<Authorization>> FindAuthorizationsByUserIdAsync(string userId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(userId, "User ID");
 
-            return FindAuthorizationsByAsync(userId, null);
+            return FindAuthorizationsByAsync(userId, null, cancellationToken);
         }
 
         /// <summary>
         /// List all authorizations belonging to specified user.
         /// </summary>
         /// <param name="userName">Name of User</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of authorizations</returns>
-        public Task<List<Authorization>> FindAuthorizationsByUserNameAsync(string userName)
+        public Task<List<Authorization>> FindAuthorizationsByUserNameAsync(string userName,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(userName, "User name");
 
-            return FindAuthorizationsByAsync(null, userName);
+            return FindAuthorizationsByAsync(null, userName, cancellationToken);
         }
 
-        private async Task<List<Authorization>> FindAuthorizationsByAsync(string userId, string userName)
+        private async Task<List<Authorization>> FindAuthorizationsByAsync(string userId, string userName,
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetAuthorizationsAsync(null, userId, userName).ConfigureAwait(false);
+            var response = await _service
+                .GetAuthorizationsAsync(null, userId, userName, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response._Authorizations;
         }
     }

--- a/Client/BucketsApi.cs
+++ b/Client/BucketsApi.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -24,27 +25,29 @@ namespace InfluxDB.Client
         /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
         /// </summary>
         /// <param name="bucket">bucket to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
-        public Task<Bucket> CreateBucketAsync(Bucket bucket)
+        public Task<Bucket> CreateBucketAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
             var postBucket = new PostBucketRequest(bucket.OrgID, bucket.Name, bucket.Description,
                 bucket.Rp, bucket.RetentionRules);
 
-            return _service.PostBucketsAsync(postBucket);
+            return _service.PostBucketsAsync(postBucket, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
         /// </summary>
         /// <param name="bucket">bucket to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
-        public Task<Bucket> CreateBucketAsync(PostBucketRequest bucket)
+        public Task<Bucket> CreateBucketAsync(PostBucketRequest bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return _service.PostBucketsAsync(bucket);
+            return _service.PostBucketsAsync(bucket, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -52,13 +55,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name">name of the bucket</param>
         /// <param name="organization">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
-        public Task<Bucket> CreateBucketAsync(string name, Organization organization)
+        public Task<Bucket> CreateBucketAsync(string name, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return CreateBucketAsync(name, organization.Id);
+            return CreateBucketAsync(name, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -67,14 +72,15 @@ namespace InfluxDB.Client
         /// <param name="name">name of the bucket</param>
         /// <param name="bucketRetentionRules">retention rule of the bucket</param>
         /// <param name="organization">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
         public Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules,
-            Organization organization)
+            Organization organization, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return CreateBucketAsync(name, bucketRetentionRules, organization.Id);
+            return CreateBucketAsync(name, bucketRetentionRules, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -82,13 +88,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name">name of the bucket</param>
         /// <param name="orgId">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
-        public Task<Bucket> CreateBucketAsync(string name, string orgId)
+        public Task<Bucket> CreateBucketAsync(string name, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return CreateBucketAsync(name, default, orgId);
+            return CreateBucketAsync(name, default, orgId, cancellationToken);
         }
 
         /// <summary>
@@ -97,8 +104,10 @@ namespace InfluxDB.Client
         /// <param name="name">name of the bucket</param>
         /// <param name="bucketRetentionRules">retention rule of the bucket</param>
         /// <param name="orgId">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Bucket</returns>
-        public Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules, string orgId)
+        public Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
@@ -109,15 +118,16 @@ namespace InfluxDB.Client
                 bucket.RetentionRules.Add(bucketRetentionRules);
             }
 
-            return CreateBucketAsync(bucket);
+            return CreateBucketAsync(bucket, cancellationToken);
         }
 
         /// <summary>
         /// Update a bucket name and retention.
         /// </summary>
         /// <param name="bucket">bucket update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>bucket updated</returns>
-        public Task<Bucket> UpdateBucketAsync(Bucket bucket)
+        public Task<Bucket> UpdateBucketAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
@@ -128,31 +138,33 @@ namespace InfluxDB.Client
             }).ToList();
 
             var request = new PatchBucketRequest(bucket.Name, bucket.Description, retentionRules);
-            return _service.PatchBucketsIDAsync(bucket.Id, request);
+            return _service.PatchBucketsIDAsync(bucket.Id, request, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a bucket.
         /// </summary>
         /// <param name="bucketId">ID of bucket to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteBucketAsync(string bucketId)
+        public Task DeleteBucketAsync(string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return _service.DeleteBucketsIDAsync(bucketId);
+            return _service.DeleteBucketsIDAsync(bucketId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a bucket.
         /// </summary>
         /// <param name="bucket">bucket to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteBucketAsync(Bucket bucket)
+        public Task DeleteBucketAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return DeleteBucketAsync(bucket.Id);
+            return DeleteBucketAsync(bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -160,14 +172,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned bucket</param>
         /// <param name="bucketId">ID of bucket to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned bucket</returns>
-        public async Task<Bucket> CloneBucketAsync(string clonedName, string bucketId)
+        public async Task<Bucket> CloneBucketAsync(string clonedName, string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var bucket = await FindBucketByIdAsync(bucketId).ConfigureAwait(false);
-            return await CloneBucketAsync(clonedName, bucket).ConfigureAwait(false);
+            var bucket = await FindBucketByIdAsync(bucketId, cancellationToken).ConfigureAwait(false);
+            return await CloneBucketAsync(clonedName, bucket, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -175,18 +189,20 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned bucket</param>
         /// <param name="bucket">bucket to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned bucket</returns>
-        public async Task<Bucket> CloneBucketAsync(string clonedName, Bucket bucket)
+        public async Task<Bucket> CloneBucketAsync(string clonedName, Bucket bucket,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
             var cloned = new Bucket(null, clonedName, null, bucket.OrgID, bucket.Rp, null, bucket.RetentionRules);
 
-            var created = await CreateBucketAsync(cloned).ConfigureAwait(false);
+            var created = await CreateBucketAsync(cloned, cancellationToken).ConfigureAwait(false);
 
-            var labels = await GetLabelsAsync(bucket).ConfigureAwait(false);
-            foreach (var label in labels) await AddLabelAsync(label, created).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(bucket, cancellationToken).ConfigureAwait(false);
+            foreach (var label in labels) await AddLabelAsync(label, created, cancellationToken).ConfigureAwait(false);
 
             return created;
         }
@@ -195,25 +211,29 @@ namespace InfluxDB.Client
         /// Retrieve a bucket.
         /// </summary>
         /// <param name="bucketId">ID of bucket to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Bucket Details</returns>
-        public Task<Bucket> FindBucketByIdAsync(string bucketId)
+        public Task<Bucket> FindBucketByIdAsync(string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            return _service.GetBucketsIDAsync(bucketId);
+            return _service.GetBucketsIDAsync(bucketId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Retrieve a bucket.
         /// </summary>
         /// <param name="bucketName">Name of bucket to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Bucket Details</returns>
-        public async Task<Bucket> FindBucketByNameAsync(string bucketName)
+        public async Task<Bucket> FindBucketByNameAsync(string bucketName,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketName, nameof(bucketName));
 
             var buckets = await _service
-                .GetBucketsAsync(null, null, null, null, null, null, bucketName).ConfigureAwait(false);
+                .GetBucketsAsync(null, null, null, null, null, null, bucketName, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
 
             return buckets._Buckets.FirstOrDefault();
         }
@@ -222,22 +242,26 @@ namespace InfluxDB.Client
         /// List all buckets for specified organization.
         /// </summary>
         /// <param name="organization">filter buckets to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of buckets</returns>
-        public Task<List<Bucket>> FindBucketsByOrganizationAsync(Organization organization)
+        public Task<List<Bucket>> FindBucketsByOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return FindBucketsByOrgNameAsync(organization.Name);
+            return FindBucketsByOrgNameAsync(organization.Name, cancellationToken);
         }
 
         /// <summary>
         /// List all buckets for specified orgId.
         /// </summary>
         /// <param name="orgName">filter buckets to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of buckets</returns>
-        public Task<List<Bucket>> FindBucketsByOrgNameAsync(string orgName)
+        public Task<List<Bucket>> FindBucketsByOrgNameAsync(string orgName,
+            CancellationToken cancellationToken = default)
         {
-            return FindBucketsAsync(org: orgName);
+            return FindBucketsAsync(org: orgName, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -250,11 +274,14 @@ namespace InfluxDB.Client
         /// <param name="orgID">The organization ID. (optional)</param>
         /// <param name="name">Only returns buckets with a specific name. (optional)</param>
         /// <param name="id">Only returns buckets with a specific ID. (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List all buckets</returns>
         public async Task<List<Bucket>> FindBucketsAsync(int? offset = null, int? limit = null, string after = null,
-            string org = null, string orgID = null, string name = null, string id = null)
+            string org = null, string orgID = null, string name = null, string id = null,
+            CancellationToken cancellationToken = default)
         {
-            var buckets = await GetBucketsAsync(offset, limit, after, org, orgID, name, id).ConfigureAwait(false);
+            var buckets = await GetBucketsAsync(offset, limit, after, org, orgID, name, id, cancellationToken)
+                .ConfigureAwait(false);
             return buckets._Buckets;
         }
 
@@ -262,36 +289,42 @@ namespace InfluxDB.Client
         /// List all buckets.
         /// </summary>
         /// <param name="findOptions">the find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List all buckets</returns>
-        public Task<Buckets> FindBucketsAsync(FindOptions findOptions)
+        public Task<Buckets> FindBucketsAsync(FindOptions findOptions, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
-            return GetBucketsAsync(findOptions.Offset, findOptions.Limit, findOptions.After);
+            return GetBucketsAsync(findOptions.Offset, findOptions.Limit, findOptions.After,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all members of a bucket.
         /// </summary>
         /// <param name="bucket">bucket of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a bucket</returns>
-        public Task<List<ResourceMember>> GetMembersAsync(Bucket bucket)
+        public Task<List<ResourceMember>> GetMembersAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return GetMembersAsync(bucket.Id);
+            return GetMembersAsync(bucket.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all members of a bucket.
         /// </summary>
         /// <param name="bucketId">ID of bucket to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a bucket</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(string bucketId)
+        public async Task<List<ResourceMember>> GetMembersAsync(string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var members = await _service.GetBucketsIDMembersAsync(bucketId).ConfigureAwait(false);
+            var members = await _service.GetBucketsIDMembersAsync(bucketId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return members.Users;
         }
 
@@ -300,13 +333,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a bucket</param>
         /// <param name="bucket">the bucket of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(User member, Bucket bucket)
+        public Task<ResourceMember> AddMemberAsync(User member, Bucket bucket,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return AddMemberAsync(member.Id, bucket.Id);
+            return AddMemberAsync(member.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -314,15 +349,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(string memberId, string bucketId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
             var mapping = new AddResourceMemberRequestBody(memberId);
 
-            return _service.PostBucketsIDMembersAsync(bucketId, mapping);
+            return _service.PostBucketsIDMembersAsync(bucketId, mapping, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -330,13 +367,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a bucket</param>
         /// <param name="bucket">the bucket of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(User member, Bucket bucket)
+        public Task DeleteMemberAsync(User member, Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return DeleteMemberAsync(member.Id, bucket.Id);
+            return DeleteMemberAsync(member.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -344,37 +382,42 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(string memberId, string bucketId)
+        public Task DeleteMemberAsync(string memberId, string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.DeleteBucketsIDMembersIDAsync(memberId, bucketId);
+            return _service.DeleteBucketsIDMembersIDAsync(memberId, bucketId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a bucket.
         /// </summary>
         /// <param name="bucket">bucket of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a bucket</returns>
-        public Task<List<ResourceOwner>> GetOwnersAsync(Bucket bucket)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return GetOwnersAsync(bucket.Id);
+            return GetOwnersAsync(bucket.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a bucket.
         /// </summary>
         /// <param name="bucketId">ID of a bucket to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a bucket</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(string bucketId)
+        public async Task<List<ResourceOwner>> GetOwnersAsync(string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var members = await _service.GetBucketsIDOwnersAsync(bucketId).ConfigureAwait(false);
+            var members = await _service.GetBucketsIDOwnersAsync(bucketId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return members.Users;
         }
 
@@ -383,13 +426,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(User owner, Bucket bucket)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Bucket bucket,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return AddOwnerAsync(owner.Id, bucket.Id);
+            return AddOwnerAsync(owner.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -397,15 +442,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string bucketId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
             var mapping = new AddResourceMemberRequestBody(ownerId);
 
-            return _service.PostBucketsIDOwnersAsync(bucketId, mapping);
+            return _service.PostBucketsIDOwnersAsync(bucketId, mapping, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -413,13 +460,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(User owner, Bucket bucket)
+        public Task DeleteOwnerAsync(User owner, Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return DeleteOwnerAsync(owner.Id, bucket.Id);
+            return DeleteOwnerAsync(owner.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -427,37 +475,41 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(string ownerId, string bucketId)
+        public Task DeleteOwnerAsync(string ownerId, string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.DeleteBucketsIDOwnersIDAsync(ownerId, bucketId);
+            return _service.DeleteBucketsIDOwnersIDAsync(ownerId, bucketId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all labels of a bucket.
         /// </summary>
         /// <param name="bucket">bucket of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a bucket</returns>
-        public Task<List<Label>> GetLabelsAsync(Bucket bucket)
+        public Task<List<Label>> GetLabelsAsync(Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
 
-            return GetLabelsAsync(bucket.Id);
+            return GetLabelsAsync(bucket.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels of a bucket.
         /// </summary>
         /// <param name="bucketId">ID of a bucket to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a bucket</returns>
-        public async Task<List<Label>> GetLabelsAsync(string bucketId)
+        public async Task<List<Label>> GetLabelsAsync(string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
 
-            var response = await _service.GetBucketsIDLabelsAsync(bucketId).ConfigureAwait(false);
+            var response = await _service.GetBucketsIDLabelsAsync(bucketId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -466,13 +518,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a bucket</param>
         /// <param name="bucket">the bucket of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public Task<Label> AddLabelAsync(Label label, Bucket bucket)
+        public Task<Label> AddLabelAsync(Label label, Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, bucket.Id);
+            return AddLabelAsync(label.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -480,15 +533,19 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string bucketId)
+        public async Task<Label> AddLabelAsync(string labelId, string bucketId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostBucketsIDLabelsAsync(bucketId, mapping).ConfigureAwait(false);
+            var response = await _service
+                .PostBucketsIDLabelsAsync(bucketId, mapping, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
@@ -497,13 +554,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a bucket</param>
         /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(Label label, Bucket bucket)
+        public Task DeleteLabelAsync(Label label, Bucket bucket, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(bucket, nameof(bucket));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, bucket.Id);
+            return DeleteLabelAsync(label.Id, bucket.Id, cancellationToken);
         }
 
         /// <summary>
@@ -511,20 +569,22 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(string labelId, string bucketId)
+        public Task DeleteLabelAsync(string labelId, string bucketId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(bucketId, nameof(bucketId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteBucketsIDLabelsIDAsync(bucketId, labelId);
+            return _service.DeleteBucketsIDLabelsIDAsync(bucketId, labelId, cancellationToken: cancellationToken);
         }
 
         private Task<Buckets> GetBucketsAsync(int? offset = null, int? limit = null, string after = null,
-            string org = null, string orgID = null, string name = null, string id = null)
+            string org = null, string orgID = null, string name = null, string id = null,
+            CancellationToken cancellationToken = default)
         {
             return _service.GetBucketsAsync(offset: offset, limit: limit, after: after, org: org, orgID: orgID,
-                name: name, id: id);
+                name: name, id: id, cancellationToken: cancellationToken);
         }
     }
 }

--- a/Client/ChecksApi.cs
+++ b/Client/ChecksApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -31,15 +32,16 @@ namespace InfluxDB.Client
         /// <param name="messageTemplate">template that is used to generate and write a status message</param>
         /// <param name="threshold">condition for that specific status</param>
         /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>ThresholdCheck created</returns>
-        public Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query,
-            string every, string messageTemplate, Threshold threshold, string orgId)
+        public Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query, string every,
+            string messageTemplate, Threshold threshold, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(threshold, nameof(threshold));
 
             var thresholds = new List<Threshold> { threshold };
 
-            return CreateThresholdCheckAsync(name, query, every, messageTemplate, thresholds, orgId);
+            return CreateThresholdCheckAsync(name, query, every, messageTemplate, thresholds, orgId, cancellationToken);
         }
 
         /// <summary>
@@ -51,10 +53,11 @@ namespace InfluxDB.Client
         /// <param name="messageTemplate">template that is used to generate and write a status message</param>
         /// <param name="thresholds">conditions for that specific status</param>
         /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>ThresholdCheck created</returns>
-        public async Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query,
-            string every,
-            string messageTemplate, List<Threshold> thresholds, string orgId)
+        public async Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query, string every,
+            string messageTemplate, List<Threshold> thresholds, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(query, nameof(query));
@@ -67,7 +70,7 @@ namespace InfluxDB.Client
                 orgID: orgId, every: every, statusMessageTemplate: messageTemplate, status: TaskStatusType.Active,
                 query: CreateDashboardQuery(query));
 
-            return (ThresholdCheck)await CreateCheckAsync(check).ConfigureAwait(false);
+            return (ThresholdCheck)await CreateCheckAsync(check, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -81,9 +84,11 @@ namespace InfluxDB.Client
         /// <param name="messageTemplate">template that is used to generate and write a status message</param>
         /// <param name="level">the state to record if check matches a criteria</param>
         /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>DeadmanCheck created</returns>
         public async Task<DeadmanCheck> CreateDeadmanCheckAsync(string name, string query, string every,
-            string timeSince, string staleTime, string messageTemplate, CheckStatusLevel level, string orgId)
+            string timeSince, string staleTime, string messageTemplate, CheckStatusLevel level, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(query, nameof(query));
@@ -99,25 +104,27 @@ namespace InfluxDB.Client
                 orgID: orgId, query: CreateDashboardQuery(query), statusMessageTemplate: messageTemplate,
                 status: TaskStatusType.Active);
 
-            return (DeadmanCheck)await CreateCheckAsync(check).ConfigureAwait(false);
+            return (DeadmanCheck)await CreateCheckAsync(check, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Add new check.
         /// </summary>
         /// <param name="check">check to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Check created</returns>
-        public Task<Check> CreateCheckAsync(Check check)
+        public Task<Check> CreateCheckAsync(Check check, CancellationToken cancellationToken = default)
         {
-            return _service.CreateCheckAsync(check);
+            return _service.CreateCheckAsync(check, cancellationToken);
         }
 
         /// <summary>
         /// Update a check.
         /// </summary>
         /// <param name="check">check update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated check</returns>
-        public Task<Check> UpdateCheckAsync(Check check)
+        public Task<Check> UpdateCheckAsync(Check check, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
@@ -125,7 +132,7 @@ namespace InfluxDB.Client
                 out CheckPatch.StatusEnum status);
 
             return UpdateCheckAsync(check.Id,
-                new CheckPatch(check.Name, check.Description, status));
+                new CheckPatch(check.Name, check.Description, status), cancellationToken);
         }
 
         /// <summary>
@@ -133,61 +140,67 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="checkId">ID of check</param>
         /// <param name="patch">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated check</returns>
-        public Task<Check> UpdateCheckAsync(string checkId, CheckPatch patch)
+        public Task<Check> UpdateCheckAsync(string checkId, CheckPatch patch,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
             Arguments.CheckNotNull(patch, nameof(patch));
 
-            return _service.PatchChecksIDAsync(checkId, patch);
+            return _service.PatchChecksIDAsync(checkId, patch, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a check.
         /// </summary>
         /// <param name="check">the check to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteCheckAsync(Check check)
+        public Task DeleteCheckAsync(Check check, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
-            return DeleteCheckAsync(check.Id);
+            return DeleteCheckAsync(check.Id, cancellationToken);
         }
 
         /// <summary>
         /// Delete a check.
         /// </summary>
         /// <param name="checkId">checkID the ID of check to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteCheckAsync(string checkId)
+        public Task DeleteCheckAsync(string checkId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            return _service.DeleteChecksIDAsync(checkId);
+            return _service.DeleteChecksIDAsync(checkId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get a check.
         /// </summary>
         /// <param name="checkId">ID of check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the check requested</returns>
-        public Task<Check> FindCheckByIdAsync(string checkId)
+        public Task<Check> FindCheckByIdAsync(string checkId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            return _service.GetChecksIDAsync(checkId);
+            return _service.GetChecksIDAsync(checkId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get checks.
         /// </summary>
         /// <param name="orgId">only show checks belonging to specified organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of checks</returns>
-        public async Task<List<Check>> FindChecksAsync(string orgId)
+        public async Task<List<Check>> FindChecksAsync(string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var checks = await FindChecksAsync(orgId, new FindOptions()).ConfigureAwait(false);
+            var checks = await FindChecksAsync(orgId, new FindOptions(), cancellationToken).ConfigureAwait(false);
             return checks._Checks;
         }
 
@@ -196,38 +209,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">only show checks belonging to specified organization</param>
         /// <param name="findOptions">find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of checks</returns>
-        public Task<Checks> FindChecksAsync(string orgId, FindOptions findOptions)
+        public Task<Checks> FindChecksAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
             return _service.GetChecksAsync(orgId, offset: findOptions.Offset,
-                limit: findOptions.Limit);
+                limit: findOptions.Limit, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a check.
         /// </summary>
         /// <param name="check"> the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a check</returns>
-        public Task<List<Label>> GetLabelsAsync(Check check)
+        public Task<List<Label>> GetLabelsAsync(Check check, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(check, nameof(check));
 
-            return GetLabelsAsync(check.Id);
+            return GetLabelsAsync(check.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a check.
         /// </summary>
         /// <param name="checkId">ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a check</returns>
-        public async Task<List<Label>> GetLabelsAsync(string checkId)
+        public async Task<List<Label>> GetLabelsAsync(string checkId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
 
-            var labels = await _service.GetChecksIDLabelsAsync(checkId).ConfigureAwait(false);
+            var labels = await _service.GetChecksIDLabelsAsync(checkId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return labels.Labels;
         }
 
@@ -236,13 +254,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to add</param>
         /// <param name="check">the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the label was added to the check</returns>
-        public Task<Label> AddLabelAsync(Label label, Check check)
+        public Task<Label> AddLabelAsync(Label label, Check check, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(check, nameof(check));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, check.Id);
+            return AddLabelAsync(label.Id, check.Id, cancellationToken);
         }
 
         /// <summary>
@@ -250,15 +269,18 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">ID of label to add</param>
         /// <param name="checkId">ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the label was added to the check</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string checkId)
+        public async Task<Label> AddLabelAsync(string labelId, string checkId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var labels = await _service.PostChecksIDLabelsAsync(checkId, mapping).ConfigureAwait(false);
+            var labels = await _service.PostChecksIDLabelsAsync(checkId, mapping, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return labels.Label;
         }
 
@@ -267,13 +289,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label to delete</param>
         /// <param name="check">the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteLabelAsync(Label label, Check check)
+        public Task DeleteLabelAsync(Label label, Check check, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(check, nameof(check));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, check.Id);
+            return DeleteLabelAsync(label.Id, check.Id, cancellationToken);
         }
 
         /// <summary>
@@ -281,13 +304,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">labelID the label id to delete</param>
         /// <param name="checkId">checkID ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteLabelAsync(string labelId, string checkId)
+        public Task DeleteLabelAsync(string labelId, string checkId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(checkId, nameof(checkId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteChecksIDLabelsIDAsync(checkId, labelId);
+            return _service.DeleteChecksIDLabelsIDAsync(checkId, labelId, cancellationToken: cancellationToken);
         }
 
         private DashboardQuery CreateDashboardQuery(string query)

--- a/Client/DeleteApi.cs
+++ b/Client/DeleteApi.cs
@@ -1,10 +1,9 @@
 using System;
-using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
 using InfluxDB.Client.Core;
-using NodaTime;
 
 namespace InfluxDB.Client
 {
@@ -27,7 +26,9 @@ namespace InfluxDB.Client
         /// <param name="predicate">Sql where like delete statement</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public Task Delete(DateTime start, DateTime stop, string predicate, Bucket bucket, Organization org)
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task Delete(DateTime start, DateTime stop, string predicate, Bucket bucket, Organization org,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(start, "Start is required");
             Arguments.CheckNotNull(stop, "Stop is required");
@@ -35,7 +36,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(bucket, "Bucket is required");
             Arguments.CheckNotNull(org, "Organization is required");
 
-            return Delete(start, stop, predicate, bucket.Id, org.Id);
+            return Delete(start, stop, predicate, bucket.Id, org.Id, cancellationToken);
         }
 
         /// <summary>
@@ -46,7 +47,9 @@ namespace InfluxDB.Client
         /// <param name="predicate">Sql where like delete statement</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public Task Delete(DateTime start, DateTime stop, string predicate, string bucket, string org)
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task Delete(DateTime start, DateTime stop, string predicate, string bucket, string org,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(start, "Start is required");
             Arguments.CheckNotNull(stop, "Stop is required");
@@ -56,7 +59,7 @@ namespace InfluxDB.Client
 
             var predicateRequest = new DeletePredicateRequest(start, stop, predicate);
 
-            return Delete(predicateRequest, bucket, org);
+            return Delete(predicateRequest, bucket, org, cancellationToken);
         }
 
         /// <summary>
@@ -65,13 +68,15 @@ namespace InfluxDB.Client
         /// <param name="predicate">Predicate delete request</param>
         /// <param name="bucket">The bucket from which data will be deleted</param>
         /// <param name="org">The organization of the above bucket</param>
-        public Task Delete(DeletePredicateRequest predicate, string bucket, string org)
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task Delete(DeletePredicateRequest predicate, string bucket, string org,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(predicate, "Predicate is required");
             Arguments.CheckNonEmptyString(bucket, "Bucket is required");
             Arguments.CheckNonEmptyString(org, "Organization is required");
 
-            return _service.PostDeleteAsync(predicate, null, org, bucket, null, null);
+            return _service.PostDeleteAsync(predicate, null, org, bucket, null, null, cancellationToken);
         }
     }
 }

--- a/Client/LabelsApi.cs
+++ b/Client/LabelsApi.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -19,108 +20,121 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
-        ///     Create a label
+        /// Create a label
         /// </summary>
         /// <param name="request">label to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Added label</returns>
-        public async Task<Label> CreateLabelAsync(LabelCreateRequest request)
+        public async Task<Label> CreateLabelAsync(LabelCreateRequest request,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(request, nameof(request));
 
-            var response = await _service.PostLabelsAsync(request).ConfigureAwait(false);
+            var response = await _service.PostLabelsAsync(request, cancellationToken).ConfigureAwait(false);
             return response.Label;
         }
 
         /// <summary>
-        ///     Create a label
+        /// Create a label
         /// </summary>
         /// <param name="name">name of a label</param>
         /// <param name="properties">properties of a label</param>
         /// <param name="orgId">owner of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Added label</returns>
         public Task<Label> CreateLabelAsync(string name, Dictionary<string, string> properties,
-            string orgId)
+            string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(properties, nameof(properties));
 
-            return CreateLabelAsync(new LabelCreateRequest(orgId, name, properties));
+            return CreateLabelAsync(new LabelCreateRequest(orgId, name, properties), cancellationToken);
         }
 
         /// <summary>
-        ///     Update a single label
+        /// Update a single label
         /// </summary>
         /// <param name="label">label to update</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Updated label</returns>
-        public Task<Label> UpdateLabelAsync(Label label)
+        public Task<Label> UpdateLabelAsync(Label label, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(label, nameof(label));
 
             var labelUpdate = new LabelUpdate { Properties = label.Properties };
 
-            return UpdateLabelAsync(label.Id, labelUpdate);
+            return UpdateLabelAsync(label.Id, labelUpdate, cancellationToken);
         }
 
         /// <summary>
-        ///     Update a single label
+        /// Update a single label
         /// </summary>
         /// <param name="labelId">ID of label to update</param>
         /// <param name="labelUpdate">label update</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Updated label</returns>
-        public async Task<Label> UpdateLabelAsync(string labelId, LabelUpdate labelUpdate)
+        public async Task<Label> UpdateLabelAsync(string labelId, LabelUpdate labelUpdate,
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.PatchLabelsIDAsync(labelId, labelUpdate).ConfigureAwait(false);
+            var response = await _service.PatchLabelsIDAsync(labelId, labelUpdate, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
         /// <summary>
-        ///     Delete a label.
+        /// Delete a label.
         /// </summary>
         /// <param name="label">label to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(Label label)
+        public Task DeleteLabelAsync(Label label, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id);
+            return DeleteLabelAsync(label.Id, cancellationToken);
         }
 
         /// <summary>
-        ///     Delete a label.
+        /// Delete a label.
         /// </summary>
         /// <param name="labelId">ID of label to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(string labelId)
+        public Task DeleteLabelAsync(string labelId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteLabelsIDAsync(labelId);
+            return _service.DeleteLabelsIDAsync(labelId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
-        ///     Clone a label.
+        /// Clone a label.
         /// </summary>
         /// <param name="clonedName">name of cloned label</param>
         /// <param name="labelId">ID of label to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned label</returns>
-        public async Task<Label> CloneLabelAsync(string clonedName, string labelId)
+        public async Task<Label> CloneLabelAsync(string clonedName, string labelId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var label = await FindLabelByIdAsync(labelId).ConfigureAwait(false);
 
-            return await CloneLabelAsync(clonedName, label).ConfigureAwait(false);
+            return await CloneLabelAsync(clonedName, label, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
-        ///     Clone a label.
+        /// Clone a label.
         /// </summary>
         /// <param name="clonedName">name of cloned label</param>
         /// <param name="label">label to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned label</returns>
-        public Task<Label> CloneLabelAsync(string clonedName, Label label)
+        public Task<Label> CloneLabelAsync(string clonedName, Label label,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(label, nameof(label));
@@ -128,52 +142,59 @@ namespace InfluxDB.Client
             var cloned =
                 new LabelCreateRequest(label.OrgID, clonedName, new Dictionary<string, string>(label.Properties));
 
-            return CreateLabelAsync(cloned);
+            return CreateLabelAsync(cloned, cancellationToken);
         }
 
         /// <summary>
-        ///     Retrieve a label.
+        /// Retrieve a label.
         /// </summary>
         /// <param name="labelId">ID of a label to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Label detail</returns>
-        public async Task<Label> FindLabelByIdAsync(string labelId)
+        public async Task<Label> FindLabelByIdAsync(string labelId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            var response = await _service.GetLabelsIDAsync(labelId).ConfigureAwait(false);
+            var response = await _service.GetLabelsIDAsync(labelId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
         /// <summary>
-        ///     List all labels.
+        /// List all labels.
+        /// <param name="cancellationToken">Cancellation token</param>
         /// </summary>
         /// <returns>List all labels.</returns>
-        public async Task<List<Label>> FindLabelsAsync()
+        public async Task<List<Label>> FindLabelsAsync(CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetLabelsAsync().ConfigureAwait(false);
+            var response = await _service.GetLabelsAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Labels;
         }
 
         /// <summary>
-        ///     Get all labels.
+        /// Get all labels.
         /// </summary>
         /// <param name="organization">specifies the organization of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>all labels</returns>
-        public Task<List<Label>> FindLabelsByOrgAsync(Organization organization)
+        public Task<List<Label>> FindLabelsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return FindLabelsByOrgIdAsync(organization.Id);
+            return FindLabelsByOrgIdAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
-        ///     Get all labels.
+        /// Get all labels.
         /// </summary>
         /// <param name="orgId">specifies the organization ID of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>all labels</returns>
-        public async Task<List<Label>> FindLabelsByOrgIdAsync(string orgId)
+        public async Task<List<Label>> FindLabelsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetLabelsAsync(null, orgId).ConfigureAwait(false);
+            var response = await _service.GetLabelsAsync(null, orgId, cancellationToken).ConfigureAwait(false);
             return response.Labels;
         }
     }

--- a/Client/NotificationEndpointsApi.cs
+++ b/Client/NotificationEndpointsApi.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -26,14 +26,16 @@ namespace InfluxDB.Client
         /// <param name="name">Endpoint name</param>
         /// <param name="url">Slack WebHook URL</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Slack notification endpoint</returns>
-        public Task<SlackNotificationEndpoint> CreateSlackEndpointAsync(string name, string url, string orgId)
+        public Task<SlackNotificationEndpoint> CreateSlackEndpointAsync(string name, string url, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(url, nameof(url));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return CreateSlackEndpointAsync(name, url, null, orgId);
+            return CreateSlackEndpointAsync(name, url, null, orgId, cancellationToken);
         }
 
         /// <summary>
@@ -43,9 +45,10 @@ namespace InfluxDB.Client
         /// <param name="url">Slack WebHook URL</param>
         /// <param name="token">Slack WebHook Token</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Slack notification endpoint</returns>
         public async Task<SlackNotificationEndpoint> CreateSlackEndpointAsync(string name, string url, string token,
-            string orgId)
+            string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
@@ -54,7 +57,8 @@ namespace InfluxDB.Client
             var endpoint = new SlackNotificationEndpoint(type: NotificationEndpointType.Slack,
                 url: url, token: token, orgID: orgId, name: name, status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (SlackNotificationEndpoint)await CreateEndpointAsync(endpoint).ConfigureAwait(false);
+            return (SlackNotificationEndpoint)await CreateEndpointAsync(endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -64,9 +68,10 @@ namespace InfluxDB.Client
         /// <param name="clientUrl">Client URL</param>
         /// <param name="routingKey">Routing Key</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created PagerDuty notification endpoint</returns>
         public async Task<PagerDutyNotificationEndpoint> CreatePagerDutyEndpointAsync(string name, string clientUrl,
-            string routingKey, string orgId)
+            string routingKey, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(clientUrl, nameof(clientUrl));
@@ -77,7 +82,8 @@ namespace InfluxDB.Client
                 clientURL: clientUrl, routingKey: routingKey, orgID: orgId, name: name,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (PagerDutyNotificationEndpoint)await CreateEndpointAsync(endpoint).ConfigureAwait(false);
+            return (PagerDutyNotificationEndpoint)await CreateEndpointAsync(endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -87,9 +93,10 @@ namespace InfluxDB.Client
         /// <param name="url">URL</param>
         /// <param name="method">HTTP Method</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created HTTP notification endpoint</returns>
-        public async Task<HTTPNotificationEndpoint> CreateHttpEndpointAsync(string name,
-            string url, HTTPNotificationEndpoint.MethodEnum method, string orgId)
+        public async Task<HTTPNotificationEndpoint> CreateHttpEndpointAsync(string name, string url,
+            HTTPNotificationEndpoint.MethodEnum method, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(url, nameof(url));
@@ -101,7 +108,8 @@ namespace InfluxDB.Client
                 name: name, authMethod: HTTPNotificationEndpoint.AuthMethodEnum.None,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -113,9 +121,11 @@ namespace InfluxDB.Client
         /// <param name="username">HTTP Basic Username</param>
         /// <param name="password">HTTP Basic Password</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created HTTP notification endpoint</returns>
         public async Task<HTTPNotificationEndpoint> CreateHttpEndpointBasicAuthAsync(string name, string url,
-            HTTPNotificationEndpoint.MethodEnum method, string username, string password, string orgId)
+            HTTPNotificationEndpoint.MethodEnum method, string username, string password, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(url, nameof(url));
@@ -130,7 +140,8 @@ namespace InfluxDB.Client
                 password: password,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -141,9 +152,11 @@ namespace InfluxDB.Client
         /// <param name="method">HTTP Method</param>
         /// <param name="token">Bearer token</param>
         /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created HTTP notification endpoint</returns>
         public async Task<HTTPNotificationEndpoint> CreateHttpEndpointBearerAsync(string name, string url,
-            HTTPNotificationEndpoint.MethodEnum method, string token, string orgId)
+            HTTPNotificationEndpoint.MethodEnum method, string token, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(url, nameof(url));
@@ -156,27 +169,32 @@ namespace InfluxDB.Client
                 name: name, authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Bearer, token: token,
                 status: NotificationEndpointBase.StatusEnum.Active);
 
-            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CreateEndpointAsync(endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Add new notification endpoint.
         /// </summary>
         /// <param name="notificationEndpoint">notificationEndpoint to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint created</returns>
-        public Task<NotificationEndpoint> CreateEndpointAsync(NotificationEndpoint notificationEndpoint)
+        public Task<NotificationEndpoint> CreateEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(notificationEndpoint, nameof(notificationEndpoint));
 
-            return _service.CreateNotificationEndpointAsync(notificationEndpoint);
+            return _service.CreateNotificationEndpointAsync(notificationEndpoint, cancellationToken);
         }
 
         /// <summary>
         /// Update a notification endpoint. The updates is used for fields from <see cref="NotificationEndpointUpdate"/>.
         /// </summary>
         /// <param name="notificationEndpoint">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated notification endpoint</returns>
-        public Task<NotificationEndpoint> UpdateEndpointAsync(NotificationEndpoint notificationEndpoint)
+        public Task<NotificationEndpoint> UpdateEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(notificationEndpoint, nameof(notificationEndpoint));
 
@@ -185,7 +203,7 @@ namespace InfluxDB.Client
 
             return UpdateEndpointAsync(notificationEndpoint.Id,
                 new NotificationEndpointUpdate(notificationEndpoint.Name,
-                    notificationEndpoint.Description, status));
+                    notificationEndpoint.Description, status), cancellationToken);
         }
 
         /// <summary>
@@ -193,50 +211,58 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="endpointId">ID of notification endpoint</param>
         /// <param name="notificationEndpointUpdate">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated notification endpoint</returns>
         public Task<NotificationEndpoint> UpdateEndpointAsync(string endpointId,
-            NotificationEndpointUpdate notificationEndpointUpdate)
+            NotificationEndpointUpdate notificationEndpointUpdate, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
             Arguments.CheckNotNull(notificationEndpointUpdate, nameof(notificationEndpointUpdate));
 
-            return _service.PatchNotificationEndpointsIDAsync(endpointId, notificationEndpointUpdate);
+            return _service.PatchNotificationEndpointsIDAsync(endpointId, notificationEndpointUpdate,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a notification endpoint.
         /// </summary>
         /// <param name="notificationEndpoint">notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted></returns>
-        public Task DeleteNotificationEndpointAsync(NotificationEndpoint notificationEndpoint)
+        public Task DeleteNotificationEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(notificationEndpoint, nameof(notificationEndpoint));
 
-            return DeleteNotificationEndpointAsync(notificationEndpoint.Id);
+            return DeleteNotificationEndpointAsync(notificationEndpoint.Id, cancellationToken);
         }
 
         /// <summary>
         /// Delete a notification endpoint.
         /// </summary>
         /// <param name="endpointId">ID of notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteNotificationEndpointAsync(string endpointId)
+        public Task DeleteNotificationEndpointAsync(string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            return _service.DeleteNotificationEndpointsIDAsync(endpointId);
+            return _service.DeleteNotificationEndpointsIDAsync(endpointId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get notification endpoints.
         /// </summary>
         /// <param name="orgId">only show notification endpoints belonging to specified organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of notification endpoint</returns>
-        public async Task<List<NotificationEndpoint>> FindNotificationEndpointsAsync(string orgId)
+        public async Task<List<NotificationEndpoint>> FindNotificationEndpointsAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await FindNotificationEndpointsAsync(orgId, new FindOptions()).ConfigureAwait(false);
+            var response = await FindNotificationEndpointsAsync(orgId, new FindOptions(), cancellationToken)
+                .ConfigureAwait(false);
             return response._NotificationEndpoints;
         }
 
@@ -245,26 +271,30 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">only show notification endpoints belonging to specified organization</param>
         /// <param name="findOptions">the find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task<NotificationEndpoints> FindNotificationEndpointsAsync(string orgId, FindOptions findOptions)
+        public Task<NotificationEndpoints> FindNotificationEndpointsAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
             return _service.GetNotificationEndpointsAsync(orgId, offset: findOptions.Offset,
-                limit: findOptions.Limit);
+                limit: findOptions.Limit, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get a notification endpoint.
         /// </summary>
         /// <param name="endpointId">ID of notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the notification endpoint requested</returns>
-        public Task<NotificationEndpoint> FindNotificationEndpointByIdAsync(string endpointId)
+        public Task<NotificationEndpoint> FindNotificationEndpointByIdAsync(string endpointId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            return _service.GetNotificationEndpointsIDAsync(endpointId);
+            return _service.GetNotificationEndpointsIDAsync(endpointId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -273,15 +303,17 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="token">Slack WebHook Token</param>
         /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<SlackNotificationEndpoint> CloneSlackEndpointAsync(string name, string token,
-            string endpointId)
+            string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
             var endpoint =
-                (SlackNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+                (SlackNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId, cancellationToken)
+                    .ConfigureAwait(false);
             return await CloneSlackEndpointAsync(name, token, endpoint).ConfigureAwait(false);
         }
 
@@ -291,16 +323,18 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="token"></param>
         /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<SlackNotificationEndpoint> CloneSlackEndpointAsync(string name, string token,
-            SlackNotificationEndpoint endpoint)
+            SlackNotificationEndpoint endpoint, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
 
             var cloned = new SlackNotificationEndpoint(endpoint.Url, token, name: name);
 
-            return (SlackNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
+            return (SlackNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -309,16 +343,17 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="routingKey">Routing Key</param>
         /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<PagerDutyNotificationEndpoint> ClonePagerDutyEndpointAsync(string name, string routingKey,
-            string endpointId)
+            string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(routingKey, nameof(routingKey));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
             var endpoint =
-                (PagerDutyNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId)
+                (PagerDutyNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId, cancellationToken)
                     .ConfigureAwait(false);
             return await ClonePagerDutyEndpointAsync(name, routingKey, endpoint).ConfigureAwait(false);
         }
@@ -329,9 +364,10 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="routingKey">Routing Key</param>
         /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<PagerDutyNotificationEndpoint> ClonePagerDutyEndpointAsync(string name, string routingKey,
-            PagerDutyNotificationEndpoint endpoint)
+            PagerDutyNotificationEndpoint endpoint, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(routingKey, nameof(routingKey));
@@ -339,7 +375,7 @@ namespace InfluxDB.Client
 
             var cloned = new PagerDutyNotificationEndpoint(endpoint.ClientURL, routingKey, name: name);
 
-            return (PagerDutyNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned)
+            return (PagerDutyNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -348,14 +384,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
-        public async Task<HTTPNotificationEndpoint> CloneHttpEndpointAsync(string name, string endpointId)
+        public async Task<HTTPNotificationEndpoint> CloneHttpEndpointAsync(string name, string endpointId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
             var endpoint =
-                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
+                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId, cancellationToken)
+                    .ConfigureAwait(false);
             return await CloneHttpEndpoint(name, endpoint).ConfigureAwait(false);
         }
 
@@ -364,8 +403,10 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
-        public async Task<HTTPNotificationEndpoint> CloneHttpEndpoint(string name, HTTPNotificationEndpoint endpoint)
+        public async Task<HTTPNotificationEndpoint> CloneHttpEndpoint(string name, HTTPNotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
@@ -374,7 +415,8 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.None, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -384,9 +426,10 @@ namespace InfluxDB.Client
         /// <param name="username">HTTP Basic Username</param>
         /// <param name="password">HTTP Basic Password</param>
         /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<HTTPNotificationEndpoint> CloneHttpEndpointBasicAuthAsync(string name, string username,
-            string password, string endpointId)
+            string password, string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(username, nameof(username));
@@ -394,8 +437,10 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
             var endpoint =
-                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
-            return await CloneHttpEndpointBasicAuthAsync(name, username, password, endpoint).ConfigureAwait(false);
+                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId, cancellationToken)
+                    .ConfigureAwait(false);
+            return await CloneHttpEndpointBasicAuthAsync(name, username, password, endpoint, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -405,9 +450,10 @@ namespace InfluxDB.Client
         /// <param name="username">HTTP Basic Username</param>
         /// <param name="password">HTTP Basic Password</param>
         /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<HTTPNotificationEndpoint> CloneHttpEndpointBasicAuthAsync(string name, string username,
-            string password, HTTPNotificationEndpoint endpoint)
+            string password, HTTPNotificationEndpoint endpoint, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(username, nameof(username));
@@ -420,7 +466,8 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Basic, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
@@ -429,17 +476,19 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="token">Bearer token</param>
         /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<HTTPNotificationEndpoint> CloneHttpEndpointBearerAsync(string name, string token,
-            string endpointId)
+            string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(token, nameof(token));
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
             var endpoint =
-                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId).ConfigureAwait(false);
-            return await CloneHttpEndpointBearerAsync(name, token, endpoint).ConfigureAwait(false);
+                (HTTPNotificationEndpoint)await FindNotificationEndpointByIdAsync(endpointId, cancellationToken)
+                    .ConfigureAwait(false);
+            return await CloneHttpEndpointBearerAsync(name, token, endpoint, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -448,9 +497,10 @@ namespace InfluxDB.Client
         /// <param name="name">name of cloned endpoint</param>
         /// <param name="token">Bearer token</param>
         /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification endpoint cloned</returns>
         public async Task<HTTPNotificationEndpoint> CloneHttpEndpointBearerAsync(string name, string token,
-            HTTPNotificationEndpoint endpoint)
+            HTTPNotificationEndpoint endpoint, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(token, nameof(token));
@@ -461,31 +511,37 @@ namespace InfluxDB.Client
                 authMethod: HTTPNotificationEndpoint.AuthMethodEnum.Bearer, contentTemplate: endpoint.ContentTemplate,
                 headers: endpoint.Headers);
 
-            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned).ConfigureAwait(false);
+            return (HTTPNotificationEndpoint)await CloneEndpointAsync(name, endpoint, cloned, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
         /// List all labels for a notification endpoint.
         /// </summary>
         /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a notification endpoint</returns>
-        public Task<List<Label>> GetLabelsAsync(NotificationEndpoint endpoint)
+        public Task<List<Label>> GetLabelsAsync(NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
 
-            return GetLabelsAsync(endpoint.Id);
+            return GetLabelsAsync(endpoint.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a notification endpoint.
         /// </summary>
         /// <param name="endpointId">ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a notification endpoint</returns>
-        public async Task<List<Label>> GetLabelsAsync(string endpointId)
+        public async Task<List<Label>> GetLabelsAsync(string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
 
-            var response = await _service.GetNotificationEndpointsIDLabelsAsync(endpointId).ConfigureAwait(false);
+            var response = await _service
+                .GetNotificationEndpointsIDLabelsAsync(endpointId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -494,13 +550,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to add</param>
         /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task<Label> AddLabelAsync(Label label, NotificationEndpoint endpoint)
+        public Task<Label> AddLabelAsync(Label label, NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, endpoint.Id);
+            return AddLabelAsync(label.Id, endpoint.Id, cancellationToken);
         }
 
         /// <summary>
@@ -508,15 +566,18 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of label to add</param>
         /// <param name="endpointId">the ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public async Task<Label> AddLabelAsync(string labelId, string endpointId)
+        public async Task<Label> AddLabelAsync(string labelId, string endpointId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostNotificationEndpointIDLabelsAsync(endpointId, mapping)
+            var response = await _service
+                .PostNotificationEndpointIDLabelsAsync(endpointId, mapping, cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return response.Label;
         }
@@ -526,13 +587,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label to delete</param>
         /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteLabelAsync(Label label, NotificationEndpoint endpoint)
+        public Task DeleteLabelAsync(Label label, NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(endpoint, nameof(endpoint));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, endpoint.Id);
+            return DeleteLabelAsync(label.Id, endpoint.Id, cancellationToken);
         }
 
         /// <summary>
@@ -540,27 +603,29 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the label id to delete</param>
         /// <param name="endpointId">ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteLabelAsync(string labelId, string endpointId)
+        public Task DeleteLabelAsync(string labelId, string endpointId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(endpointId, nameof(endpointId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteNotificationEndpointsIDLabelsIDAsync(endpointId, labelId);
+            return _service.DeleteNotificationEndpointsIDLabelsIDAsync(endpointId, labelId,
+                cancellationToken: cancellationToken);
         }
 
         private async Task<NotificationEndpoint> CloneEndpointAsync(string name, NotificationEndpoint toCloneEndpoint,
-            NotificationEndpoint clonedEndpoint)
+            NotificationEndpoint clonedEndpoint, CancellationToken cancellationToken = default)
         {
             clonedEndpoint.OrgID = toCloneEndpoint.OrgID;
             clonedEndpoint.Description = toCloneEndpoint.Description;
             clonedEndpoint.Status = toCloneEndpoint.Status;
             clonedEndpoint.Type = toCloneEndpoint.Type;
 
-            var created = await CreateEndpointAsync(clonedEndpoint).ConfigureAwait(false);
-            var labels = await GetLabelsAsync(toCloneEndpoint).ConfigureAwait(false);
+            var created = await CreateEndpointAsync(clonedEndpoint, cancellationToken).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(toCloneEndpoint, cancellationToken).ConfigureAwait(false);
 
-            foreach (var label in labels) await AddLabelAsync(label, created).ConfigureAwait(false);
+            foreach (var label in labels) await AddLabelAsync(label, created, cancellationToken).ConfigureAwait(false);
 
             return created;
         }

--- a/Client/NotificationRulesApi.cs
+++ b/Client/NotificationRulesApi.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -28,9 +29,11 @@ namespace InfluxDB.Client
         /// <param name="status">Status rule the notification rule attempts to match.</param>
         /// <param name="endpoint">The endpoint to use for notification.</param>
         /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification rule created</returns>
         public Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
-            RuleStatusLevel status, SlackNotificationEndpoint endpoint, string orgId)
+            RuleStatusLevel status, SlackNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(every, nameof(every));
@@ -40,21 +43,9 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
             return CreateSlackRuleAsync(name, every, messageTemplate, status, new List<TagRule>(), endpoint,
-                orgId);
+                orgId, cancellationToken);
         }
 
-        /**
-         * Add a Slack notification rule.
-         *
-         * @param name            Human-readable name describing the notification rule.
-         * @param every           The notification repetition interval.
-         * @param messageTemplate The template used to generate notification.
-         * @param status          Status rule the notification rule attempts to match.
-         * @param tagRules        List of tag rules the notification rule attempts to match.
-         * @param endpoint        The endpoint to use for notification.
-         * @param orgID           The ID of the organization that owns this notification rule.
-         * @return Notification rule created
-         */
         /// <summary>
         /// Add a Slack notification rule.
         /// </summary>
@@ -65,9 +56,11 @@ namespace InfluxDB.Client
         /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
         /// <param name="endpoint">The endpoint to use for notification.</param>
         /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification rule created</returns>
         public async Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
-            RuleStatusLevel status, List<TagRule> tagRules, SlackNotificationEndpoint endpoint, string orgId)
+            RuleStatusLevel status, List<TagRule> tagRules, SlackNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(every, nameof(every));
@@ -81,21 +74,9 @@ namespace InfluxDB.Client
                 orgID: orgId, tagRules: tagRules, statusRules: new List<StatusRule> { new StatusRule(status) },
                 endpointID: endpoint.Id, status: TaskStatusType.Active);
 
-            return (SlackNotificationRule)await CreateRuleAsync(rule).ConfigureAwait(false);
+            return (SlackNotificationRule)await CreateRuleAsync(rule, cancellationToken).ConfigureAwait(false);
         }
 
-        /**
-         * Add a PagerDuty notification rule.
-         *
-         * @param name            Human-readable name describing the notification rule.
-         * @param every           The notification repetition interval.
-         * @param messageTemplate The template used to generate notification.
-         * @param status          Status rule the notification rule attempts to match.
-         * @param tagRules        List of tag rules the notification rule attempts to match.
-         * @param endpoint        The endpoint to use for notification.
-         * @param orgID           The ID of the organization that owns this notification rule.
-         * @return Notification rule created
-         */
         /// <summary>
         /// Add a PagerDuty notification rule. 
         /// </summary>
@@ -106,10 +87,11 @@ namespace InfluxDB.Client
         /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
         /// <param name="endpoint">The endpoint to use for notification.</param>
         /// <param name="orgId">The ID of the organization that owns this notification rule</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification rule created</returns>
         public async Task<PagerDutyNotificationRule> CreatePagerDutyRuleAsync(string name, string every,
             string messageTemplate, RuleStatusLevel status, List<TagRule> tagRules,
-            PagerDutyNotificationEndpoint endpoint, string orgId)
+            PagerDutyNotificationEndpoint endpoint, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(every, nameof(every));
@@ -123,7 +105,7 @@ namespace InfluxDB.Client
                 orgID: orgId, tagRules: tagRules, statusRules: new List<StatusRule> { new StatusRule(status) },
                 endpointID: endpoint.Id, status: TaskStatusType.Active);
 
-            return (PagerDutyNotificationRule)await CreateRuleAsync(rule).ConfigureAwait(false);
+            return (PagerDutyNotificationRule)await CreateRuleAsync(rule, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -135,36 +117,41 @@ namespace InfluxDB.Client
         /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
         /// <param name="endpoint">The endpoint to use for notification.</param>
         /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification rule created</returns>
         public async Task<HTTPNotificationRule> CreateHttpRuleAsync(string name, string every, RuleStatusLevel status,
-            List<TagRule> tagRules,
-            HTTPNotificationEndpoint endpoint, string orgId)
+            List<TagRule> tagRules, HTTPNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default)
         {
             var rule = new HTTPNotificationRule(name: name, every: every,
                 orgID: orgId, tagRules: tagRules, statusRules: new List<StatusRule> { new StatusRule(status) },
                 endpointID: endpoint.Id, status: TaskStatusType.Active);
 
-            return (HTTPNotificationRule)await CreateRuleAsync(rule).ConfigureAwait(false);
+            return (HTTPNotificationRule)await CreateRuleAsync(rule, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Add a notification rule.
         /// </summary>
         /// <param name="rule">Notification rule to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Notification rule created</returns>
-        public Task<NotificationRule> CreateRuleAsync(NotificationRule rule)
+        public Task<NotificationRule> CreateRuleAsync(NotificationRule rule,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            return _service.CreateNotificationRuleAsync(rule);
+            return _service.CreateNotificationRuleAsync(rule, cancellationToken);
         }
 
         /// <summary>
         /// Update a notification rule.
         /// </summary>
         /// <param name="rule">Notification rule update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated notification rule</returns>
-        public Task<NotificationRule> UpdateNotificationRuleAsync(NotificationRule rule)
+        public Task<NotificationRule> UpdateNotificationRuleAsync(NotificationRule rule,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
@@ -172,7 +159,7 @@ namespace InfluxDB.Client
                 out NotificationRuleUpdate.StatusEnum status);
 
             return UpdateNotificationRuleAsync(rule.Id,
-                new NotificationRuleUpdate(rule.Name, rule.Description, status));
+                new NotificationRuleUpdate(rule.Name, rule.Description, status), cancellationToken);
         }
 
         /// <summary>
@@ -180,61 +167,70 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ruleId">The notification rule ID.</param>
         /// <param name="update">Notification rule update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated notification rule</returns>
-        public Task<NotificationRule> UpdateNotificationRuleAsync(string ruleId, NotificationRuleUpdate update)
+        public Task<NotificationRule> UpdateNotificationRuleAsync(string ruleId, NotificationRuleUpdate update,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
             Arguments.CheckNotNull(update, nameof(update));
 
-            return _service.PatchNotificationRulesIDAsync(ruleId, update);
+            return _service.PatchNotificationRulesIDAsync(ruleId, update, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a notification rule.
         /// </summary>
         /// <param name="rule">The notification rule</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteNotificationRuleAsync(NotificationRule rule)
+        public Task DeleteNotificationRuleAsync(NotificationRule rule, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            return DeleteNotificationRuleAsync(rule.Id);
+            return DeleteNotificationRuleAsync(rule.Id, cancellationToken);
         }
 
         /// <summary>
         /// Delete a notification rule.
         /// </summary>
         /// <param name="ruleId">The notification rule ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteNotificationRuleAsync(string ruleId)
+        public Task DeleteNotificationRuleAsync(string ruleId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            return _service.DeleteNotificationRulesIDAsync(ruleId);
+            return _service.DeleteNotificationRulesIDAsync(ruleId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get a notification rule.
         /// </summary>
         /// <param name="ruleId">The notification rule ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The notification rule requested</returns>
-        public Task<NotificationRule> FindNotificationRuleByIdAsync(string ruleId)
+        public Task<NotificationRule> FindNotificationRuleByIdAsync(string ruleId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            return _service.GetNotificationRulesIDAsync(ruleId);
+            return _service.GetNotificationRulesIDAsync(ruleId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get notification rules.
         /// </summary>
         /// <param name="orgId">Only show notification rules that belong to a specific organization ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of notification rules</returns>
-        public async Task<List<NotificationRule>> FindNotificationRulesAsync(string orgId)
+        public async Task<List<NotificationRule>> FindNotificationRulesAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await FindNotificationRulesAsync(orgId, new FindOptions()).ConfigureAwait(false);
+            var response = await FindNotificationRulesAsync(orgId, new FindOptions(), cancellationToken)
+                .ConfigureAwait(false);
             return response._NotificationRules;
         }
 
@@ -243,44 +239,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="orgId">Only show notification rules that belong to a specific organization ID.</param>
         /// <param name="findOptions">find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task<NotificationRules> FindNotificationRulesAsync(string orgId, FindOptions findOptions)
+        public Task<NotificationRules> FindNotificationRulesAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNotNull(findOptions, nameof(findOptions));
 
             return _service.GetNotificationRulesAsync(orgId, offset: findOptions.Offset,
-                limit: findOptions.Limit);
+                limit: findOptions.Limit, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a notification rule.
         /// </summary>
         /// <param name="rule">The notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of all labels for a notification rule</returns>
-        public Task<List<Label>> GetLabelsAsync(NotificationRule rule)
+        public Task<List<Label>> GetLabelsAsync(NotificationRule rule, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
 
-            return GetLabelsAsync(rule.Id);
+            return GetLabelsAsync(rule.Id, cancellationToken);
         }
 
-        /**
-         * List all labels for a notification rule.
-         *
-         * @param ruleID The notification rule ID.
-         * @return A list of all labels for a notification rule
-         */
         /// <summary>
         /// List all labels for a notification rule
         /// </summary>
         /// <param name="ruleId"> The notification rule ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of all labels for a notification rule</returns>
-        public async Task<List<Label>> GetLabelsAsync(string ruleId)
+        public async Task<List<Label>> GetLabelsAsync(string ruleId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
 
-            var response = await _service.GetNotificationRulesIDLabelsAsync(ruleId).ConfigureAwait(false);
+            var response = await _service
+                .GetNotificationRulesIDLabelsAsync(ruleId, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -289,13 +284,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">Label to add</param>
         /// <param name="rule">The notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The label was added to the notification rule</returns>
-        public Task<Label> AddLabelAsync(Label label, NotificationRule rule)
+        public Task<Label> AddLabelAsync(Label label, NotificationRule rule,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, rule.Id);
+            return AddLabelAsync(label.Id, rule.Id, cancellationToken);
         }
 
         /// <summary>
@@ -303,15 +300,19 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">Label to add</param>
         /// <param name="ruleId">The notification rule ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The label was added to the notification rule</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string ruleId)
+        public async Task<Label> AddLabelAsync(string labelId, string ruleId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostNotificationRuleIDLabelsAsync(ruleId, mapping).ConfigureAwait(false);
+            var response = await _service
+                .PostNotificationRuleIDLabelsAsync(ruleId, mapping, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
@@ -320,12 +321,13 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">The label to delete.</param>
         /// <param name="rule">The notification rule.</param>
-        public Task DeleteLabelAsync(Label label, NotificationRule rule)
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task DeleteLabelAsync(Label label, NotificationRule rule, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(rule, nameof(rule));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, rule.Id);
+            return DeleteLabelAsync(label.Id, rule.Id, cancellationToken);
         }
 
         /// <summary>
@@ -333,12 +335,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">The ID of the label to delete.</param>
         /// <param name="ruleId">The notification rule ID.</param>
-        public Task DeleteLabelAsync(string labelId, string ruleId)
+        /// <param name="cancellationToken">Cancellation token</param>
+        public Task DeleteLabelAsync(string labelId, string ruleId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(ruleId, nameof(ruleId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteNotificationRulesIDLabelsIDAsync(ruleId, labelId);
+            return _service.DeleteNotificationRulesIDLabelsIDAsync(ruleId, labelId,
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/Client/OrganizationsApi.cs
+++ b/Client/OrganizationsApi.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -24,64 +25,71 @@ namespace InfluxDB.Client
         /// Creates a new organization and sets <see cref="InfluxDB.Client.Api.Domain.Organization.Id" /> with the new identifier.
         /// </summary>
         /// <param name="name"></param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Created organization</returns>
-        public Task<Organization> CreateOrganizationAsync(string name)
+        public Task<Organization> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
 
             var organization = new Organization(null, name);
 
-            return CreateOrganizationAsync(organization);
+            return CreateOrganizationAsync(organization, cancellationToken);
         }
 
         /// <summary>
         /// Creates a new organization and sets <see cref="Organization.Id" /> with the new identifier.
         /// </summary>
         /// <param name="organization">the organization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created organization</returns>
-        public Task<Organization> CreateOrganizationAsync(Organization organization)
+        public Task<Organization> CreateOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
             var request = new PostOrganizationRequest(organization.Name, organization.Description);
-            return _service.PostOrgsAsync(request);
+            return _service.PostOrgsAsync(request, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Update an organization.
         /// </summary>
         /// <param name="organization">organization update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>updated organization</returns>
-        public Task<Organization> UpdateOrganizationAsync(Organization organization)
+        public Task<Organization> UpdateOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
             var request = new PatchOrganizationRequest(organization.Name, organization.Description);
-            return _service.PatchOrgsIDAsync(organization.Id, request);
+            return _service.PatchOrgsIDAsync(organization.Id, request, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete an organization.
         /// </summary>
         /// <param name="orgId">ID of organization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteOrganizationAsync(string orgId)
+        public Task DeleteOrganizationAsync(string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(orgId, nameof(orgId));
 
-            return _service.DeleteOrgsIDAsync(orgId);
+            return _service.DeleteOrgsIDAsync(orgId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete an organization.
         /// </summary>
         /// <param name="organization">organization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteOrganizationAsync(Organization organization)
+        public Task DeleteOrganizationAsync(Organization organization, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return DeleteOrganizationAsync(organization.Id);
+            return DeleteOrganizationAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -89,14 +97,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned organization</param>
         /// <param name="orgId">ID of organization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned organization</returns>
-        public async Task<Organization> CloneOrganizationAsync(string clonedName, string orgId)
+        public async Task<Organization> CloneOrganizationAsync(string clonedName, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var org = await FindOrganizationByIdAsync(orgId).ConfigureAwait(false);
-            return await CloneOrganizationAsync(clonedName, org).ConfigureAwait(false);
+            var org = await FindOrganizationByIdAsync(orgId, cancellationToken).ConfigureAwait(false);
+            return await CloneOrganizationAsync(clonedName, org, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -104,27 +114,30 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned organization</param>
         /// <param name="organization">organization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned organization</returns>
-        public Task<Organization> CloneOrganizationAsync(string clonedName, Organization organization)
+        public Task<Organization> CloneOrganizationAsync(string clonedName, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(organization, nameof(organization));
 
             var cloned = new Organization(null, clonedName);
 
-            return CreateOrganizationAsync(cloned);
+            return CreateOrganizationAsync(cloned, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve an organization.
         /// </summary>
         /// <param name="orgId">ID of organization to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>organization details</returns>
-        public Task<Organization> FindOrganizationByIdAsync(string orgId)
+        public Task<Organization> FindOrganizationByIdAsync(string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return _service.GetOrgsIDAsync(orgId);
+            return _service.GetOrgsIDAsync(orgId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -136,12 +149,14 @@ namespace InfluxDB.Client
         /// <param name="org">Filter organizations to a specific organization name. (optional)</param>
         /// <param name="orgID">Filter organizations to a specific organization ID. (optional)</param>
         /// <param name="userID">Filter organizations to a specific user ID. (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List all organizations</returns>
         public async Task<List<Organization>> FindOrganizationsAsync(int? limit = null, int? offset = null,
-            bool? descending = null, string org = null, string orgID = null, string userID = null)
+            bool? descending = null, string org = null, string orgID = null, string userID = null,
+            CancellationToken cancellationToken = default)
         {
             var response = await _service.GetOrgsAsync(limit: limit, offset: offset, descending: descending, org: org,
-                orgID: orgID, userID: userID).ConfigureAwait(false);
+                orgID: orgID, userID: userID, cancellationToken: cancellationToken).ConfigureAwait(false);
 
             return response.Orgs;
         }
@@ -155,12 +170,14 @@ namespace InfluxDB.Client
         /// </code>
         /// </summary>
         /// <param name="organization">the organization for get secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the secret keys</returns>
-        public Task<List<string>> GetSecretsAsync(Organization organization)
+        public Task<List<string>> GetSecretsAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return GetSecretsAsync(organization.Id);
+            return GetSecretsAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -172,12 +189,14 @@ namespace InfluxDB.Client
         /// </code>
         /// </summary>
         /// <param name="orgId">the organization for get secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the secret keys</returns>
-        public async Task<List<string>> GetSecretsAsync(string orgId)
+        public async Task<List<string>> GetSecretsAsync(string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _secretsService.GetOrgsIDSecretsAsync(orgId).ConfigureAwait(false);
+            var response = await _secretsService.GetOrgsIDSecretsAsync(orgId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Secrets;
         }
 
@@ -186,13 +205,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="secrets">secrets to update/add</param>
         /// <param name="organization">the organization for put secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task PutSecretsAsync(Dictionary<string, string> secrets, Organization organization)
+        public Task PutSecretsAsync(Dictionary<string, string> secrets, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return PutSecretsAsync(secrets, organization.Id);
+            return PutSecretsAsync(secrets, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -200,13 +221,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="secrets">secrets to update/add</param>
         /// <param name="orgId">the organization for put secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task PutSecretsAsync(Dictionary<string, string> secrets, string orgId)
+        public Task PutSecretsAsync(Dictionary<string, string> secrets, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return _secretsService.PatchOrgsIDSecretsAsync(orgId, secrets);
+            return _secretsService.PatchOrgsIDSecretsAsync(orgId, secrets, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -214,13 +237,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="secrets">secrets to delete</param>
         /// <param name="organization">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>keys successfully patched</returns>
-        public Task DeleteSecretsAsync(List<string> secrets, Organization organization)
+        public Task DeleteSecretsAsync(List<string> secrets, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return DeleteSecretsAsync(secrets, organization.Id);
+            return DeleteSecretsAsync(secrets, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -228,13 +253,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="secrets">secrets to delete</param>
         /// <param name="orgId">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>keys successfully patched</returns>
-        public Task DeleteSecretsAsync(List<string> secrets, string orgId)
+        public Task DeleteSecretsAsync(List<string> secrets, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return DeleteSecretsAsync(new SecretKeys(secrets), orgId);
+            return DeleteSecretsAsync(new SecretKeys(secrets), orgId, cancellationToken);
         }
 
         /// <summary>
@@ -242,37 +269,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="secrets">secrets to delete</param>
         /// <param name="orgId">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>keys successfully patched</returns>
-        public Task DeleteSecretsAsync(SecretKeys secrets, string orgId)
+        public Task DeleteSecretsAsync(SecretKeys secrets, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(secrets, nameof(secrets));
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return _secretsService.PostOrgsIDSecretsAsync(orgId, secrets);
+            return _secretsService.PostOrgsIDSecretsAsync(orgId, secrets, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all members of an organization.
         /// </summary>
         /// <param name="organization">organization of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of an organization</returns>
-        public Task<List<ResourceMember>> GetMembersAsync(Organization organization)
+        public Task<List<ResourceMember>> GetMembersAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return GetMembersAsync(organization.Id);
+            return GetMembersAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all members of an organization.
         /// </summary>
         /// <param name="orgId">ID of organization to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of an organization</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(string orgId)
+        public async Task<List<ResourceMember>> GetMembersAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetOrgsIDMembersAsync(orgId).ConfigureAwait(false);
+            var response = await _service.GetOrgsIDMembersAsync(orgId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -281,13 +314,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of an organization</param>
         /// <param name="organization">the organization of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(User member, Organization organization)
+        public Task<ResourceMember> AddMemberAsync(User member, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return AddMemberAsync(member.Id, organization.Id);
+            return AddMemberAsync(member.Id, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -295,13 +330,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(string memberId, string orgId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.PostOrgsIDMembersAsync(orgId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostOrgsIDMembersAsync(orgId, new AddResourceMemberRequestBody(memberId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -309,13 +347,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of an organization</param>
         /// <param name="organization">the organization of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteMemberAsync(User member, Organization organization)
+        public Task DeleteMemberAsync(User member, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return DeleteMemberAsync(member.Id, organization.Id);
+            return DeleteMemberAsync(member.Id, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -323,37 +363,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteMemberAsync(string memberId, string orgId)
+        public Task DeleteMemberAsync(string memberId, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.DeleteOrgsIDMembersIDAsync(memberId, orgId);
+            return _service.DeleteOrgsIDMembersIDAsync(memberId, orgId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all owners of an organization.
         /// </summary>
         /// <param name="organization">organization of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of an organization</returns>
-        public Task<List<ResourceOwner>> GetOwnersAsync(Organization organization)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return GetOwnersAsync(organization.Id);
+            return GetOwnersAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all owners of an organization.
         /// </summary>
         /// <param name="orgId">ID of organization to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of an organization</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(string orgId)
+        public async Task<List<ResourceOwner>> GetOwnersAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetOrgsIDOwnersAsync(orgId).ConfigureAwait(false);
+            var response = await _service.GetOrgsIDOwnersAsync(orgId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -362,13 +408,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of an organization</param>
         /// <param name="organization">the organization of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(User owner, Organization organization)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return AddOwnerAsync(owner.Id, organization.Id);
+            return AddOwnerAsync(owner.Id, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -376,13 +424,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string orgId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.PostOrgsIDOwnersAsync(orgId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostOrgsIDOwnersAsync(orgId, new AddResourceMemberRequestBody(ownerId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -390,13 +441,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of an organization</param>
         /// <param name="organization">the organization of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteOwnerAsync(User owner, Organization organization)
+        public Task DeleteOwnerAsync(User owner, Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return DeleteOwnerAsync(owner.Id, organization.Id);
+            return DeleteOwnerAsync(owner.Id, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -404,13 +457,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task DeleteOwnerAsync(string ownerId, string orgId)
+        public Task DeleteOwnerAsync(string ownerId, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.DeleteOrgsIDOwnersIDAsync(ownerId, orgId);
+            return _service.DeleteOrgsIDOwnersIDAsync(ownerId, orgId, cancellationToken: cancellationToken);
         }
     }
 }

--- a/Client/ScraperTargetsApi.cs
+++ b/Client/ScraperTargetsApi.cs
@@ -1,10 +1,9 @@
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
-using InfluxDB.Client.Core;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
-using Task = System.Threading.Tasks.Task;
+using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
@@ -23,12 +22,14 @@ namespace InfluxDB.Client
         /// Creates a new ScraperTarget and sets <see cref="ScraperTargetResponse.Id" /> with the new identifier.
         /// </summary>
         /// <param name="scraperTargetRequest">the scraper to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created ScraperTarget</returns>
-        public Task<ScraperTargetResponse> CreateScraperTargetAsync(ScraperTargetRequest scraperTargetRequest)
+        public Task<ScraperTargetResponse> CreateScraperTargetAsync(ScraperTargetRequest scraperTargetRequest,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetRequest, nameof(scraperTargetRequest));
 
-            return _service.PostScrapersAsync(scraperTargetRequest);
+            return _service.PostScrapersAsync(scraperTargetRequest, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -38,9 +39,10 @@ namespace InfluxDB.Client
         /// <param name="url">the url of the new ScraperTarget</param>
         /// <param name="bucketId">the id of the bucket that its use to writes</param>
         /// <param name="orgId">the id of the organization that owns new ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created ScraperTarget</returns>
         public Task<ScraperTargetResponse> CreateScraperTargetAsync(string name, string url,
-            string bucketId, string orgId)
+            string bucketId, string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(url, nameof(url));
@@ -50,19 +52,21 @@ namespace InfluxDB.Client
             var scrapperTarget =
                 new ScraperTargetRequest(name, ScraperTargetRequest.TypeEnum.Prometheus, url, orgId, bucketId);
 
-            return CreateScraperTargetAsync(scrapperTarget);
+            return CreateScraperTargetAsync(scrapperTarget, cancellationToken);
         }
 
         /// <summary>
         /// Update a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetResponse">ScraperTarget update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>updated ScraperTarget</returns>
-        public Task<ScraperTargetResponse> UpdateScraperTargetAsync(ScraperTargetResponse scraperTargetResponse)
+        public Task<ScraperTargetResponse> UpdateScraperTargetAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
 
-            return UpdateScraperTargetAsync(scraperTargetResponse.Id, scraperTargetResponse);
+            return UpdateScraperTargetAsync(scraperTargetResponse.Id, scraperTargetResponse, cancellationToken);
         }
 
         /// <summary>
@@ -70,38 +74,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="scraperTargetId">id of the scraper target (required)</param>
         /// <param name="scraperTargetRequest">ScraperTargetRequest update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>updated ScraperTarget</returns>
         public Task<ScraperTargetResponse> UpdateScraperTargetAsync(string scraperTargetId,
-            ScraperTargetRequest scraperTargetRequest)
+            ScraperTargetRequest scraperTargetRequest, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNotNull(scraperTargetRequest, nameof(scraperTargetRequest));
 
-            return _service.PatchScrapersIDAsync(scraperTargetId, scraperTargetRequest);
+            return _service.PatchScrapersIDAsync(scraperTargetId, scraperTargetRequest,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetId">ID of ScraperTarget to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>scraper target deleted</returns>
-        public Task DeleteScraperTargetAsync(string scraperTargetId)
+        public Task DeleteScraperTargetAsync(string scraperTargetId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetId, nameof(scraperTargetId));
 
-            return _service.DeleteScrapersIDAsync(scraperTargetId);
+            return _service.DeleteScrapersIDAsync(scraperTargetId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetResponse">ScraperTarget to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>scraper target deleted</returns>
-        public Task DeleteScraperTargetAsync(ScraperTargetResponse scraperTargetResponse)
+        public Task DeleteScraperTargetAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
 
-            return DeleteScraperTargetAsync(scraperTargetResponse.Id);
+            return DeleteScraperTargetAsync(scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -109,14 +118,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned ScraperTarget</param>
         /// <param name="scraperTargetId">ID of ScraperTarget to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned ScraperTarget</returns>
-        public async Task<ScraperTargetResponse> CloneScraperTargetAsync(string clonedName, string scraperTargetId)
+        public async Task<ScraperTargetResponse> CloneScraperTargetAsync(string clonedName, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var scraperTarget = await FindScraperTargetByIdAsync(scraperTargetId).ConfigureAwait(false);
-            return await CloneScraperTargetAsync(clonedName, scraperTarget).ConfigureAwait(false);
+            var scraperTarget =
+                await FindScraperTargetByIdAsync(scraperTargetId, cancellationToken).ConfigureAwait(false);
+            return await CloneScraperTargetAsync(clonedName, scraperTarget, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -124,9 +136,10 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned ScraperTarget</param>
         /// <param name="scraperTargetResponse">ScraperTarget to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned ScraperTarget</returns>
         public async Task<ScraperTargetResponse> CloneScraperTargetAsync(string clonedName,
-            ScraperTargetResponse scraperTargetResponse)
+            ScraperTargetResponse scraperTargetResponse, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
@@ -134,9 +147,9 @@ namespace InfluxDB.Client
             var cloned = new ScraperTargetRequest(clonedName, scraperTargetResponse.Type, scraperTargetResponse.Url,
                 scraperTargetResponse.OrgID, scraperTargetResponse.BucketID);
 
-            var created = await CreateScraperTargetAsync(cloned).ConfigureAwait(false);
-            var labels = await GetLabelsAsync(scraperTargetResponse).ConfigureAwait(false);
-            foreach (var label in labels) await AddLabelAsync(label, created).ConfigureAwait(false);
+            var created = await CreateScraperTargetAsync(cloned, cancellationToken).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(scraperTargetResponse, cancellationToken).ConfigureAwait(false);
+            foreach (var label in labels) await AddLabelAsync(label, created, cancellationToken).ConfigureAwait(false);
 
             return created;
         }
@@ -145,21 +158,25 @@ namespace InfluxDB.Client
         /// Retrieve a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetId">ID of ScraperTarget to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>ScraperTarget details</returns>
-        public Task<ScraperTargetResponse> FindScraperTargetByIdAsync(string scraperTargetId)
+        public Task<ScraperTargetResponse> FindScraperTargetByIdAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            return _service.GetScrapersIDAsync(scraperTargetId);
+            return _service.GetScrapersIDAsync(scraperTargetId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get all ScraperTargets.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of ScraperTargets</returns>
-        public async Task<List<ScraperTargetResponse>> FindScraperTargetsAsync()
+        public async Task<List<ScraperTargetResponse>> FindScraperTargetsAsync(
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetScrapersAsync().ConfigureAwait(false);
+            var response = await _service.GetScrapersAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -167,24 +184,29 @@ namespace InfluxDB.Client
         /// Get all ScraperTargets.
         /// </summary>
         /// <param name="organization">specifies the organization of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of ScraperTargets</returns>
-        public Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgAsync(Organization organization)
+        public Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return FindScraperTargetsByOrgIdAsync(organization.Id);
+            return FindScraperTargetsByOrgIdAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
         /// Get all ScraperTargets.
         /// </summary>
         /// <param name="orgId">specifies the organization ID of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of ScraperTargets</returns>
-        public async Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgIdAsync(string orgId)
+        public async Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetScrapersAsync(null, orgId).ConfigureAwait(false);
+            var response = await _service.GetScrapersAsync(null, orgId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -192,24 +214,29 @@ namespace InfluxDB.Client
         /// List all members of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetResponse">ScraperTarget of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a ScraperTarget</returns>
-        public Task<List<ResourceMember>> GetMembersAsync(ScraperTargetResponse scraperTargetResponse)
+        public Task<List<ResourceMember>> GetMembersAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
 
-            return GetMembersAsync(scraperTargetResponse.Id);
+            return GetMembersAsync(scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all members of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetId">ID of ScraperTarget to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a ScraperTarget</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(string scraperTargetId)
+        public async Task<List<ResourceMember>> GetMembersAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDMembersAsync(scraperTargetId).ConfigureAwait(false);
+            var response = await _service
+                .GetScrapersIDMembersAsync(scraperTargetId, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -218,13 +245,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a scraperTarget</param>
         /// <param name="scraperTargetResponse">the ScraperTarget of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(User member, ScraperTargetResponse scraperTargetResponse)
+        public Task<ResourceMember> AddMemberAsync(User member, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return AddMemberAsync(member.Id, scraperTargetResponse.Id);
+            return AddMemberAsync(member.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -232,14 +261,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="scraperTargetId">the ID of a scraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(string memberId, string scraperTargetId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
             return _service.PostScrapersIDMembersAsync(scraperTargetId,
-                new AddResourceMemberRequestBody(memberId));
+                new AddResourceMemberRequestBody(memberId), cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -247,13 +278,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a ScraperTarget</param>
         /// <param name="scraperTargetResponse">the ScraperTarget of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteMemberAsync(User member, ScraperTargetResponse scraperTargetResponse)
+        public Task DeleteMemberAsync(User member, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return DeleteMemberAsync(member.Id, scraperTargetResponse.Id);
+            return DeleteMemberAsync(member.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -261,37 +294,45 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteMemberAsync(string memberId, string scraperTargetId)
+        public Task DeleteMemberAsync(string memberId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.DeleteScrapersIDMembersIDAsync(memberId, scraperTargetId);
+            return _service.DeleteScrapersIDMembersIDAsync(memberId, scraperTargetId,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetResponse">ScraperTarget of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a ScraperTarget</returns>
-        public Task<List<ResourceOwner>> GetOwnersAsync(ScraperTargetResponse scraperTargetResponse)
+        public Task<List<ResourceOwner>> GetOwnersAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
 
-            return GetOwnersAsync(scraperTargetResponse.Id);
+            return GetOwnersAsync(scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetId">ID of a ScraperTarget to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a scraperTarget</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(string scraperTargetId)
+        public async Task<List<ResourceOwner>> GetOwnersAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDOwnersAsync(scraperTargetId).ConfigureAwait(false);
+            var response = await _service
+                .GetScrapersIDOwnersAsync(scraperTargetId, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Users;
         }
 
@@ -300,13 +341,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a ScraperTarget</param>
         /// <param name="scraperTargetResponse">the ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return AddOwnerAsync(owner.Id, scraperTargetResponse.Id);
+            return AddOwnerAsync(owner.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -314,15 +357,18 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string scraperTargetId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
             var memberRequest = new AddResourceMemberRequestBody(ownerId);
 
-            return _service.PostScrapersIDOwnersAsync(scraperTargetId, memberRequest);
+            return _service.PostScrapersIDOwnersAsync(scraperTargetId, memberRequest,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -330,13 +376,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a scraperTarget</param>
         /// <param name="scraperTargetResponse">the ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse)
+        public Task DeleteOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return DeleteOwnerAsync(owner.Id, scraperTargetResponse.Id);
+            return DeleteOwnerAsync(owner.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -344,37 +392,45 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteOwnerAsync(string ownerId, string scraperTargetId)
+        public Task DeleteOwnerAsync(string ownerId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.DeleteScrapersIDOwnersIDAsync(ownerId, scraperTargetId);
+            return _service.DeleteScrapersIDOwnersIDAsync(ownerId, scraperTargetId,
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all labels of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetResponse">a ScraperTarget of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a ScraperTarget</returns>
-        public Task<List<Label>> GetLabelsAsync(ScraperTargetResponse scraperTargetResponse)
+        public Task<List<Label>> GetLabelsAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
 
-            return GetLabelsAsync(scraperTargetResponse.Id);
+            return GetLabelsAsync(scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels of a ScraperTarget.
         /// </summary>
         /// <param name="scraperTargetId">ID of a ScraperTarget to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a ScraperTarget</returns>
-        public async Task<List<Label>> GetLabelsAsync(string scraperTargetId)
+        public async Task<List<Label>> GetLabelsAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
 
-            var response = await _service.GetScrapersIDLabelsAsync(scraperTargetId).ConfigureAwait(false);
+            var response = await _service
+                .GetScrapersIDLabelsAsync(scraperTargetId, cancellationToken: cancellationToken).ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -383,13 +439,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a ScraperTarget</param>
         /// <param name="scraperTargetResponse">a ScraperTarget of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public Task<Label> AddLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse)
+        public Task<Label> AddLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, scraperTargetResponse.Id);
+            return AddLabelAsync(label.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -397,15 +455,19 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string scraperTargetId)
+        public async Task<Label> AddLabelAsync(string labelId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostScrapersIDLabelsAsync(scraperTargetId, mapping).ConfigureAwait(false);
+            var response = await _service
+                .PostScrapersIDLabelsAsync(scraperTargetId, mapping, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
@@ -414,13 +476,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a ScraperTarget</param>
         /// <param name="scraperTargetResponse">a ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse)
+        public Task DeleteLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(scraperTargetResponse, nameof(scraperTargetResponse));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, scraperTargetResponse.Id);
+            return DeleteLabelAsync(label.Id, scraperTargetResponse.Id, cancellationToken);
         }
 
         /// <summary>
@@ -428,13 +492,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(string labelId, string scraperTargetId)
+        public Task DeleteLabelAsync(string labelId, string scraperTargetId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(scraperTargetId, nameof(scraperTargetId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteScrapersIDLabelsIDAsync(scraperTargetId, labelId);
+            return _service.DeleteScrapersIDLabelsIDAsync(scraperTargetId, labelId,
+                cancellationToken: cancellationToken);
         }
     }
 }

--- a/Client/SourcesApi.cs
+++ b/Client/SourcesApi.cs
@@ -1,11 +1,9 @@
-using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
 using InfluxDB.Client.Core;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client
 {
@@ -24,48 +22,52 @@ namespace InfluxDB.Client
         /// Creates a new Source and sets <see cref="InfluxDB.Client.Api.Domain.Source.Id" /> with the new identifier.
         /// </summary>
         /// <param name="source">source to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created Source</returns>
-        public Task<Source> CreateSourceAsync(Source source)
+        public Task<Source> CreateSourceAsync(Source source, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return _service.PostSourcesAsync(source);
+            return _service.PostSourcesAsync(source, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Update a Source.
         /// </summary>
         /// <param name="source">source update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>updated source</returns>
-        public Task<Source> UpdateSourceAsync(Source source)
+        public Task<Source> UpdateSourceAsync(Source source, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return _service.PatchSourcesIDAsync(source.Id, source);
+            return _service.PatchSourcesIDAsync(source.Id, source, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a source.
         /// </summary>
         /// <param name="sourceId">ID of source to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteSourceAsync(string sourceId)
+        public Task DeleteSourceAsync(string sourceId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(sourceId, nameof(sourceId));
 
-            return _service.DeleteSourcesIDAsync(sourceId);
+            return _service.DeleteSourcesIDAsync(sourceId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a source.
         /// </summary>
         /// <param name="source">source to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteSourceAsync(Source source)
+        public Task DeleteSourceAsync(Source source, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return DeleteSourceAsync(source.Id);
+            return DeleteSourceAsync(source.Id, cancellationToken);
         }
 
         /// <summary>
@@ -73,14 +75,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned source</param>
         /// <param name="sourceId">ID of source to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned source</returns>
-        public async Task<Source> CloneSourceAsync(string clonedName, string sourceId)
+        public async Task<Source> CloneSourceAsync(string clonedName, string sourceId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            var source = await FindSourceByIdAsync(sourceId).ConfigureAwait(false);
-            return await CloneSourceAsync(clonedName, source).ConfigureAwait(false);
+            var source = await FindSourceByIdAsync(sourceId, cancellationToken).ConfigureAwait(false);
+            return await CloneSourceAsync(clonedName, source, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -88,8 +92,10 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned source</param>
         /// <param name="source">source to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned source</returns>
-        public Task<Source> CloneSourceAsync(string clonedName, Source source)
+        public Task<Source> CloneSourceAsync(string clonedName, Source source,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(source, nameof(source));
@@ -111,28 +117,30 @@ namespace InfluxDB.Client
                 DefaultRP = source.DefaultRP
             };
 
-            return CreateSourceAsync(cloned);
+            return CreateSourceAsync(cloned, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve a source.
         /// </summary>
         /// <param name="sourceId">ID of source to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>source details</returns>
-        public Task<Source> FindSourceByIdAsync(string sourceId)
+        public Task<Source> FindSourceByIdAsync(string sourceId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return _service.GetSourcesIDAsync(sourceId);
+            return _service.GetSourcesIDAsync(sourceId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Get all sources.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of sources</returns>
-        public async Task<List<Source>> FindSourcesAsync()
+        public async Task<List<Source>> FindSourcesAsync(CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetSourcesAsync().ConfigureAwait(false);
+            var response = await _service.GetSourcesAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
             return response._Sources;
         }
 
@@ -140,24 +148,28 @@ namespace InfluxDB.Client
         /// Get a sources buckets (will return dbrps in the form of buckets if it is a v1 source).
         /// </summary>
         /// <param name="source">filter buckets to a specific source</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The buckets for source. If source does not exist than return null.</returns>
-        public Task<List<Bucket>> FindBucketsBySourceAsync(Source source)
+        public Task<List<Bucket>> FindBucketsBySourceAsync(Source source, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return FindBucketsBySourceIdAsync(source.Id);
+            return FindBucketsBySourceIdAsync(source.Id, cancellationToken);
         }
 
         /// <summary>
         /// Get a sources buckets (will return dbrps in the form of buckets if it is a v1 source).
         /// </summary>
         /// <param name="sourceId">filter buckets to a specific source ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>The buckets for source. If source does not exist than return null.</returns>
-        public async Task<List<Bucket>> FindBucketsBySourceIdAsync(string sourceId)
+        public async Task<List<Bucket>> FindBucketsBySourceIdAsync(string sourceId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            var response = await _service.GetSourcesIDBucketsAsync(sourceId).ConfigureAwait(false);
+            var response = await _service.GetSourcesIDBucketsAsync(sourceId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response._Buckets;
         }
 
@@ -165,24 +177,27 @@ namespace InfluxDB.Client
         /// Get a sources health.
         /// </summary>
         /// <param name="source">source to check health</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>health of source</returns>
-        public Task<HealthCheck> HealthAsync(Source source)
+        public Task<HealthCheck> HealthAsync(Source source, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(source, nameof(source));
 
-            return HealthAsync(source.Id);
+            return HealthAsync(source.Id, cancellationToken);
         }
 
         /// <summary>
         /// Get a sources health.
         /// </summary>
         /// <param name="sourceId">source to check health</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>health of source</returns>
-        public Task<HealthCheck> HealthAsync(string sourceId)
+        public Task<HealthCheck> HealthAsync(string sourceId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(sourceId, nameof(sourceId));
 
-            return InfluxDBClient.GetHealthAsync(_service.GetSourcesIDHealthAsync(sourceId));
+            return InfluxDBClient.GetHealthAsync(
+                _service.GetSourcesIDHealthAsync(sourceId, cancellationToken: cancellationToken));
         }
     }
 }

--- a/Client/TasksApi.cs
+++ b/Client/TasksApi.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -38,10 +38,11 @@ namespace InfluxDB.Client
         /// </code>
         /// </example>
         /// </summary>
-        /// <param name="task"></param>
-        /// <returns></returns>
+        /// <param name="task">task to create (required)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
         /// <exception cref="NotImplementedException"></exception>
-        public Task<TaskType> CreateTaskAsync(TaskType task)
+        public Task<TaskType> CreateTaskAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
@@ -49,19 +50,21 @@ namespace InfluxDB.Client
             var taskCreateRequest = new TaskCreateRequest(task.OrgID, task.Org, status,
                 task.Flux, task.Description);
 
-            return CreateTaskAsync(taskCreateRequest);
+            return CreateTaskAsync(taskCreateRequest, cancellationToken);
         }
 
         /// <summary>
         /// Create a new task.
         /// </summary>
         /// <param name="taskCreateRequest">task to create (required)</param>
-        /// <returns>Task created</returns>
-        public Task<TaskType> CreateTaskAsync(TaskCreateRequest taskCreateRequest)
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
+        public Task<TaskType> CreateTaskAsync(TaskCreateRequest taskCreateRequest,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(taskCreateRequest, nameof(taskCreateRequest));
 
-            return _service.PostTasksAsync(taskCreateRequest);
+            return _service.PostTasksAsync(taskCreateRequest, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -73,17 +76,18 @@ namespace InfluxDB.Client
         /// <param name="flux">the Flux script to run for this task</param>
         /// <param name="cron">a task repetition schedule in the form '* * * * * *'</param>
         /// <param name="organization">the organization that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
         public Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
-            Organization organization)
+            Organization organization, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(flux, nameof(flux));
             Arguments.CheckNonEmptyString(cron, nameof(cron));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return CreateTaskCronAsync(name, flux, cron, organization.Id);
+            return CreateTaskCronAsync(name, flux, cron, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -95,10 +99,11 @@ namespace InfluxDB.Client
         /// <param name="flux">the Flux script to run for this task</param>
         /// <param name="cron">a task repetition schedule in the form '* * * * * *'</param>
         /// <param name="orgId">the organization ID that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
         /// <exception cref="NotImplementedException"></exception>
         public Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
-            string orgId)
+            string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(flux, nameof(flux));
@@ -107,7 +112,7 @@ namespace InfluxDB.Client
 
             var task = CreateTaskAsync(name, flux, null, cron, orgId);
 
-            return CreateTaskAsync(task);
+            return CreateTaskAsync(task, cancellationToken);
         }
 
         /// <summary>
@@ -119,17 +124,18 @@ namespace InfluxDB.Client
         /// <param name="flux">the Flux script to run for this task</param>
         /// <param name="every">a task repetition by duration expression</param>
         /// <param name="organization">the organization that owns this Task</param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
         /// <exception cref="NotImplementedException"></exception>
         public Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
-            Organization organization)
+            Organization organization, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(flux, nameof(flux));
             Arguments.CheckNonEmptyString(every, nameof(every));
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return CreateTaskEveryAsync(name, flux, every, organization.Id);
+            return CreateTaskEveryAsync(name, flux, every, organization.Id, cancellationToken);
         }
 
         /// <summary>
@@ -141,10 +147,11 @@ namespace InfluxDB.Client
         /// <param name="flux">the Flux script to run for this task</param>
         /// <param name="every">a task repetition by duration expression</param>
         /// <param name="orgId">the organization ID that owns this Task</param>
-        /// <returns></returns>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
         /// <exception cref="NotImplementedException"></exception>
         public Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
-            string orgId)
+            string orgId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
             Arguments.CheckNonEmptyString(flux, nameof(flux));
@@ -153,15 +160,16 @@ namespace InfluxDB.Client
 
             var task = CreateTaskAsync(name, flux, every, null, orgId);
 
-            return CreateTaskAsync(task);
+            return CreateTaskAsync(task, cancellationToken);
         }
 
         /// <summary>
         /// Update a task. This will cancel all queued runs.
         /// </summary>
         /// <param name="task">task update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>task updated</returns>
-        public Task<TaskType> UpdateTaskAsync(TaskType task)
+        public Task<TaskType> UpdateTaskAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
@@ -169,7 +177,7 @@ namespace InfluxDB.Client
 
             var request = new TaskUpdateRequest(status, task.Flux, task.Name, task.Every, task.Cron);
 
-            return UpdateTaskAsync(task.Id, request);
+            return UpdateTaskAsync(task.Id, request, cancellationToken);
         }
 
 
@@ -178,59 +186,65 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task to get</param>
         /// <param name="request">task update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>task updated</returns>
-        public Task<TaskType> UpdateTaskAsync(string taskId, TaskUpdateRequest request)
+        public Task<TaskType> UpdateTaskAsync(string taskId, TaskUpdateRequest request,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNotNull(request, nameof(request));
 
-            return _service.PatchTasksIDAsync(taskId, request);
+            return _service.PatchTasksIDAsync(taskId, request, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a task.
         /// </summary>
         /// <param name="taskId">ID of task to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>task deleted</returns>
-        public Task DeleteTaskAsync(string taskId)
+        public Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(taskId, nameof(taskId));
 
-            return _service.DeleteTasksIDAsync(taskId);
+            return _service.DeleteTasksIDAsync(taskId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a task.
         /// </summary>
         /// <param name="task">task to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>task deleted</returns>
-        public Task DeleteTaskAsync(TaskType task)
+        public Task DeleteTaskAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return DeleteTaskAsync(task.Id);
+            return DeleteTaskAsync(task.Id, cancellationToken);
         }
 
         /// <summary>
         /// Clone a task.
         /// </summary>
         /// <param name="taskId">ID of task to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned task</returns>
-        public async Task<TaskType> CloneTaskAsync(string taskId)
+        public async Task<TaskType> CloneTaskAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var task = await FindTaskByIdAsync(taskId).ConfigureAwait(false);
+            var task = await FindTaskByIdAsync(taskId, cancellationToken).ConfigureAwait(false);
 
-            return await CloneTaskAsync(task).ConfigureAwait(false);
+            return await CloneTaskAsync(task, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
         /// Clone a task.
         /// </summary>
         /// <param name="task">task to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned task</returns>
-        public async Task<TaskType> CloneTaskAsync(TaskType task)
+        public async Task<TaskType> CloneTaskAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
@@ -238,9 +252,9 @@ namespace InfluxDB.Client
             var cloned = new TaskCreateRequest(task.OrgID, task.Org, status,
                 task.Flux, task.Description);
 
-            var created = await CreateTaskAsync(cloned).ConfigureAwait(false);
-            var labels = await GetLabelsAsync(task).ConfigureAwait(false);
-            foreach (var label in labels) await AddLabelAsync(label, created).ConfigureAwait(false);
+            var created = await CreateTaskAsync(cloned, cancellationToken).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(task, cancellationToken).ConfigureAwait(false);
+            foreach (var label in labels) await AddLabelAsync(label, created, cancellationToken).ConfigureAwait(false);
 
             return created;
         }
@@ -249,46 +263,51 @@ namespace InfluxDB.Client
         /// Retrieve a task.
         /// </summary>
         /// <param name="taskId">ID of task to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>task details</returns>
-        public Task<TaskType> FindTaskByIdAsync(string taskId)
+        public Task<TaskType> FindTaskByIdAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            return _service.GetTasksIDAsync(taskId);
+            return _service.GetTasksIDAsync(taskId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Lists tasks, limit 100.
         /// </summary>
         /// <param name="user">filter tasks to a specific user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of tasks</returns>
-        public Task<List<TaskType>> FindTasksByUserAsync(User user)
+        public Task<List<TaskType>> FindTasksByUserAsync(User user, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return FindTasksByUserIdAsync(user.Id);
+            return FindTasksByUserIdAsync(user.Id, cancellationToken);
         }
 
         /// <summary>
         /// Lists tasks, limit 100.
         /// </summary>
         /// <param name="userId">filter tasks to a specific user ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of tasks</returns>
-        public Task<List<TaskType>> FindTasksByUserIdAsync(string userId)
+        public Task<List<TaskType>> FindTasksByUserIdAsync(string userId, CancellationToken cancellationToken = default)
         {
-            return FindTasksAsync(null, userId);
+            return FindTasksAsync(userId: userId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Lists tasks, limit 100.
         /// </summary>
         /// <param name="organization">filter tasks to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of tasks</returns>
-        public Task<List<TaskType>> FindTasksByOrganizationAsync(Organization organization)
+        public Task<List<TaskType>> FindTasksByOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return FindTasksByOrganizationIdAsync(organization.Id);
+            return FindTasksByOrganizationIdAsync(organization.Id, cancellationToken);
         }
 
 
@@ -296,10 +315,12 @@ namespace InfluxDB.Client
         /// Lists tasks, limit 100.
         /// </summary>
         /// <param name="orgId">filter tasks to a specific organization ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of tasks</returns>
-        public Task<List<TaskType>> FindTasksByOrganizationIdAsync(string orgId)
+        public Task<List<TaskType>> FindTasksByOrganizationIdAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
-            return FindTasksAsync(null, null, orgId);
+            return FindTasksAsync(orgId: orgId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -308,11 +329,18 @@ namespace InfluxDB.Client
         /// <param name="afterId">returns tasks after specified ID</param>
         /// <param name="userId">filter tasks to a specific user ID</param>
         /// <param name="orgId">filter tasks to a specific organization ID</param>
+        /// <param name="org">Filter tasks to a specific organization name. (optional)</param>
+        /// <param name="name">Returns task with a specific name. (optional)</param>
+        /// <param name="limit">The number of tasks to return (optional, default to 100)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of tasks</returns>
         public async Task<List<TaskType>> FindTasksAsync(string afterId = null, string userId = null,
-            string orgId = null)
+            string orgId = null, string org = null, string name = null, int? limit = null,
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetTasksAsync(after: afterId, user: userId, orgID: orgId)
+            var response = await _service
+                .GetTasksAsync(after: afterId, user: userId, orgID: orgId, name: name, org: org, limit: limit,
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return response._Tasks;
         }
@@ -321,24 +349,28 @@ namespace InfluxDB.Client
         /// List all members of a task.
         /// </summary>
         /// <param name="task">task of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a task</returns>
-        public Task<List<ResourceMember>> GetMembersAsync(TaskType task)
+        public Task<List<ResourceMember>> GetMembersAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "task");
 
-            return GetMembersAsync(task.Id);
+            return GetMembersAsync(task.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all members of a task.
         /// </summary>
         /// <param name="taskId">ID of task to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all members of a task</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(string taskId)
+        public async Task<List<ResourceMember>> GetMembersAsync(string taskId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDMembersAsync(taskId).ConfigureAwait(false);
+            var response = await _service.GetTasksIDMembersAsync(taskId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -347,13 +379,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a task</param>
         /// <param name="task">the task of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(User member, TaskType task)
+        public Task<ResourceMember> AddMemberAsync(User member, TaskType task,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(member, "member");
 
-            return AddMemberAsync(member.Id, task.Id);
+            return AddMemberAsync(member.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -361,13 +395,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceMember> AddMemberAsync(string memberId, string taskId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string taskId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.PostTasksIDMembersAsync(taskId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostTasksIDMembersAsync(taskId, new AddResourceMemberRequestBody(memberId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -375,13 +412,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">the member of a task</param>
         /// <param name="task">the task of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(User member, TaskType task)
+        public Task DeleteMemberAsync(User member, TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(member, "member");
 
-            return DeleteMemberAsync(member.Id, task.Id);
+            return DeleteMemberAsync(member.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -389,37 +427,42 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">the ID of a member</param>
         /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(string memberId, string taskId)
+        public Task DeleteMemberAsync(string memberId, string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.DeleteTasksIDMembersIDAsync(memberId, taskId);
+            return _service.DeleteTasksIDMembersIDAsync(memberId, taskId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a task.
         /// </summary>
         /// <param name="task">task of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a task</returns>
-        public Task<List<ResourceOwner>> GetOwnersAsync(TaskType task)
+        public Task<List<ResourceOwner>> GetOwnersAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "Task is required");
 
-            return GetOwnersAsync(task.Id);
+            return GetOwnersAsync(task.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a task.
         /// </summary>
         /// <param name="taskId">ID of a task to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all owners of a task</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(string taskId)
+        public async Task<List<ResourceOwner>> GetOwnersAsync(string taskId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDOwnersAsync(taskId).ConfigureAwait(false);
+            var response = await _service.GetTasksIDOwnersAsync(taskId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -428,13 +471,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a task</param>
         /// <param name="task">the task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(User owner, TaskType task)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, TaskType task,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(owner, "owner");
 
-            return AddOwnerAsync(owner.Id, task.Id);
+            return AddOwnerAsync(owner.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -442,13 +487,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>created mapping</returns>
-        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string taskId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string taskId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.PostTasksIDOwnersAsync(taskId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostTasksIDOwnersAsync(taskId, new AddResourceMemberRequestBody(ownerId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -456,13 +504,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">the owner of a task</param>
         /// <param name="task">the task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(User owner, TaskType task)
+        public Task DeleteOwnerAsync(User owner, TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, "task");
             Arguments.CheckNotNull(owner, "owner");
 
-            return DeleteOwnerAsync(owner.Id, task.Id);
+            return DeleteOwnerAsync(owner.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -470,37 +519,41 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">the ID of a owner</param>
         /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(string ownerId, string taskId)
+        public Task DeleteOwnerAsync(string ownerId, string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.DeleteTasksIDOwnersIDAsync(ownerId, taskId);
+            return _service.DeleteTasksIDOwnersIDAsync(ownerId, taskId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Retrieve all logs for a task.
         /// </summary>
         /// <param name="task">task to get logs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of all logs for a task</returns>
-        public Task<List<LogEvent>> GetLogsAsync(TaskType task)
+        public Task<List<LogEvent>> GetLogsAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return GetLogsAsync(task.Id);
+            return GetLogsAsync(task.Id, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve all logs for a task.
         /// </summary>
         /// <param name="taskId">ID of task to get logs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of all logs for a task</returns>
-        public async Task<List<LogEvent>> GetLogsAsync(string taskId)
+        public async Task<List<LogEvent>> GetLogsAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDLogsAsync(taskId).ConfigureAwait(false);
+            var response = await _service.GetTasksIDLogsAsync(taskId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Events;
         }
 
@@ -508,12 +561,13 @@ namespace InfluxDB.Client
         /// Retrieve list of run records for a task.
         /// </summary>
         /// <param name="task"> task to get runs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of run records for a task</returns>
-        public Task<List<Run>> GetRunsAsync(TaskType task)
+        public Task<List<Run>> GetRunsAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return GetRunsAsync(task, null, null, null);
+            return GetRunsAsync(task, null, null, null, cancellationToken);
         }
 
 
@@ -524,45 +578,45 @@ namespace InfluxDB.Client
         /// <param name="afterTime">filter runs to those scheduled after this time</param>
         /// <param name="beforeTime">filter runs to those scheduled before this time</param>
         /// <param name="limit">the number of runs to return. Default value: 20.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of run records for a task</returns>
         public Task<List<Run>> GetRunsAsync(TaskType task, DateTime? afterTime,
-            DateTime? beforeTime, int? limit)
+            DateTime? beforeTime, int? limit, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return GetRunsAsync(task.Id, task.Org, afterTime, beforeTime, limit);
+            return GetRunsAsync(task.Id, afterTime, beforeTime, limit, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve list of run records for a task.
         /// </summary>
         /// <param name="taskId">ID of task to get runs for</param>
-        /// <param name="orgId">ID of organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of run records for a task</returns>
-        public Task<List<Run>> GetRunsAsync(string taskId, string orgId)
+        public Task<List<Run>> GetRunsAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
-            Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            return GetRunsAsync(taskId, orgId, null, null, null);
+            return GetRunsAsync(taskId, null, null, null, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve list of run records for a task.
         /// </summary>
         /// <param name="taskId">ID of task to get runs for</param>
-        /// <param name="orgId">ID of organization</param>
         /// <param name="afterTime">filter runs to those scheduled after this time</param>
         /// <param name="beforeTime">filter runs to those scheduled before this time</param>
         /// <param name="limit">the number of runs to return. Default value: 20.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of run records for a task</returns>
-        public async Task<List<Run>> GetRunsAsync(string taskId, string orgId,
-            DateTime? afterTime, DateTime? beforeTime, int? limit)
+        public async Task<List<Run>> GetRunsAsync(string taskId,
+            DateTime? afterTime, DateTime? beforeTime, int? limit, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
-            Arguments.CheckNonEmptyString(orgId, nameof(orgId));
 
-            var response = await _service.GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime)
+            var response = await _service
+                .GetTasksIDRunsAsync(taskId, null, null, limit, afterTime, beforeTime, cancellationToken)
                 .ConfigureAwait(false);
             return response._Runs;
         }
@@ -572,25 +626,27 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task to get runs for</param>
         /// <param name="runId">ID of run</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a single run record for a task</returns>
-        public Task<Run> GetRunAsync(string taskId, string runId)
+        public Task<Run> GetRunAsync(string taskId, string runId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return _service.GetTasksIDRunsIDAsync(taskId, runId);
+            return _service.GetTasksIDRunsIDAsync(taskId, runId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Retry a task run.
         /// </summary>
         /// <param name="run">the run to retry</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the executed run</returns>
-        public Task<Run> RetryRunAsync(Run run)
+        public Task<Run> RetryRunAsync(Run run, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(run, nameof(run));
 
-            return RetryRunAsync(run.TaskID, run.Id);
+            return RetryRunAsync(run.TaskID, run.Id, cancellationToken);
         }
 
         /// <summary>
@@ -598,25 +654,27 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task with the run to retry</param>
         /// <param name="runId">ID of run to retry</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the executed run</returns>
-        public Task<Run> RetryRunAsync(string taskId, string runId)
+        public Task<Run> RetryRunAsync(string taskId, string runId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return _service.PostTasksIDRunsIDRetryAsync(taskId, runId);
+            return _service.PostTasksIDRunsIDRetryAsync(taskId, runId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Cancels a currently running run.
         /// </summary>
         /// <param name="run">the run to cancel</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task CancelRunAsync(Run run)
+        public Task CancelRunAsync(Run run, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(run, nameof(run));
 
-            return CancelRunAsync(run.TaskID, run.Id);
+            return CancelRunAsync(run.TaskID, run.Id, cancellationToken);
         }
 
         /// <summary>
@@ -624,23 +682,25 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task with the run to cancel</param>
         /// <param name="runId">ID of run to cancel</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns></returns>
-        public Task CancelRunAsync(string taskId, string runId)
+        public Task CancelRunAsync(string taskId, string runId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            return _service.DeleteTasksIDRunsIDAsync(taskId, runId);
+            return _service.DeleteTasksIDRunsIDAsync(taskId, runId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Retrieve all logs for a run.
         /// </summary>
         /// <param name="run">the run to gets logs for it</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of all logs for a run</returns>
-        public Task<List<LogEvent>> GetRunLogsAsync(Run run)
+        public Task<List<LogEvent>> GetRunLogsAsync(Run run, CancellationToken cancellationToken = default)
         {
-            return GetRunLogsAsync(run.TaskID, run.Id);
+            return GetRunLogsAsync(run.TaskID, run.Id, cancellationToken);
         }
 
         /// <summary>
@@ -648,13 +708,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="taskId">ID of task to get run logs for it</param>
         /// <param name="runId">ID of run to get logs for it</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the list of all logs for a run</returns>
-        public async Task<List<LogEvent>> GetRunLogsAsync(string taskId, string runId)
+        public async Task<List<LogEvent>> GetRunLogsAsync(string taskId, string runId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(runId, nameof(runId));
 
-            var response = await _service.GetTasksIDRunsIDLogsAsync(taskId, runId).ConfigureAwait(false);
+            var response = await _service.GetTasksIDRunsIDLogsAsync(taskId, runId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Events;
         }
 
@@ -662,24 +725,27 @@ namespace InfluxDB.Client
         /// List all labels of a Task.
         /// </summary>
         /// <param name="task">a Task of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a Task</returns>
-        public Task<List<Label>> GetLabelsAsync(TaskType task)
+        public Task<List<Label>> GetLabelsAsync(TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
 
-            return GetLabelsAsync(task.Id);
+            return GetLabelsAsync(task.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels of a Task.
         /// </summary>
         /// <param name="taskId">ID of a Task to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>the List all labels of a Task</returns>
-        public async Task<List<Label>> GetLabelsAsync(string taskId)
+        public async Task<List<Label>> GetLabelsAsync(string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
 
-            var response = await _service.GetTasksIDLabelsAsync(taskId).ConfigureAwait(false);
+            var response = await _service.GetTasksIDLabelsAsync(taskId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -688,13 +754,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a Task</param>
         /// <param name="task">a Task of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public Task<Label> AddLabelAsync(Label label, TaskType task)
+        public Task<Label> AddLabelAsync(Label label, TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, task.Id);
+            return AddLabelAsync(label.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -702,15 +769,18 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="taskId">the ID of a Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string taskId)
+        public async Task<Label> AddLabelAsync(string labelId, string taskId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
             var mapping = new LabelMapping(labelId);
 
-            var response = await _service.PostTasksIDLabelsAsync(taskId, mapping).ConfigureAwait(false);
+            var response = await _service.PostTasksIDLabelsAsync(taskId, mapping, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Label;
         }
 
@@ -719,13 +789,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">the label of a Task</param>
         /// <param name="task">a Task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(Label label, TaskType task)
+        public Task DeleteLabelAsync(Label label, TaskType task, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(task, nameof(task));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, task.Id);
+            return DeleteLabelAsync(label.Id, task.Id, cancellationToken);
         }
 
         /// <summary>
@@ -733,13 +804,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">the ID of a label</param>
         /// <param name="taskId">the ID of a Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(string labelId, string taskId)
+        public Task DeleteLabelAsync(string labelId, string taskId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(taskId, nameof(taskId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteTasksIDLabelsIDAsync(taskId, labelId);
+            return _service.DeleteTasksIDLabelsIDAsync(taskId, labelId, cancellationToken: cancellationToken);
         }
 
         private TaskType CreateTaskAsync(string name, string flux, string every, string cron, string orgId)

--- a/Client/TelegrafsApi.cs
+++ b/Client/TelegrafsApi.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -29,11 +30,12 @@ namespace InfluxDB.Client
         /// <param name="description">Telegraf Configuration Description</param>
         /// <param name="org">The organization that owns this config</param>
         /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
-            List<TelegrafPlugin> plugins)
+            List<TelegrafPlugin> plugins, CancellationToken cancellationToken = default)
         {
-            return CreateTelegrafAsync(name, description, org, CreateAgentConfiguration(), plugins);
+            return CreateTelegrafAsync(name, description, org, CreateAgentConfiguration(), plugins, cancellationToken);
         }
 
         /// <summary>
@@ -44,11 +46,13 @@ namespace InfluxDB.Client
         /// <param name="org">The organization that owns this config</param>
         /// <param name="agentConfiguration">The telegraf agent config</param>
         /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
-            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins)
+            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins,
+            CancellationToken cancellationToken = default)
         {
-            return CreateTelegrafAsync(name, description, org.Id, agentConfiguration, plugins);
+            return CreateTelegrafAsync(name, description, org.Id, agentConfiguration, plugins, cancellationToken);
         }
 
         /// <summary>
@@ -58,11 +62,13 @@ namespace InfluxDB.Client
         /// <param name="description">Telegraf Configuration Description</param>
         /// <param name="orgId">The organization that owns this config</param>
         /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
-            List<TelegrafPlugin> plugins)
+            List<TelegrafPlugin> plugins, CancellationToken cancellationToken = default)
         {
-            return CreateTelegrafAsync(name, description, orgId, CreateAgentConfiguration(), plugins);
+            return CreateTelegrafAsync(name, description, orgId, CreateAgentConfiguration(), plugins,
+                cancellationToken);
         }
 
         /// <summary>
@@ -73,9 +79,11 @@ namespace InfluxDB.Client
         /// <param name="orgId">The organization that owns this config</param>
         /// <param name="agentConfiguration">The telegraf agent config</param>
         /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
-            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins)
+            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins,
+            CancellationToken cancellationToken = default)
         {
             var config = new StringBuilder();
 
@@ -118,7 +126,7 @@ namespace InfluxDB.Client
             var request = new TelegrafPluginRequest(name, description, orgID: orgId, config: config.ToString(),
                 plugins: pluginsList);
 
-            return CreateTelegrafAsync(request);
+            return CreateTelegrafAsync(request, cancellationToken);
         }
 
         /// <summary>
@@ -130,11 +138,13 @@ namespace InfluxDB.Client
         /// <param name="config">ConfigTOML contains the raw toml config</param>
         /// <param name="metadata">Metadata for the config</param>
         /// <param name="plugins">Plugins to use.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
-            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null)
+            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null,
+            CancellationToken cancellationToken = default)
         {
-            return CreateTelegrafAsync(name, description, org.Id, config, metadata, plugins);
+            return CreateTelegrafAsync(name, description, org.Id, config, metadata, plugins, cancellationToken);
         }
 
         /// <summary>
@@ -146,25 +156,29 @@ namespace InfluxDB.Client
         /// <param name="config">ConfigTOML contains the raw toml config</param>
         /// <param name="metadata">Metadata for the config</param>
         /// <param name="plugins">Plugins to use.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
         public Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
-            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null)
+            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null,
+            CancellationToken cancellationToken = default)
         {
             var request = new TelegrafPluginRequest(name, description, plugins, metadata, config, orgId);
 
-            return CreateTelegrafAsync(request);
+            return CreateTelegrafAsync(request, cancellationToken);
         }
 
         /// <summary>
         /// Create a telegraf config.
         /// </summary>
         /// <param name="telegrafRequest">Telegraf Configuration to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Telegraf config created</returns>
-        public Task<Telegraf> CreateTelegrafAsync(TelegrafPluginRequest telegrafRequest)
+        public Task<Telegraf> CreateTelegrafAsync(TelegrafPluginRequest telegrafRequest,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegrafRequest, nameof(telegrafRequest));
 
-            return _service.PostTelegrafsAsync(telegrafRequest);
+            return _service.PostTelegrafsAsync(telegrafRequest, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -201,8 +215,9 @@ namespace InfluxDB.Client
         /// Update a telegraf config.
         /// </summary>
         /// <param name="telegraf">telegraf config update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated telegraf</returns>
-        public Task<Telegraf> UpdateTelegrafAsync(Telegraf telegraf)
+        public Task<Telegraf> UpdateTelegrafAsync(Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
@@ -210,7 +225,7 @@ namespace InfluxDB.Client
                 telegraf.Config,
                 telegraf.OrgID);
 
-            return UpdateTelegrafAsync(telegraf.Id, request);
+            return UpdateTelegrafAsync(telegraf.Id, request, cancellationToken);
         }
 
         /// <summary>
@@ -218,37 +233,41 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config</param>
         /// <param name="telegrafRequest">telegraf config update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>An updated telegraf</returns>
-        public Task<Telegraf> UpdateTelegrafAsync(string telegrafId, TelegrafPluginRequest telegrafRequest)
+        public Task<Telegraf> UpdateTelegrafAsync(string telegrafId, TelegrafPluginRequest telegrafRequest,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNotNull(telegrafRequest, nameof(telegrafRequest));
 
-            return _service.PutTelegrafsIDAsync(telegrafId, telegrafRequest);
+            return _service.PutTelegrafsIDAsync(telegrafId, telegrafRequest, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete a telegraf config.
         /// </summary>
         /// <param name="telegraf">telegraf config to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteTelegrafAsync(Telegraf telegraf)
+        public Task DeleteTelegrafAsync(Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return DeleteTelegrafAsync(telegraf.Id);
+            return DeleteTelegrafAsync(telegraf.Id, cancellationToken);
         }
 
         /// <summary>
         /// Delete a telegraf config.
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteTelegrafAsync(string telegrafId)
+        public Task DeleteTelegrafAsync(string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return _service.DeleteTelegrafsIDAsync(telegrafId);
+            return _service.DeleteTelegrafsIDAsync(telegrafId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -256,15 +275,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned telegraf config</param>
         /// <param name="telegrafId">ID of telegraf config to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned telegraf config</returns>
-        public async Task<Telegraf> CloneTelegrafAsync(string clonedName, string telegrafId)
+        public async Task<Telegraf> CloneTelegrafAsync(string clonedName, string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var telegraf = await FindTelegrafByIdAsync(telegrafId).ConfigureAwait(false);
+            var telegraf = await FindTelegrafByIdAsync(telegrafId, cancellationToken).ConfigureAwait(false);
 
-            return await CloneTelegrafAsync(clonedName, telegraf).ConfigureAwait(false);
+            return await CloneTelegrafAsync(clonedName, telegraf, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -272,8 +293,10 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned telegraf config</param>
         /// <param name="telegraf">telegraf config to clone></param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned telegraf config</returns>
-        public async Task<Telegraf> CloneTelegrafAsync(string clonedName, Telegraf telegraf)
+        public async Task<Telegraf> CloneTelegrafAsync(string clonedName, Telegraf telegraf,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
@@ -282,8 +305,8 @@ namespace InfluxDB.Client
                 telegraf.Config,
                 telegraf.OrgID);
 
-            var created = await CreateTelegrafAsync(cloned).ConfigureAwait(false);
-            var labels = await GetLabelsAsync(telegraf).ConfigureAwait(false);
+            var created = await CreateTelegrafAsync(cloned, cancellationToken).ConfigureAwait(false);
+            var labels = await GetLabelsAsync(telegraf, cancellationToken).ConfigureAwait(false);
             foreach (var label in labels) await AddLabelAsync(label, created).ConfigureAwait(false);
 
             return created;
@@ -293,12 +316,15 @@ namespace InfluxDB.Client
         /// Retrieve a telegraf config.
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>telegraf config details</returns>
-        public async Task<Telegraf> FindTelegrafByIdAsync(string telegrafId)
+        public async Task<Telegraf> FindTelegrafByIdAsync(string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json")
+            var response = await _service
+                .GetTelegrafsIDWithIRestResponseAsync(telegrafId, null, "application/json", cancellationToken)
                 .ConfigureAwait(false);
 
             return (Telegraf)_service.Configuration.ApiClient.Deserialize(response, typeof(Telegraf));
@@ -307,32 +333,38 @@ namespace InfluxDB.Client
         /// <summary>
         /// Returns a list of telegraf configs.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of telegraf configs</returns>
-        public Task<List<Telegraf>> FindTelegrafsAsync()
+        public Task<List<Telegraf>> FindTelegrafsAsync(CancellationToken cancellationToken = default)
         {
-            return FindTelegrafsByOrgIdAsync(null);
+            return FindTelegrafsByOrgIdAsync(null, cancellationToken);
         }
 
         /// <summary>
         /// Returns a list of telegraf configs for specified organization.
         /// </summary>
         /// <param name="organization">specifies the organization of the telegraf configs</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of telegraf configs</returns>
-        public Task<List<Telegraf>> FindTelegrafsByOrgAsync(Organization organization)
+        public Task<List<Telegraf>> FindTelegrafsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(organization, nameof(organization));
 
-            return FindTelegrafsByOrgIdAsync(organization.Id);
+            return FindTelegrafsByOrgIdAsync(organization.Id, cancellationToken);
         }
 
         /// <summary>
         /// Returns a list of telegraf configs for specified organization.
         /// </summary>
         /// <param name="orgId">specifies the organization of the telegraf configs</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>A list of telegraf configs</returns>
-        public async Task<List<Telegraf>> FindTelegrafsByOrgIdAsync(string orgId)
+        public async Task<List<Telegraf>> FindTelegrafsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetTelegrafsAsync(orgId).ConfigureAwait(false);
+            var response = await _service.GetTelegrafsAsync(orgId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Configurations;
         }
 
@@ -340,48 +372,55 @@ namespace InfluxDB.Client
         /// Retrieve a telegraf config in TOML.
         /// </summary>
         /// <param name="telegraf">telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>telegraf config details in TOML format</returns>
-        public Task<string> GetTOMLAsync(Telegraf telegraf)
+        public Task<string> GetTOMLAsync(Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return GetTOMLAsync(telegraf.Id);
+            return GetTOMLAsync(telegraf.Id, cancellationToken);
         }
 
         /// <summary>
         /// Retrieve a telegraf config in TOML.
         /// </summary>
         /// <param name="telegrafId">ID of telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>telegraf config details in TOML format</returns>
-        public Task<string> GetTOMLAsync(string telegrafId)
+        public Task<string> GetTOMLAsync(string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            return _service.GetTelegrafsIDAsync(telegrafId, null, "application/toml");
+            return _service.GetTelegrafsIDAsync(telegrafId, null, "application/toml", cancellationToken);
         }
 
         /// <summary>
         /// List all users with member privileges for a telegraf config.
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of telegraf config members</returns>
-        public Task<List<ResourceMember>> GetMembersAsync(Telegraf telegraf)
+        public Task<List<ResourceMember>> GetMembersAsync(Telegraf telegraf,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return GetMembersAsync(telegraf.Id);
+            return GetMembersAsync(telegraf.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all users with member privileges for a telegraf config.
         /// </summary>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of telegraf config members</returns>
-        public async Task<List<ResourceMember>> GetMembersAsync(string telegrafId)
+        public async Task<List<ResourceMember>> GetMembersAsync(string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDMembersAsync(telegrafId).ConfigureAwait(false);
+            var response = await _service.GetTelegrafsIDMembersAsync(telegrafId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -390,13 +429,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">user to add as member</param>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member added to telegraf</returns>
-        public Task<ResourceMember> AddMemberAsync(User member, Telegraf telegraf)
+        public Task<ResourceMember> AddMemberAsync(User member, Telegraf telegraf,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return AddMemberAsync(member.Id, telegraf.Id);
+            return AddMemberAsync(member.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -404,13 +445,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">user ID to add as member</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member added to telegraf</returns>
-        public Task<ResourceMember> AddMemberAsync(string memberId, string telegrafId)
+        public Task<ResourceMember> AddMemberAsync(string memberId, string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.PostTelegrafsIDMembersAsync(telegrafId, new AddResourceMemberRequestBody(memberId));
+            return _service.PostTelegrafsIDMembersAsync(telegrafId, new AddResourceMemberRequestBody(memberId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -418,13 +462,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="member">member to remove</param>
         /// <param name="telegraf">the telegraf</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(User member, Telegraf telegraf)
+        public Task DeleteMemberAsync(User member, Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(member, nameof(member));
 
-            return DeleteMemberAsync(member.Id, telegraf.Id);
+            return DeleteMemberAsync(member.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -432,37 +477,43 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="memberId">ID of member to remove</param>
         /// <param name="telegrafId">ID of the telegraf</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>member removed</returns>
-        public Task DeleteMemberAsync(string memberId, string telegrafId)
+        public Task DeleteMemberAsync(string memberId, string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(memberId, nameof(memberId));
 
-            return _service.DeleteTelegrafsIDMembersIDAsync(memberId, telegrafId);
+            return _service.DeleteTelegrafsIDMembersIDAsync(memberId, telegrafId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a telegraf config.
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of telegraf config owners</returns>
-        public Task<List<ResourceOwner>> GetOwnersAsync(Telegraf telegraf)
+        public Task<List<ResourceOwner>> GetOwnersAsync(Telegraf telegraf,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return GetOwnersAsync(telegraf.Id);
+            return GetOwnersAsync(telegraf.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all owners of a telegraf config.
         /// </summary>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of telegraf config owners</returns>
-        public async Task<List<ResourceOwner>> GetOwnersAsync(string telegrafId)
+        public async Task<List<ResourceOwner>> GetOwnersAsync(string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDOwnersAsync(telegrafId).ConfigureAwait(false);
+            var response = await _service.GetTelegrafsIDOwnersAsync(telegrafId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Users;
         }
 
@@ -471,13 +522,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">user to add as owner</param>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>telegraf config owner added</returns>
-        public Task<ResourceOwner> AddOwnerAsync(User owner, Telegraf telegraf)
+        public Task<ResourceOwner> AddOwnerAsync(User owner, Telegraf telegraf,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return AddOwnerAsync(owner.Id, telegraf.Id);
+            return AddOwnerAsync(owner.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -485,13 +538,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">ID of user to add as owner</param>
         /// <param name="telegrafId"> ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>telegraf config owner added</returns>
-        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string telegrafId)
+        public Task<ResourceOwner> AddOwnerAsync(string ownerId, string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.PostTelegrafsIDOwnersAsync(telegrafId, new AddResourceMemberRequestBody(ownerId));
+            return _service.PostTelegrafsIDOwnersAsync(telegrafId, new AddResourceMemberRequestBody(ownerId),
+                cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -499,13 +555,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="owner">owner to remove</param>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(User owner, Telegraf telegraf)
+        public Task DeleteOwnerAsync(User owner, Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(owner, nameof(owner));
 
-            return DeleteOwnerAsync(owner.Id, telegraf.Id);
+            return DeleteOwnerAsync(owner.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -513,37 +570,41 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="ownerId">ID of owner to remove</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>owner removed</returns>
-        public Task DeleteOwnerAsync(string ownerId, string telegrafId)
+        public Task DeleteOwnerAsync(string ownerId, string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(ownerId, nameof(ownerId));
 
-            return _service.DeleteTelegrafsIDOwnersIDAsync(ownerId, telegrafId);
+            return _service.DeleteTelegrafsIDOwnersIDAsync(ownerId, telegrafId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a telegraf config.
         /// </summary>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a telegraf config</returns>
-        public Task<List<Label>> GetLabelsAsync(Telegraf telegraf)
+        public Task<List<Label>> GetLabelsAsync(Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
 
-            return GetLabelsAsync(telegraf.Id);
+            return GetLabelsAsync(telegraf.Id, cancellationToken);
         }
 
         /// <summary>
         /// List all labels for a telegraf config.
         /// </summary>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>a list of all labels for a telegraf config</returns>
-        public async Task<List<Label>> GetLabelsAsync(string telegrafId)
+        public async Task<List<Label>> GetLabelsAsync(string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
 
-            var response = await _service.GetTelegrafsIDLabelsAsync(telegrafId).ConfigureAwait(false);
+            var response = await _service.GetTelegrafsIDLabelsAsync(telegrafId, cancellationToken: cancellationToken)
+                .ConfigureAwait(false);
             return response.Labels;
         }
 
@@ -552,13 +613,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to add</param>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public Task<Label> AddLabelAsync(Label label, Telegraf telegraf)
+        public Task<Label> AddLabelAsync(Label label, Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return AddLabelAsync(label.Id, telegraf.Id);
+            return AddLabelAsync(label.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -566,13 +628,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">ID of label to add</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>added label</returns>
-        public async Task<Label> AddLabelAsync(string labelId, string telegrafId)
+        public async Task<Label> AddLabelAsync(string labelId, string telegrafId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            var response = await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId))
+            var response = await _service.PostTelegrafsIDLabelsAsync(telegrafId, new LabelMapping(labelId),
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return response.Label;
         }
@@ -582,13 +647,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="label">label to delete</param>
         /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(Label label, Telegraf telegraf)
+        public Task DeleteLabelAsync(Label label, Telegraf telegraf, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(telegraf, nameof(telegraf));
             Arguments.CheckNotNull(label, nameof(label));
 
-            return DeleteLabelAsync(label.Id, telegraf.Id);
+            return DeleteLabelAsync(label.Id, telegraf.Id, cancellationToken);
         }
 
         /// <summary>
@@ -596,13 +662,14 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="labelId">ID of label to delete</param>
         /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>delete has been accepted</returns>
-        public Task DeleteLabelAsync(string labelId, string telegrafId)
+        public Task DeleteLabelAsync(string labelId, string telegrafId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(telegrafId, nameof(telegrafId));
             Arguments.CheckNonEmptyString(labelId, nameof(labelId));
 
-            return _service.DeleteTelegrafsIDLabelsIDAsync(telegrafId, labelId);
+            return _service.DeleteTelegrafsIDLabelsIDAsync(telegrafId, labelId, cancellationToken: cancellationToken);
         }
 
         private void AppendConfiguration(StringBuilder config, string key, object value)

--- a/Client/UsersApi.cs
+++ b/Client/UsersApi.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
@@ -23,38 +24,41 @@ namespace InfluxDB.Client
         /// Creates a new user and sets <see cref="User.Id" /> with the new identifier.
         /// </summary>
         /// <param name="name">name of the user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Created user</returns>
-        public Task<User> CreateUserAsync(string name)
+        public Task<User> CreateUserAsync(string name, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(name, nameof(name));
 
             var user = new User(name: name);
 
-            return CreateUserAsync(user);
+            return CreateUserAsync(user, cancellationToken);
         }
 
         /// <summary>
         /// Creates a new user and sets <see cref="User.Id" /> with the new identifier.
         /// </summary>
         /// <param name="user">name of the user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Created user</returns>
-        public Task<User> CreateUserAsync(User user)
+        public Task<User> CreateUserAsync(User user, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return _service.PostUsersAsync(ToPostUser(user));
+            return _service.PostUsersAsync(ToPostUser(user), cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Update an user.
         /// </summary>
         /// <param name="user">user update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>user updated</returns>
-        public Task<User> UpdateUserAsync(User user)
+        public Task<User> UpdateUserAsync(User user, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return _service.PatchUsersIDAsync(user.Id, ToPostUser(user));
+            return _service.PatchUsersIDAsync(user.Id, ToPostUser(user), cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -63,14 +67,16 @@ namespace InfluxDB.Client
         /// <param name="user">user to update password</param>
         /// <param name="oldPassword">old password</param>
         /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>user updated</returns>
-        public Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword)
+        public Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, nameof(user));
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            return UpdateUserPasswordAsync(user.Id, user.Name, oldPassword, newPassword);
+            return UpdateUserPasswordAsync(user.Id, user.Name, oldPassword, newPassword, cancellationToken);
         }
 
         /// <summary>
@@ -79,39 +85,43 @@ namespace InfluxDB.Client
         /// <param name="userId">ID of user to update password</param>
         /// <param name="oldPassword">old password</param>
         /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>user updated</returns>
-        public Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword)
+        public Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            return FindUserByIdAsync(userId)
-                .ContinueWith(t => UpdateUserPasswordAsync(t.Result, oldPassword, newPassword));
+            return FindUserByIdAsync(userId, cancellationToken)
+                .ContinueWith(t => UpdateUserPasswordAsync(t.Result, oldPassword, newPassword), cancellationToken);
         }
 
         /// <summary>
         /// Delete an user.
         /// </summary>
         /// <param name="userId">ID of user to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteUserAsync(string userId)
+        public Task DeleteUserAsync(string userId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
 
-            return _service.DeleteUsersIDAsync(userId);
+            return _service.DeleteUsersIDAsync(userId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
         /// Delete an user.
         /// </summary>
         /// <param name="user">user to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>async task</returns>
-        public Task DeleteUserAsync(User user)
+        public Task DeleteUserAsync(User user, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(user, nameof(user));
 
-            return DeleteUserAsync(user.Id);
+            return DeleteUserAsync(user.Id, cancellationToken);
         }
 
         /// <summary>
@@ -119,15 +129,17 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned user</param>
         /// <param name="userId">ID of user to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned user</returns>
-        public async Task<User> CloneUserAsync(string clonedName, string userId)
+        public async Task<User> CloneUserAsync(string clonedName, string userId,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNonEmptyString(userId, nameof(userId));
 
-            var user = await FindUserByIdAsync(userId).ConfigureAwait(false);
+            var user = await FindUserByIdAsync(userId, cancellationToken).ConfigureAwait(false);
 
-            return await CloneUserAsync(clonedName, user).ConfigureAwait(false);
+            return await CloneUserAsync(clonedName, user, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -135,24 +147,26 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="clonedName">name of cloned user</param>
         /// <param name="user">user to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>cloned user</returns>
-        public Task<User> CloneUserAsync(string clonedName, User user)
+        public Task<User> CloneUserAsync(string clonedName, User user, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(clonedName, nameof(clonedName));
             Arguments.CheckNotNull(user, nameof(user));
 
             var cloned = new User(name: clonedName);
 
-            return CreateUserAsync(cloned);
+            return CreateUserAsync(cloned, cancellationToken);
         }
 
         /// <summary>
         /// Returns currently authenticated user.
         /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>currently authenticated user</returns>
-        public Task<User> MeAsync()
+        public Task<User> MeAsync(CancellationToken cancellationToken = default)
         {
-            return _service.GetMeAsync();
+            return _service.GetMeAsync(cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -160,13 +174,15 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="oldPassword">old password</param>
         /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>currently authenticated user</returns>
-        public async Task MeUpdatePasswordAsync(string oldPassword, string newPassword)
+        public async Task MeUpdatePasswordAsync(string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(oldPassword, nameof(oldPassword));
             Arguments.CheckNotNull(newPassword, nameof(newPassword));
 
-            var me = await MeAsync().ConfigureAwait(false);
+            var me = await MeAsync(cancellationToken).ConfigureAwait(false);
             if (me == null)
             {
                 Trace.WriteLine("User is not authenticated.");
@@ -175,19 +191,21 @@ namespace InfluxDB.Client
 
             var header = InfluxDBClient.AuthorizationHeader(me.Name, oldPassword);
 
-            await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header).ConfigureAwait(false);
+            await _service.PutMePasswordAsync(new PasswordResetBody(newPassword), null, header, cancellationToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>
         /// Retrieve an user.
         /// </summary>
         /// <param name="userId">ID of user to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>User Details</returns>
-        public Task<User> FindUserByIdAsync(string userId)
+        public Task<User> FindUserByIdAsync(string userId, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNonEmptyString(userId, nameof(userId));
 
-            return _service.GetUsersIDAsync(userId);
+            return _service.GetUsersIDAsync(userId, cancellationToken: cancellationToken);
         }
 
         /// <summary>
@@ -198,17 +216,19 @@ namespace InfluxDB.Client
         /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
         /// <param name="name"> (optional)</param>
         /// <param name="id"> (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>List all users</returns>
         public async Task<List<User>> FindUsersAsync(int? offset = null, int? limit = null, string after = null,
-            string name = null, string id = null)
+            string name = null, string id = null, CancellationToken cancellationToken = default)
         {
-            var response = await _service.GetUsersAsync(offset: offset, limit: limit, after: after, name: name, id: id)
+            var response = await _service.GetUsersAsync(offset: offset, limit: limit, after: after, name: name, id: id,
+                    cancellationToken: cancellationToken)
                 .ConfigureAwait(false);
             return response._Users;
         }
 
         private Task UpdateUserPasswordAsync(string userId, string userName, string oldPassword,
-            string newPassword)
+            string newPassword, CancellationToken cancellationToken = default)
         {
             Arguments.CheckNotNull(userId, nameof(userId));
             Arguments.CheckNotNull(userName, nameof(userName));
@@ -217,7 +237,8 @@ namespace InfluxDB.Client
 
             var header = InfluxDBClient.AuthorizationHeader(userName, oldPassword);
 
-            return _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null, header);
+            return _service.PostUsersIDPasswordAsync(userId, new PasswordResetBody(newPassword), null, header,
+                cancellationToken);
         }
 
         private PostUser ToPostUser(User user)


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/issues/228#issuecomment-1043157838

## Proposed Changes

1. Removed useless `orgId` argument from `GetRunsAsync`
2. Async APIs uses `CancellationToken` in all `async` methods
3. Added Migration Notice in `CHANGELOG.md`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
