### PR TITLE
fix: Fix authorization by username/password.

### DIFF
--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -22,6 +22,7 @@ namespace InfluxDB.Client.Api.Client
         internal readonly RestClientOptions RestClientOptions;
 
         private bool _initializedSessionTokens = false;
+        private char[] _sessionToken;
         private bool _signout;
 
         public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler)
@@ -83,6 +84,11 @@ namespace InfluxDB.Client.Api.Client
             else if (InfluxDBClientOptions.AuthenticationScheme.Session.Equals(_options.AuthScheme))
             {
                 InitToken();
+
+                if (_sessionToken != null)
+                {
+                    request.AddHeader("Cookie", "session=" + new string(_sessionToken));
+                }
             }
 
             _loggingHandler.BeforeIntercept(request);
@@ -126,6 +132,14 @@ namespace InfluxDB.Client.Api.Client
                 if (authResponse.Cookies != null)
                 {
                     _initializedSessionTokens = true;
+                    
+                    if (authResponse.Cookies.Count == 1)
+                    {
+                        if (authResponse.Cookies[0].Name.ToString().Equals("session"))
+                        {
+                            _sessionToken = authResponse.Cookies[0].Value.ToCharArray();
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
I used to use InfluxDB.Client v1.18.0 and I successfully authorized my requests to influxdb using username/password, without using token.
After I upgraded to InfluxDB.Client v4.0.0 I started getting 'unauthorized access' 401 error on trying to execute any request while still using username/password.

I looked into your 4.0.0 code and it looks like authorization with username/password is broken - auth request is executed, but received sessionToken isn't going anywhere, like it used to in 1.18.0.
I propose bringing back the code that stores sessionToken and uses it to authorize requests when client is authorized using username/password (Session scheme), without token.

Closes #

## Proposed Changes

Bring back the code that stores sessionToken and uses it to authorize requests when client is authorized using username/password (Session scheme), without token
