### PR TITLE
fix: get version from `X-Influxdb-Version` header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.0.0 [unreleased]
 
+### Bug Fixes
+1. [#297](https://github.com/influxdata/influxdb-client-csharp/pull/297): Get version from `X-Influxdb-Version` header
+
 ## 4.0.0-rc3 [2022-03-04]
 
 ### Features

--- a/Client.Core/Internal/AbstractRestClient.cs
+++ b/Client.Core/Internal/AbstractRestClient.cs
@@ -49,7 +49,7 @@ namespace InfluxDB.Client.Core.Internal
             Arguments.CheckNotNull(responseHttp, "responseHttp");
 
             var value = responseHttp.Headers
-                .Where(header => header.Name.Equals("X-Influxdb-Version"))
+                .Where(header => header.Name.Equals("X-Influxdb-Version", StringComparison.OrdinalIgnoreCase))
                 .Select(header => header.Value.ToString())
                 .FirstOrDefault();
 

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -319,5 +319,15 @@ namespace InfluxDB.Client.Test
 
             Assert.AreEqual(true, disposed);
         }
+        
+        [Test]
+        public async Task VersionIsNotCaseSensitive()
+        {
+            MockServer.Given(Request.Create().WithPath("/ping").UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(204)
+                    .WithHeader("x-influxdb-version", "2.0.0"));
+
+            Assert.AreEqual("2.0.0", await _client.VersionAsync());
+        }
     }
 }

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -319,7 +319,7 @@ namespace InfluxDB.Client.Test
 
             Assert.AreEqual(true, disposed);
         }
-        
+
         [Test]
         public async Task VersionIsNotCaseSensitive()
         {

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -443,7 +443,7 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
-        /// The readiness of the InfluxDB 2.0.
+        /// Check the readiness of InfluxDB Server at startup. Is is not supported by InfluxDB Cloud. 
         /// </summary>
         /// <returns>return null if the InfluxDB is not ready</returns>
         public async Task<Ready> ReadyAsync()

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -443,7 +443,7 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
-        /// Check the readiness of InfluxDB Server at startup. Is is not supported by InfluxDB Cloud. 
+        /// Check the readiness of InfluxDB Server at startup. It is not supported by InfluxDB Cloud. 
         /// </summary>
         /// <returns>return null if the InfluxDB is not ready</returns>
         public async Task<Ready> ReadyAsync()


### PR DESCRIPTION
Closes #296

## Proposed Changes

Fixed getting version from `X-Influxdb-Version` header.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
