### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,9 +99,17 @@ jobs:
             and:
               - equal: [ true, << parameters.code-coverage-report >> ]
           steps:
-            - run:
-                name: "Collecting coverage reports"
-                command: bash <(curl -s https://codecov.io/bash) || echo "Codecov did not collect coverage reports"
+              - run:
+                  name: Collecting coverage reports
+                  command: |
+                      curl -Os https://uploader.codecov.io/latest/linux/codecov
+                      curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+                      curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+                      curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+                      gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+                      shasum -a 256 -c codecov.SHA256SUM
+                      chmod +x ./codecov
+                      ./codecov
 
   tests-windows:
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,11 @@ jobs:
               - equal: [ true, << parameters.code-coverage-report >> ]
           steps:
               - run:
+                  name: Install GPG
+                  command: |
+                      apt-get update
+                      apt-get install gpg -y
+              - run:
                   name: Collecting coverage reports
                   command: |
                       curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.0.0-rc2 [unreleased]
 
+### CI
+1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage
+
 ## 4.0.0-rc1 [2022-02-18]
 
 ### Breaking Changes


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
