### PR TITLE
feat: optimize serialization `PointData` into LineProtocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 ### Features
 1. [#291](https://github.com/influxdata/influxdb-client-csharp/pull/291): Add possibility to generate Flux query without `pivot()` function [LINQ]
 1. [#289](https://github.com/influxdata/influxdb-client-csharp/pull/289): Async APIs uses `CancellationToken` in all `async` methods
+1. [#294](https://github.com/influxdata/influxdb-client-csharp/pull/294): Optimize serialization `PointData` into LineProtocol
 
 ### Bug Fixes
 1. [#290](https://github.com/influxdata/influxdb-client-csharp/pull/290): Change `PermissionResource.Type` to `String`

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using NodaTime.Text;
@@ -417,6 +420,29 @@ namespace InfluxDB.Client.Test
                 .Field("flout-nan", float.NaN);
 
             Assert.AreEqual("", point.ToLineProtocol());
+        }
+
+        [Test]
+        public void ToLineProtocolPerformance()
+        {
+            var points = new List<PointData>();
+            for (var i = 0; i < 1000000; i++)
+            {
+                points.Add(PointData.Measurement("h2o")
+                    .Tag("location", "europe")
+                    .Field("level", 2));
+            }
+            
+            var pointSettings = new PointSettings();
+            var stopwatch = new Stopwatch();
+            stopwatch.Start();
+            foreach (var point in points)
+            {
+                point.ToLineProtocol(pointSettings);
+            }
+            stopwatch.Stop();
+            
+            Console.WriteLine($"Elapsed milliseconds: {stopwatch.Elapsed.TotalMilliseconds}");
         }
     }
 }

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -1,7 +1,4 @@
 using System;
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 using NodaTime.Text;
@@ -420,29 +417,6 @@ namespace InfluxDB.Client.Test
                 .Field("flout-nan", float.NaN);
 
             Assert.AreEqual("", point.ToLineProtocol());
-        }
-
-        [Test]
-        public void ToLineProtocolPerformance()
-        {
-            var points = new List<PointData>();
-            for (var i = 0; i < 1000000; i++)
-            {
-                points.Add(PointData.Measurement("h2o")
-                    .Tag("location", "europe")
-                    .Field("level", 2));
-            }
-            
-            var pointSettings = new PointSettings();
-            var stopwatch = new Stopwatch();
-            stopwatch.Start();
-            foreach (var point in points)
-            {
-                point.ToLineProtocol(pointSettings);
-            }
-            stopwatch.Stop();
-            
-            Console.WriteLine($"Elapsed milliseconds: {stopwatch.Elapsed.TotalMilliseconds}");
         }
     }
 }

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -393,8 +393,7 @@ namespace InfluxDB.Client.Writes
             }
             else
             {
-                IReadOnlyDictionary<string, string> defaultTags =
-                    pointSettings.GetDefaultTags();
+                var defaultTags = pointSettings.GetDefaultTags();
                 try
                 {
                     entries = _tags.AddRange(defaultTags);

--- a/Client/Writes/PointSettings.cs
+++ b/Client/Writes/PointSettings.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Configuration;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -44,8 +45,13 @@ namespace InfluxDB.Client.Writes
         /// Get default tags with evaluated expressions.
         /// </summary>
         /// <returns>evaluated default tags</returns>
-        internal Dictionary<string, string> GetDefaultTags()
+        internal IDictionary<string, string> GetDefaultTags()
         {
+            if (_defaultTags.Count == 0)
+            {
+                return ImmutableDictionary<string, string>.Empty;
+            }
+            
             string Evaluation(string expression)
             {
                 if (string.IsNullOrEmpty(expression))

--- a/Client/Writes/PointSettings.cs
+++ b/Client/Writes/PointSettings.cs
@@ -51,7 +51,7 @@ namespace InfluxDB.Client.Writes
             {
                 return ImmutableDictionary<string, string>.Empty;
             }
-            
+
             string Evaluation(string expression)
             {
                 if (string.IsNullOrEmpty(expression))


### PR DESCRIPTION
## Proposed Changes

Optimized serialization `PointData` into LineProtocol.


```c#
[Test]
public void ToLineProtocolPerformance()
{
    var points = new List<PointData>();
    for (var i = 0; i < 1000000; i++)
    {
        points.Add(PointData.Measurement("h2o")
            .Tag("location", "europe")
            .Field("level", 2));
    }
    
    var pointSettings = new PointSettings();
    var stopwatch = new Stopwatch();
    stopwatch.Start();
    foreach (var point in points)
    {
        point.ToLineProtocol(pointSettings);
    }
    stopwatch.Stop();
    
    Console.WriteLine($"Elapsed milliseconds: {stopwatch.Elapsed.TotalMilliseconds}");
}
```

![image](https://user-images.githubusercontent.com/455137/155287110-0c1084a8-7268-4812-8475-b8622d06a2d1.png)

vs

![image](https://user-images.githubusercontent.com/455137/155287147-4027f420-c9b6-439b-9894-ec67ff0d2e7a.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
