### PR TITLE
fix: change type of `PermissionResource.type` to `string` to avoid exception for non-existing item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,18 @@
 #### API
 
 - Removed `orgId` argument from `TelegrafsApi.GetRunsAsync` methods
+- Change type of `PermissionResource.Type` to `string`. You are able to easily migrate by:
+    ```diff
+    - new PermissionResource { Type = PermissionResource.TypeEnum.Users, OrgID = _organization.Id }
+    + new PermissionResource { Type = PermissionResource.TypeUsers, OrgID = _organization.Id }
+    ```
 
 ### Features
 1. [#291](https://github.com/influxdata/influxdb-client-csharp/pull/291): Add possibility to generate Flux query without `pivot()` function [LINQ]
 1. [#289](https://github.com/influxdata/influxdb-client-csharp/pull/289): Async APIs uses `CancellationToken` in all `async` methods
+
+### Bug Fixes
+1. [#290](https://github.com/influxdata/influxdb-client-csharp/pull/290): Change `PermissionResource.Type` to `String`
 
 ### CI
 1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage
@@ -211,7 +219,6 @@
 - Rename `TelegrafPlugin` types:
   - from `TelegrafPlugin.TypeEnum.Inputs` to `TelegrafPlugin.TypeEnum.Input`
   - from `TelegrafPlugin.TypeEnum.Outputs` to `TelegrafPlugin.TypeEnum.Output`
-- `TasksApi.FindTasksByOrganizationIdAsync(string orgId)` requires pass Organization `ID` as a parameter. For find Tasks by Organization name you can use: `_tasksApi.FindTasksAsync(org: "my-org")`.
 
 #### Services
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -219,6 +219,7 @@
 - Rename `TelegrafPlugin` types:
   - from `TelegrafPlugin.TypeEnum.Inputs` to `TelegrafPlugin.TypeEnum.Input`
   - from `TelegrafPlugin.TypeEnum.Outputs` to `TelegrafPlugin.TypeEnum.Output`
+- `TasksApi.FindTasksByOrganizationIdAsync(string orgId)` requires pass Organization `ID` as a parameter. For find Tasks by Organization name you can use: `_tasksApi.FindTasksAsync(org: "my-org")`.
 
 #### Services
 

--- a/Client.Test/ItAuthorizationsApiTest.cs
+++ b/Client.Test/ItAuthorizationsApiTest.cs
@@ -26,13 +26,13 @@ namespace InfluxDB.Client.Test
         {
             var readUsers = new Permission(
                 Permission.ActionEnum.Read,
-                new PermissionResource { Type = PermissionResource.TypeEnum.Users, OrgID = _organization.Id }
+                new PermissionResource { Type = PermissionResource.TypeUsers, OrgID = _organization.Id }
             );
 
             var writeOrganizations = new Permission
             (
                 Permission.ActionEnum.Write,
-                new PermissionResource { Type = PermissionResource.TypeEnum.Orgs, OrgID = _organization.Id }
+                new PermissionResource { Type = PermissionResource.TypeOrgs, OrgID = _organization.Id }
             );
 
             var permissions = new List<Permission> { readUsers, writeOrganizations };
@@ -47,11 +47,11 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(authorization.Status, AuthorizationUpdateRequest.StatusEnum.Active);
 
             Assert.AreEqual(authorization.Permissions.Count, 2);
-            Assert.AreEqual(authorization.Permissions[0].Resource.Type, PermissionResource.TypeEnum.Users);
+            Assert.AreEqual(authorization.Permissions[0].Resource.Type, PermissionResource.TypeUsers);
             Assert.AreEqual(authorization.Permissions[0].Resource.OrgID, _organization.Id);
             Assert.AreEqual(authorization.Permissions[0].Action, Permission.ActionEnum.Read);
 
-            Assert.AreEqual(authorization.Permissions[1].Resource.Type, PermissionResource.TypeEnum.Orgs);
+            Assert.AreEqual(authorization.Permissions[1].Resource.Type, PermissionResource.TypeOrgs);
             Assert.AreEqual(authorization.Permissions[1].Resource.OrgID, _organization.Id);
             Assert.AreEqual(authorization.Permissions[1].Action, Permission.ActionEnum.Write);
 
@@ -66,7 +66,7 @@ namespace InfluxDB.Client.Test
         public async Task AuthorizationDescription()
         {
             var writeSources = new Permission(Permission.ActionEnum.Write,
-                new PermissionResource { Type = PermissionResource.TypeEnum.Sources, OrgID = _organization.Id }
+                new PermissionResource { Type = PermissionResource.TypeSources, OrgID = _organization.Id }
             );
 
             var authorization = new AuthorizationPostRequest
@@ -86,7 +86,7 @@ namespace InfluxDB.Client.Test
         public async Task UpdateAuthorizationStatus()
         {
             var readUsers = new Permission(Permission.ActionEnum.Read,
-                new PermissionResource { Type = PermissionResource.TypeEnum.Users, OrgID = _organization.Id }
+                new PermissionResource { Type = PermissionResource.TypeUsers, OrgID = _organization.Id }
             );
 
             var permissions = new List<Permission> { readUsers };
@@ -200,7 +200,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(source.Description, cloned.Description);
             Assert.AreEqual(1, cloned.Permissions.Count);
             Assert.AreEqual(Permission.ActionEnum.Read, cloned.Permissions[0].Action);
-            Assert.AreEqual(PermissionResource.TypeEnum.Users, cloned.Permissions[0].Resource.Type);
+            Assert.AreEqual(PermissionResource.TypeUsers, cloned.Permissions[0].Resource.Type);
             Assert.AreEqual(_organization.Id, cloned.Permissions[0].Resource.OrgID);
         }
 
@@ -217,7 +217,7 @@ namespace InfluxDB.Client.Test
         private List<Permission> NewPermissions()
         {
             var resource = new PermissionResource
-                { Type = PermissionResource.TypeEnum.Users, OrgID = _organization.Id };
+                { Type = PermissionResource.TypeUsers, OrgID = _organization.Id };
 
             var permission = new Permission(Permission.ActionEnum.Read, resource);
 

--- a/Client.Test/ItDeleteApiTest.cs
+++ b/Client.Test/ItDeleteApiTest.cs
@@ -25,7 +25,7 @@ namespace InfluxDB.Client.Test
             // Add Permissions to read and write to the Bucket
             //
             var resource =
-                new PermissionResource(PermissionResource.TypeEnum.Buckets, _bucket.Id, null,
+                new PermissionResource(PermissionResource.TypeBuckets, _bucket.Id, null,
                     _organization.Id);
 
             var readBucket = new Permission(Permission.ActionEnum.Read, resource);

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -45,13 +45,13 @@ namespace InfluxDB.Client.Test
 
         private async Task<Authorization> AddAuthorization(Organization organization)
         {
-            var resourceTask = new PermissionResource(PermissionResource.TypeEnum.Tasks, null, null, organization.Id);
-            var resourceBucket = new PermissionResource(PermissionResource.TypeEnum.Buckets,
+            var resourceTask = new PermissionResource(PermissionResource.TypeTasks, null, null, organization.Id);
+            var resourceBucket = new PermissionResource(PermissionResource.TypeBuckets,
                 (await Client.GetBucketsApi().FindBucketByNameAsync("my-bucket")).Id, null, organization.Id);
-            var resourceOrg = new PermissionResource(PermissionResource.TypeEnum.Orgs);
-            var resourceUser = new PermissionResource(PermissionResource.TypeEnum.Users);
-            var resourceAuthorization = new PermissionResource(PermissionResource.TypeEnum.Authorizations);
-            var resourceLabels = new PermissionResource(PermissionResource.TypeEnum.Labels);
+            var resourceOrg = new PermissionResource(PermissionResource.TypeOrgs);
+            var resourceUser = new PermissionResource(PermissionResource.TypeUsers);
+            var resourceAuthorization = new PermissionResource(PermissionResource.TypeAuthorizations);
+            var resourceLabels = new PermissionResource(PermissionResource.TypeLabels);
 
 
             var authorization = await Client.GetAuthorizationsApi()

--- a/Client.Test/ItWriteApiAsyncTest.cs
+++ b/Client.Test/ItWriteApiAsyncTest.cs
@@ -28,7 +28,7 @@ namespace InfluxDB.Client.Test
             //
             // Add Permissions to read and write to the Bucket
             //
-            var resource = new PermissionResource(PermissionResource.TypeEnum.Buckets, _bucket.Id, null,
+            var resource = new PermissionResource(PermissionResource.TypeBuckets, _bucket.Id, null,
                 _organization.Id);
 
             var readBucket = new Permission(Permission.ActionEnum.Read, resource);

--- a/Client.Test/ItWriteApiRaceTest.cs
+++ b/Client.Test/ItWriteApiRaceTest.cs
@@ -24,7 +24,7 @@ namespace InfluxDB.Client.Test
             // Add Permissions to read and write to the Bucket
             //
             var resource =
-                new PermissionResource(PermissionResource.TypeEnum.Buckets, _bucket.Id, null, _organization.Id);
+                new PermissionResource(PermissionResource.TypeBuckets, _bucket.Id, null, _organization.Id);
 
             var readBucket = new Permission(Permission.ActionEnum.Read, resource);
             var writeBucket = new Permission(Permission.ActionEnum.Write, resource);

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -31,7 +31,7 @@ namespace InfluxDB.Client.Test
             // Add Permissions to read and write to the Bucket
             //
             var resource =
-                new PermissionResource(PermissionResource.TypeEnum.Buckets, _bucket.Id, null, _organization.Id);
+                new PermissionResource(PermissionResource.TypeBuckets, _bucket.Id, null, _organization.Id);
 
             var readBucket = new Permission(Permission.ActionEnum.Read, resource);
             var writeBucket = new Permission(Permission.ActionEnum.Write, resource);

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -30,141 +30,6 @@ namespace InfluxDB.Client.Api.Domain
     public partial class PermissionResource : IEquatable<PermissionResource>
     {
         /// <summary>
-        /// Defines Type
-        /// </summary>
-        [JsonConverter(typeof(StringEnumConverter))]
-        public enum TypeEnum
-        {
-            /// <summary>
-            /// Enum Authorizations for value: authorizations
-            /// </summary>
-            [EnumMember(Value = "authorizations")] Authorizations = 1,
-
-            /// <summary>
-            /// Enum Buckets for value: buckets
-            /// </summary>
-            [EnumMember(Value = "buckets")] Buckets = 2,
-
-            /// <summary>
-            /// Enum Dashboards for value: dashboards
-            /// </summary>
-            [EnumMember(Value = "dashboards")] Dashboards = 3,
-
-            /// <summary>
-            /// Enum Orgs for value: orgs
-            /// </summary>
-            [EnumMember(Value = "orgs")] Orgs = 4,
-
-            /// <summary>
-            /// Enum Sources for value: sources
-            /// </summary>
-            [EnumMember(Value = "sources")] Sources = 5,
-
-            /// <summary>
-            /// Enum Tasks for value: tasks
-            /// </summary>
-            [EnumMember(Value = "tasks")] Tasks = 6,
-
-            /// <summary>
-            /// Enum Telegrafs for value: telegrafs
-            /// </summary>
-            [EnumMember(Value = "telegrafs")] Telegrafs = 7,
-
-            /// <summary>
-            /// Enum Users for value: users
-            /// </summary>
-            [EnumMember(Value = "users")] Users = 8,
-
-            /// <summary>
-            /// Enum Variables for value: variables
-            /// </summary>
-            [EnumMember(Value = "variables")] Variables = 9,
-
-            /// <summary>
-            /// Enum Scrapers for value: scrapers
-            /// </summary>
-            [EnumMember(Value = "scrapers")] Scrapers = 10,
-
-            /// <summary>
-            /// Enum Secrets for value: secrets
-            /// </summary>
-            [EnumMember(Value = "secrets")] Secrets = 11,
-
-            /// <summary>
-            /// Enum Labels for value: labels
-            /// </summary>
-            [EnumMember(Value = "labels")] Labels = 12,
-
-            /// <summary>
-            /// Enum Views for value: views
-            /// </summary>
-            [EnumMember(Value = "views")] Views = 13,
-
-            /// <summary>
-            /// Enum Documents for value: documents
-            /// </summary>
-            [EnumMember(Value = "documents")] Documents = 14,
-
-            /// <summary>
-            /// Enum NotificationRules for value: notificationRules
-            /// </summary>
-            [EnumMember(Value = "notificationRules")]
-            NotificationRules = 15,
-
-            /// <summary>
-            /// Enum NotificationEndpoints for value: notificationEndpoints
-            /// </summary>
-            [EnumMember(Value = "notificationEndpoints")]
-            NotificationEndpoints = 16,
-
-            /// <summary>
-            /// Enum Checks for value: checks
-            /// </summary>
-            [EnumMember(Value = "checks")] Checks = 17,
-
-            /// <summary>
-            /// Enum Dbrp for value: dbrp
-            /// </summary>
-            [EnumMember(Value = "dbrp")] Dbrp = 18,
-
-            /// <summary>
-            /// Enum Notebooks for value: notebooks
-            /// </summary>
-            [EnumMember(Value = "notebooks")] Notebooks = 19,
-
-            /// <summary>
-            /// Enum Annotations for value: annotations
-            /// </summary>
-            [EnumMember(Value = "annotations")] Annotations = 20,
-
-            /// <summary>
-            /// Enum Remotes for value: remotes
-            /// </summary>
-            [EnumMember(Value = "remotes")] Remotes = 21,
-
-            /// <summary>
-            /// Enum Replications for value: replications
-            /// </summary>
-            [EnumMember(Value = "replications")] Replications = 22,
-
-            /// <summary>
-            /// Enum Flows for value: flows
-            /// </summary>
-            [EnumMember(Value = "flows")] Flows = 23,
-
-            /// <summary>
-            /// Enum Functions for value: functions
-            /// </summary>
-            [EnumMember(Value = "functions")] Functions = 24
-        }
-
-        /// <summary>
-        /// Gets or Sets Type
-        /// </summary>
-        [DataMember(Name = "type", EmitDefaultValue = false)]
-        public TypeEnum Type { get; set; }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="PermissionResource" /> class.
         /// </summary>
         [JsonConstructorAttribute]
@@ -180,10 +45,15 @@ namespace InfluxDB.Client.Api.Domain
         /// <param name="name">Optional name of the resource if the resource has a name field..</param>
         /// <param name="orgID">If orgID is set that is a permission for all resources owned my that org. if it is not set it is a permission for all resources of that resource type..</param>
         /// <param name="org">Optional name of the organization of the organization with orgID..</param>
-        public PermissionResource(TypeEnum type = default, string id = default, string name = default,
+        public PermissionResource(string type = default, string id = default, string name = default,
             string orgID = default, string org = default)
         {
             // to ensure "type" is required (not null)
+            if (type == null)
+            {
+                throw new InvalidDataException("type is a required property for PermissionResource and cannot be null");
+            }
+
             Type = type;
             Id = id;
             Name = name;
@@ -191,6 +61,37 @@ namespace InfluxDB.Client.Api.Domain
             Org = org;
         }
 
+        // Possible values for Type property:
+        public const string TypeAuthorizations = "authorizations";
+        public const string TypeBuckets = "buckets";
+        public const string TypeDashboards = "dashboards";
+        public const string TypeOrgs = "orgs";
+        public const string TypeSources = "sources";
+        public const string TypeTasks = "tasks";
+        public const string TypeTelegrafs = "telegrafs";
+        public const string TypeUsers = "users";
+        public const string TypeVariables = "variables";
+        public const string TypeScrapers = "scrapers";
+        public const string TypeSecrets = "secrets";
+        public const string TypeLabels = "labels";
+        public const string TypeViews = "views";
+        public const string TypeDocuments = "documents";
+        public const string TypeNotificationRules = "notificationRules";
+        public const string TypeNotificationEndpoints = "notificationEndpoints";
+        public const string TypeChecks = "checks";
+        public const string TypeDbrp = "dbrp";
+        public const string TypeNotebooks = "notebooks";
+        public const string TypeAnnotations = "annotations";
+        public const string TypeRemotes = "remotes";
+        public const string TypeReplications = "replications";
+        public const string TypeFlows = "flows";
+        public const string TypeFunctions = "functions";
+
+        /// <summary>
+        /// Gets or Sets Type
+        /// </summary>
+        [DataMember(Name = "type", EmitDefaultValue = false)]
+        public string Type { get; set; }
 
         /// <summary>
         /// If ID is set that is a permission for a specific resource. if it is not set it is a permission for all resources of that resource type.
@@ -271,7 +172,7 @@ namespace InfluxDB.Client.Api.Domain
             return
                 (
                     Type == input.Type ||
-                    Type.Equals(input.Type)
+                    Type != null && Type.Equals(input.Type)
                 ) &&
                 (
                     Id == input.Id ||
@@ -301,7 +202,11 @@ namespace InfluxDB.Client.Api.Domain
             {
                 var hashCode = 41;
 
-                hashCode = hashCode * 59 + Type.GetHashCode();
+                if (Type != null)
+                {
+                    hashCode = hashCode * 59 + Type.GetHashCode();
+                }
+
                 if (Id != null)
                 {
                     hashCode = hashCode * 59 + Id.GetHashCode();

--- a/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
+++ b/Client/InfluxDB.Client.Api/Domain/PermissionResource.cs
@@ -48,12 +48,6 @@ namespace InfluxDB.Client.Api.Domain
         public PermissionResource(string type = default, string id = default, string name = default,
             string orgID = default, string org = default)
         {
-            // to ensure "type" is required (not null)
-            if (type == null)
-            {
-                throw new InvalidDataException("type is a required property for PermissionResource and cannot be null");
-            }
-
             Type = type;
             Id = id;
             Name = name;

--- a/Client/README.md
+++ b/Client/README.md
@@ -815,7 +815,7 @@ namespace Examples
             //
             // Create access token to "iot_bucket"
             //
-            var resource = new PermissionResource(PermissionResource.TypeEnum.Buckets, bucket.Id, null,
+            var resource = new PermissionResource(PermissionResource.TypeBuckets, bucket.Id, null,
                 orgId);
 
             // Read permission

--- a/Examples/ManagementExample.cs
+++ b/Examples/ManagementExample.cs
@@ -30,7 +30,7 @@ namespace Examples
             //
             // Create access token to "iot_bucket"
             //
-            var resource = new PermissionResource(PermissionResource.TypeEnum.Buckets, bucket.Id, null,
+            var resource = new PermissionResource(PermissionResource.TypeBuckets, bucket.Id, null,
                 orgId);
 
             // Read permission

--- a/Examples/PlatformExample.cs
+++ b/Examples/PlatformExample.cs
@@ -50,7 +50,7 @@ namespace Examples
             // Add Permissions to read and write to the Bucket
             //
             var resource = new PermissionResource
-                { Type = PermissionResource.TypeEnum.Buckets, OrgID = medicalGMBH.Id, Id = temperatureBucket.Id };
+                { Type = PermissionResource.TypeBuckets, OrgID = medicalGMBH.Id, Id = temperatureBucket.Id };
 
             var readBucket = new Permission(Permission.ActionEnum.Read, resource);
             var writeBucket = new Permission(Permission.ActionEnum.Write, resource);


### PR DESCRIPTION
## Proposed Changes

The `PermissionResource.Type` is not constant value and can evolve as the API of InfluxDB changing. 

=>

Change type of `PermissionResource.Type` to `string`. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
