### PR TITLE
feat: add possibility to put generic type object as a value for `PointData` and `PointData.Builder`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.0.0-rc3 [unreleased]
 
+### Features
+1. [#295](https://github.com/influxdata/influxdb-client-csharp/pull/295): Add possibility to put generic type object as a value for `PointData` and `PointData.Builder`
+
 ## 4.0.0-rc2 [2022-02-25]
 
 ### Migration Notice

--- a/Client.Test/PointDataBuilderTest.cs
+++ b/Client.Test/PointDataBuilderTest.cs
@@ -163,5 +163,15 @@ namespace InfluxDB.Client.Test
             Assert.IsTrue(
                 PointData.Builder.Measurement("h2o").Tag("location", "europe").Field("level", "2").HasFields());
         }
+        
+        [Test]
+        public void UseGenericObjectAsFieldValue()
+        {
+            var point = PointData.Builder.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("custom-object", new GenericObject{Value1 = "test", Value2 = 10});
+
+            Assert.AreEqual("h2o,location=europe custom-object=\"test-10\"", point.ToPointData().ToLineProtocol());
+        }
     }
 }

--- a/Client.Test/PointDataBuilderTest.cs
+++ b/Client.Test/PointDataBuilderTest.cs
@@ -163,13 +163,13 @@ namespace InfluxDB.Client.Test
             Assert.IsTrue(
                 PointData.Builder.Measurement("h2o").Tag("location", "europe").Field("level", "2").HasFields());
         }
-        
+
         [Test]
         public void UseGenericObjectAsFieldValue()
         {
             var point = PointData.Builder.Measurement("h2o")
                 .Tag("location", "europe")
-                .Field("custom-object", new GenericObject{Value1 = "test", Value2 = 10});
+                .Field("custom-object", new GenericObject { Value1 = "test", Value2 = 10 });
 
             Assert.AreEqual("h2o,location=europe custom-object=\"test-10\"", point.ToPointData().ToLineProtocol());
         }

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -418,5 +418,26 @@ namespace InfluxDB.Client.Test
 
             Assert.AreEqual("", point.ToLineProtocol());
         }
+
+        [Test]
+        public void UseGenericObjectAsFieldValue()
+        {
+            var point = PointData.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("custom-object", new GenericObject{Value1 = "test", Value2 = 10});
+
+            Assert.AreEqual("h2o,location=europe custom-object=\"test-10\"", point.ToLineProtocol());
+        }
+    }
+
+    internal class GenericObject
+    {
+        internal string Value1 { get; set; }
+        internal int Value2 { get; set; }
+
+        public override string ToString()
+        {
+            return $"{Value1}-{Value2}";
+        }
     }
 }

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -424,7 +424,7 @@ namespace InfluxDB.Client.Test
         {
             var point = PointData.Measurement("h2o")
                 .Tag("location", "europe")
-                .Field("custom-object", new GenericObject{Value1 = "test", Value2 = 10});
+                .Field("custom-object", new GenericObject { Value1 = "test", Value2 = 10 });
 
             Assert.AreEqual("h2o,location=europe custom-object=\"test-10\"", point.ToLineProtocol());
         }

--- a/Client/Writes/PointData.Builder.cs
+++ b/Client/Writes/PointData.Builder.cs
@@ -166,7 +166,7 @@ namespace InfluxDB.Client.Writes
             {
                 return PutField(name, value);
             }
-            
+
             /// <summary>
             /// Add a field with an <see cref="object"/> value.
             /// </summary>

--- a/Client/Writes/PointData.Builder.cs
+++ b/Client/Writes/PointData.Builder.cs
@@ -166,6 +166,17 @@ namespace InfluxDB.Client.Writes
             {
                 return PutField(name, value);
             }
+            
+            /// <summary>
+            /// Add a field with an <see cref="object"/> value.
+            /// </summary>
+            /// <param name="name">the field name</param>
+            /// <param name="value">the field value</param>
+            /// <returns>this</returns>
+            public Builder Field(string name, object value)
+            {
+                return PutField(name, value);
+            }
 
             /// <summary>
             /// Updates the timestamp for the point.

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -201,6 +201,17 @@ namespace InfluxDB.Client.Writes
         {
             return PutField(name, value);
         }
+        
+        /// <summary>
+        /// Add a field with an <see cref="object"/> value.
+        /// </summary>
+        /// <param name="name">the field name</param>
+        /// <param name="value">the field value</param>
+        /// <returns>this</returns>
+        public PointData Field(string name, object value)
+        {
+            return PutField(name, value);
+        }
 
         /// <summary>
         /// Updates the timestamp for the point.
@@ -489,7 +500,9 @@ namespace InfluxDB.Client.Writes
                 }
                 else
                 {
-                    sb.Append(value);
+                    sb.Append('"');
+                    EscapeValue(sb, value.ToString());
+                    sb.Append('"');
                 }
 
                 sb.Append(',');

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -201,7 +201,7 @@ namespace InfluxDB.Client.Writes
         {
             return PutField(name, value);
         }
-        
+
         /// <summary>
         /// Add a field with an <see cref="object"/> value.
         /// </summary>


### PR DESCRIPTION
Closes #276

## Proposed Changes

Added possibility to put generic type object as a field in `PointData` and `PointData.Builder`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
