### PR TITLE
fix: Authentication Cookies follow redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 4.1.0 [unreleased]
 
 ### Features
-1. [#101](https://github.com/influxdata/influxdb-client-csharp/pull/304): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+1. [#304](https://github.com/influxdata/influxdb-client-csharp/pull/304): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+
+### Bug Fixes
+1. [#305](https://github.com/influxdata/influxdb-client-csharp/pull/305): Authentication Cookies follow redirects
 
 ## 4.0.0 [2022-03-18]
 

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -293,17 +293,17 @@ namespace InfluxDB.Client.Test
                 .Authenticate("my-username", "my-password".ToCharArray())
                 .AllowRedirects(true)
                 .Build());
-            
+
             var anotherServer = WireMockServer.Start(new WireMockServerSettings
             {
                 UseSSL = false
             });
-            
+
             // auth cookies
             MockServer
                 .Given(Request.Create().UsingPost())
                 .RespondWith(Response.Create().WithHeader("Set-Cookie", "session=xyz"));
-            
+
             // redirect to another server
             MockServer
                 .Given(Request.Create().UsingGet())
@@ -317,7 +317,7 @@ namespace InfluxDB.Client.Test
             var authorization = await _client.GetAuthorizationsApi().FindAuthorizationByIdAsync("id");
             Assert.AreEqual(AuthorizationUpdateRequest.StatusEnum.Active, authorization.Status);
 
-            StringAssert.StartsWith("xyz", MockServer.LogEntries.Last().RequestMessage.Cookies["session"]);
+            Assert.AreEqual("xyz", MockServer.LogEntries.Last().RequestMessage.Cookies["session"]);
             Assert.AreEqual("xyz", anotherServer.LogEntries.Last().RequestMessage.Cookies["session"]);
 
             anotherServer.Stop();

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -279,6 +280,45 @@ namespace InfluxDB.Client.Test
             StringAssert.StartsWith("Token my-token",
                 MockServer.LogEntries.Last().RequestMessage.Headers["Authorization"].First());
             Assert.False(anotherServer.LogEntries.Last().RequestMessage.Headers.ContainsKey("Authorization"));
+
+            anotherServer.Stop();
+        }
+
+        [Test]
+        public async Task RedirectCookie()
+        {
+            _client.Dispose();
+            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
+                .Url(MockServerUrl)
+                .Authenticate("my-username", "my-password".ToCharArray())
+                .AllowRedirects(true)
+                .Build());
+            
+            var anotherServer = WireMockServer.Start(new WireMockServerSettings
+            {
+                UseSSL = false
+            });
+            
+            // auth cookies
+            MockServer
+                .Given(Request.Create().UsingPost())
+                .RespondWith(Response.Create().WithHeader("Set-Cookie", "session=xyz"));
+            
+            // redirect to another server
+            MockServer
+                .Given(Request.Create().UsingGet())
+                .RespondWith(Response.Create().WithStatusCode(301).WithHeader("location", anotherServer.Urls[0]));
+
+            // success response
+            anotherServer
+                .Given(Request.Create().UsingGet())
+                .RespondWith(CreateResponse("{\"status\":\"active\"}", "application/json"));
+
+            var authorization = await _client.GetAuthorizationsApi().FindAuthorizationByIdAsync("id");
+            Assert.AreEqual(AuthorizationUpdateRequest.StatusEnum.Active, authorization.Status);
+
+            StringAssert.StartsWith("xyz", MockServer.LogEntries.Last().RequestMessage.Cookies["session"]);
+            Assert.AreEqual("xyz", anotherServer.LogEntries.Last().RequestMessage.Cookies["session"]);
 
             anotherServer.Stop();
         }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -133,8 +133,9 @@ namespace InfluxDB.Client.Api.Client
                     {
                         var headerParameter = authResponse
                             .Headers?
-                            .FirstOrDefault(it => string.Equals("Set-Cookie", it.Name, StringComparison.OrdinalIgnoreCase));
-                        
+                            .FirstOrDefault(it =>
+                                string.Equals("Set-Cookie", it.Name, StringComparison.OrdinalIgnoreCase));
+
                         RestClient.Authenticator = new CookieRedirectAuthenticator(headerParameter);
                     }
                 }
@@ -170,6 +171,8 @@ namespace InfluxDB.Client.Api.Client
         }
 
         protected override ValueTask<Parameter> GetAuthenticationParameter(string cookie)
-            => new ValueTask<Parameter>(new HeaderParameter("Cookie", cookie));
+        {
+            return new ValueTask<Parameter>(new HeaderParameter("Cookie", cookie));
+        }
     }
 }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -6,8 +6,10 @@ using System.Linq;
 using System.Net;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
+using System.Threading.Tasks;
 using InfluxDB.Client.Core.Internal;
 using RestSharp;
+using RestSharp.Authenticators;
 
 namespace InfluxDB.Client.Api.Client
 {
@@ -126,6 +128,15 @@ namespace InfluxDB.Client.Api.Client
                 if (authResponse.Cookies != null)
                 {
                     _initializedSessionTokens = true;
+                    // The cookies doesn't follow redirects => we have to manually set `Cookie` header by Authenticator.
+                    if (_options.AllowHttpRedirects && authResponse.Cookies.Count > 0)
+                    {
+                        var headerParameter = authResponse
+                            .Headers?
+                            .FirstOrDefault(it => string.Equals("Set-Cookie", it.Name, StringComparison.OrdinalIgnoreCase));
+                        
+                        RestClient.Authenticator = new CookieRedirectAuthenticator(headerParameter);
+                    }
                 }
             }
         }
@@ -145,6 +156,20 @@ namespace InfluxDB.Client.Api.Client
 
             var request = new RestRequest("/api/v2/signout", Method.Post);
             RestClient.ExecuteAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+            RestClient.Authenticator = null;
         }
+    }
+
+    /// <summary>
+    /// Set Cookies to HTTP Request.
+    /// </summary>
+    internal class CookieRedirectAuthenticator : AuthenticatorBase
+    {
+        internal CookieRedirectAuthenticator(Parameter setCookie) : base(setCookie.Value?.ToString() ?? "")
+        {
+        }
+
+        protected override ValueTask<Parameter> GetAuthenticationParameter(string cookie)
+            => new ValueTask<Parameter>(new HeaderParameter("Cookie", cookie));
     }
 }


### PR DESCRIPTION
Closes #302

## Proposed Changes

The `CookieContainer` doesn't set Cookies if there is a redirect to other domain, we have to use custom Authenticator.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
