### PR TITLE
fix: type of `CheckBase.LatestCompleted` is `DateTime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Bug Fixes
 1. [#290](https://github.com/influxdata/influxdb-client-csharp/pull/290): Change `PermissionResource.Type` to `String`
+1. [#293](https://github.com/influxdata/influxdb-client-csharp/pull/293): Type of `CheckBase.LatestCompleted` is `DateTime`
 
 ### CI
 1. [#292](https://github.com/influxdata/influxdb-client-csharp/pull/292): Use new Codecov uploader for reporting code coverage

--- a/Client/InfluxDB.Client.Api/Domain/CheckBase.cs
+++ b/Client/InfluxDB.Client.Api/Domain/CheckBase.cs
@@ -178,7 +178,7 @@ namespace InfluxDB.Client.Api.Domain
         /// </summary>
         /// <value>Timestamp (in RFC3339 date/time format](https://datatracker.ietf.org/doc/html/rfc3339)) of the latest scheduled and completed run.</value>
         [DataMember(Name = "latestCompleted", EmitDefaultValue = false)]
-        public object LatestCompleted { get; private set; }
+        public DateTime? LatestCompleted { get; private set; }
 
 
         /// <summary>


### PR DESCRIPTION
Related to https://github.com/influxdata/openapi/pull/268

## Proposed Changes

Changed type of `CheckBase.LatestCompleted` to `DateTime`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
