### PR TITLE
feat(linq): add possibility to generate Flux query without `pivot()` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.0.0-rc2 [unreleased]
 
+### Features
+1. [#291](https://github.com/influxdata/influxdb-client-csharp/pull/291): Add possibility to generate Flux query without `pivot()` function [LINQ]
+
 ### CI
 1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage
 

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1056,7 +1056,7 @@ namespace Client.Linq.Test
                     "from(bucket: p1) " +
                     "|> range(start: time(v: start_shifted)) " +
                     "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])"
-                ),
+                )
             };
 
             foreach (var (alignFieldsWithPivot, expected) in queries)

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1041,6 +1041,35 @@ namespace Client.Linq.Test
                 nse?.Message);
         }
 
+        [Test]
+        public void AlignFieldsWithPivot()
+        {
+            var queries = new[]
+            {
+                (
+                    true,
+                    FluxStart
+                ),
+                (
+                    false,
+                    "start_shifted = int(v: time(v: p2))\n\n" +
+                    "from(bucket: p1) " +
+                    "|> range(start: time(v: start_shifted)) " +
+                    "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])"
+                ),
+            };
+
+            foreach (var (alignFieldsWithPivot, expected) in queries)
+            {
+                var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi,
+                        new QueryableOptimizerSettings { AlignFieldsWithPivot = alignFieldsWithPivot })
+                    select s;
+                var visitor = BuildQueryVisitor(query);
+
+                Assert.AreEqual(expected, visitor.BuildFluxQuery());
+            }
+        }
+
         private InfluxDBQueryVisitor BuildQueryVisitor(IQueryable queryable, Expression expression = null)
         {
             var queryExecutor = (InfluxDBQueryExecutor)((DefaultQueryProvider)queryable.Provider).Executor;

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -18,6 +18,7 @@ namespace InfluxDB.Client.Linq
         public QueryableOptimizerSettings()
         {
             QueryMultipleTimeSeries = false;
+            AlignFieldsWithPivot = true;
             DropMeasurementColumn = true;
             DropStartColumn = true;
             DropStopColumn = true;
@@ -32,6 +33,12 @@ namespace InfluxDB.Client.Linq
         /// </list>
         /// </summary>
         public bool QueryMultipleTimeSeries { get; set; }
+
+        /// <summary>
+        /// Gets or set whether the drive should use a Flux <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/pivot/">pivot()</a> function
+        /// to align fields to tabular way.
+        /// </summary>
+        public bool AlignFieldsWithPivot { get; set; }
 
         /// <summary>
         /// Gets or sets whether the _measurement column will be dropped from query results.

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -164,7 +164,9 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildRange(transforms),
                 BuildFilter(_filterByTags),
                 BuildAggregateWindow(_aggregateWindow),
-                "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
+                settings.AlignFieldsWithPivot
+                    ? "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
+                    : ""
             };
 
             var drop = BuildDrop(settings);

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -263,6 +263,19 @@ The LINQ provider needs to aligns fields within each input table that have the s
 For that reason we need to use the [pivot()](https://docs.influxdata.com/influxdb/cloud/reference/flux/stdlib/built-in/transformations/pivot/) function.
 The `pivot` is heavy and should be used at the end of our Flux query.
 
+There is an also possibility to disable appending `pivot` by:
+
+```c#
+var optimizerSettings =
+    new QueryableOptimizerSettings
+    {
+        AlignFieldsWithPivot = false
+    };
+    
+var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi, optimizerSettings)
+    select s;
+```
+
 ### Mapping LINQ filters
 
 For the best performance on the both side - `server`, `LINQ provider` we maps the LINQ expressions to FLUX query following way:


### PR DESCRIPTION
Closes #279

## Proposed Changes

Add possibility to generate Flux query without `pivot()` function (`LINQ`).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
