### PR TITLE
feat(linq): add support for TakeLast expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 ### Features
 1. [#304](https://github.com/influxdata/influxdb-client-csharp/pull/304): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
+   [#308](https://github.com/influxdata/influxdb-client-csharp/pull/308): Add support for `TakeLast` expression [LINQ]
 
 ### Bug Fixes
 1. [#305](https://github.com/influxdata/influxdb-client-csharp/pull/305): Authentication Cookies follow redirects
-
-### Bug Fixes
 1. [#309](https://github.com/influxdata/influxdb-client-csharp/pull/309): Query expression for joins of binary operators [LINQ]
 
 ## 4.0.0 [2022-03-18]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 1. [#304](https://github.com/influxdata/influxdb-client-csharp/pull/304): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
-   [#308](https://github.com/influxdata/influxdb-client-csharp/pull/308): Add support for `TakeLast` expression [LINQ]
+1. [#308](https://github.com/influxdata/influxdb-client-csharp/pull/308): Add support for `TakeLast` expression [LINQ]
 
 ### Bug Fixes
 1. [#305](https://github.com/influxdata/influxdb-client-csharp/pull/305): Authentication Cookies follow redirects

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -98,6 +98,18 @@ namespace Client.Linq.Test
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
         }
+        
+        [Test]
+        public void ResultOperatorTakeLast()
+        {
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi)
+                select s;
+            var visitor = BuildQueryVisitor(query, MakeExpression(query, q => q.TakeLast(10)));
+
+            const string expected = FluxStart + " " + "|> tail(n: p3)";
+
+            Assert.AreEqual(expected, visitor.BuildFluxQuery());
+        }
 
         [Test]
         public void ResultOperatorSkip()

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -97,18 +97,18 @@ namespace Client.Linq.Test
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
         }
-        
+
         [Test]
         public void ResultOperatorTakeLast()
         {
             var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi)
                 select s;
-            
+
             var visitor = BuildQueryVisitor(query, MakeExpression(query, q => q.TakeLast(10)));
 
             var expected = FluxStart + " " + "|> tail(n: p3)";
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
-            
+
             visitor = BuildQueryVisitor(query, MakeExpression(query, q => q.TakeLast(10).Skip(5)));
 
             expected = FluxStart + " " + "|> tail(n: p3, offset: p4)";
@@ -1111,7 +1111,8 @@ namespace Client.Linq.Test
         private InfluxDBQueryVisitor BuildQueryVisitor(IQueryable queryable, Expression expression = null)
         {
             var queryExecutor = (InfluxDBQueryExecutor)((DefaultQueryProvider)queryable.Provider).Executor;
-            var queryModel = InfluxDBQueryable<Sensor>.CreateQueryParser().GetParsedQuery(expression ?? queryable.Expression);
+            var queryModel = InfluxDBQueryable<Sensor>.CreateQueryParser()
+                .GetParsedQuery(expression ?? queryable.Expression);
             return queryExecutor.QueryVisitor(queryModel);
         }
 

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
-using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Linq.Internal;
 using InfluxDB.Client.Linq.Internal.NodeTypes;
@@ -178,7 +177,7 @@ namespace InfluxDB.Client.Linq
         /// Create a <see cref="Api.Domain.Query"/> object that will be used for Querying.
         /// </summary>
         /// <returns>Query that will be used to Querying</returns>
-        public Query ToDebugQuery()
+        public Api.Domain.Query ToDebugQuery()
         {
             var provider = Provider as DefaultQueryProvider;
             var executor = provider?.Executor as InfluxDBQueryExecutor;

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -1,12 +1,15 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Linq.Expressions;
 using System.Threading;
+using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Linq.Internal;
+using InfluxDB.Client.Linq.Internal.NodeTypes;
 using Remotion.Linq;
 using Remotion.Linq.Parsing.Structure;
+using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
+using Expression = System.Linq.Expressions.Expression;
 
 namespace InfluxDB.Client.Linq
 {
@@ -175,7 +178,7 @@ namespace InfluxDB.Client.Linq
         /// Create a <see cref="Api.Domain.Query"/> object that will be used for Querying.
         /// </summary>
         /// <returns>Query that will be used to Querying</returns>
-        public Api.Domain.Query ToDebugQuery()
+        public Query ToDebugQuery()
         {
             var provider = Provider as DefaultQueryProvider;
             var executor = provider?.Executor as InfluxDBQueryExecutor;
@@ -213,9 +216,12 @@ namespace InfluxDB.Client.Linq
                 queryableOptimizerSettings ?? new QueryableOptimizerSettings());
         }
 
-        private static QueryParser CreateQueryParser()
+        internal static QueryParser CreateQueryParser()
         {
-            return QueryParser.CreateDefault();
+            var queryParser = QueryParser.CreateDefault();
+            var compoundNodeTypeProvider = queryParser.NodeTypeProvider as CompoundNodeTypeProvider;
+            compoundNodeTypeProvider?.InnerProviders.Add(new InfluxDBNodeTypeProvider());
+            return queryParser;
         }
 
         public IAsyncEnumerable<T> GetAsyncEnumerator(CancellationToken cancellationToken = default)

--- a/Client.Linq/Internal/NodeTypes/InfluxDBNodeTypeProvider.cs
+++ b/Client.Linq/Internal/NodeTypes/InfluxDBNodeTypeProvider.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Reflection;
+using Remotion.Linq.Parsing.Structure;
+using Remotion.Linq.Parsing.Structure.NodeTypeProviders;
+
+namespace InfluxDB.Client.Linq.Internal.NodeTypes
+{
+    internal class InfluxDBNodeTypeProvider : INodeTypeProvider
+    {
+        private readonly MethodInfoBasedNodeTypeRegistry _methodInfoRegistry = new MethodInfoBasedNodeTypeRegistry();
+
+        internal InfluxDBNodeTypeProvider()
+        {
+            _methodInfoRegistry.Register(TakeLastExpressionNode.GetSupportedMethods, typeof(TakeLastExpressionNode));
+        }
+
+        public bool IsRegistered(MethodInfo method)
+        {
+            return _methodInfoRegistry.IsRegistered(method);
+        }
+
+        public Type GetNodeType(MethodInfo method)
+        {
+            return _methodInfoRegistry.GetNodeType(method);
+        }
+    }
+}

--- a/Client.Linq/Internal/NodeTypes/TakeLastNodeType.cs
+++ b/Client.Linq/Internal/NodeTypes/TakeLastNodeType.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using InfluxDB.Client.Core;
+using Remotion.Linq.Clauses;
+using Remotion.Linq.Clauses.ResultOperators;
+using Remotion.Linq.Clauses.StreamedData;
+using Remotion.Linq.Parsing.Structure.IntermediateModel;
+
+namespace InfluxDB.Client.Linq.Internal.NodeTypes
+{
+    internal class TakeLastExpressionNode : ResultOperatorExpressionNodeBase
+    {
+        private readonly Expression _count;
+
+        internal static readonly IEnumerable<MethodInfo> GetSupportedMethods =
+            new ReadOnlyCollection<MethodInfo>(typeof(Enumerable).GetRuntimeMethods()
+                    .Concat(typeof(Queryable).GetRuntimeMethods()).ToList())
+                .Where(mi => mi.Name == "TakeLast");
+
+        public TakeLastExpressionNode(MethodCallExpressionParseInfo parseInfo, Expression count)
+            : base(parseInfo, null, null)
+        {
+            _count = count;
+        }
+
+        public override Expression Resolve(
+            ParameterExpression inputParameter,
+            Expression expressionToBeResolved,
+            ClauseGenerationContext clauseGenerationContext)
+        {
+            Arguments.CheckNotNull(inputParameter, nameof(inputParameter));
+            Arguments.CheckNotNull(expressionToBeResolved, nameof(expressionToBeResolved));
+            return Source.Resolve(inputParameter, expressionToBeResolved, clauseGenerationContext);
+        }
+
+        protected override ResultOperatorBase CreateResultOperator(ClauseGenerationContext clauseGenerationContext)
+        {
+            return new TakeLastResultOperator(_count);
+        }
+    }
+
+    internal class TakeLastResultOperator : SequenceTypePreservingResultOperatorBase
+    {
+        private Expression _count;
+
+        internal TakeLastResultOperator(Expression count)
+        {
+            Arguments.CheckNotNull(count, nameof(count));
+            Count = count;
+        }
+
+        public Expression Count
+        {
+            get => _count;
+            private set
+            {
+                Arguments.CheckNotNull(value, nameof(value));
+                _count = ReferenceEquals(value.Type, typeof(int))
+                    ? value
+                    : throw new ArgumentException(string.Format(
+                        "The value expression returns '{0}', an expression returning 'System.Int32' was expected.",
+                        new object[]
+                        {
+                            value.Type
+                        }), nameof(value));
+            }
+        }
+
+        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
+            new TakeResultOperator(Count);
+
+        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input) => new StreamedSequence(
+            input.GetTypedSequence<T>().Take(GetConstantCount()).AsQueryable(),
+            GetOutputDataInfo(input.DataInfo));
+
+        public override void TransformExpressions(Func<Expression, Expression> transformation)
+        {
+            Arguments.CheckNotNull(transformation, nameof(transformation));
+            Count = transformation(Count);
+        }
+
+        public override string ToString() => $"TakeLast({Count})";
+        private int GetConstantCount() => GetConstantValueFromExpression<int>("count", Count);
+    }
+}

--- a/Client.Linq/Internal/NodeTypes/TakeLastNodeType.cs
+++ b/Client.Linq/Internal/NodeTypes/TakeLastNodeType.cs
@@ -70,12 +70,17 @@ namespace InfluxDB.Client.Linq.Internal.NodeTypes
             }
         }
 
-        public override ResultOperatorBase Clone(CloneContext cloneContext) =>
-            new TakeResultOperator(Count);
+        public override ResultOperatorBase Clone(CloneContext cloneContext)
+        {
+            return new TakeResultOperator(Count);
+        }
 
-        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input) => new StreamedSequence(
-            input.GetTypedSequence<T>().Take(GetConstantCount()).AsQueryable(),
-            GetOutputDataInfo(input.DataInfo));
+        public override StreamedSequence ExecuteInMemory<T>(StreamedSequence input)
+        {
+            return new StreamedSequence(
+                input.GetTypedSequence<T>().Take(GetConstantCount()).AsQueryable(),
+                GetOutputDataInfo(input.DataInfo));
+        }
 
         public override void TransformExpressions(Func<Expression, Expression> transformation)
         {
@@ -83,7 +88,14 @@ namespace InfluxDB.Client.Linq.Internal.NodeTypes
             Count = transformation(Count);
         }
 
-        public override string ToString() => $"TakeLast({Count})";
-        private int GetConstantCount() => GetConstantValueFromExpression<int>("count", Count);
+        public override string ToString()
+        {
+            return $"TakeLast({Count})";
+        }
+
+        private int GetConstantCount()
+        {
+            return GetConstantValueFromExpression<int>("count", Count);
+        }
     }
 }

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -110,7 +110,8 @@ namespace InfluxDB.Client.Linq.Internal
             }
             else
             {
-                _limitTailNOffsetAssignments.Add(new LimitOffsetAssignment { FluxFunction = fluxFunction, N = limitNAssignment });
+                _limitTailNOffsetAssignments.Add(new LimitOffsetAssignment
+                    { FluxFunction = fluxFunction, N = limitNAssignment });
             }
         }
 

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -49,6 +49,7 @@ namespace InfluxDB.Client.Linq.Internal
 
     internal class LimitOffsetAssignment
     {
+        internal string FluxFunction;
         internal string N;
         internal string Offset;
     }
@@ -60,7 +61,7 @@ namespace InfluxDB.Client.Linq.Internal
         private RangeExpressionType _rangeStartExpression;
         private string _rangeStopAssignment;
         private RangeExpressionType _rangeStopExpression;
-        private readonly List<LimitOffsetAssignment> _limitNOffsetAssignments;
+        private readonly List<LimitOffsetAssignment> _limitTailNOffsetAssignments;
         private ResultFunction _resultFunction;
         private readonly List<string> _filterByTags;
         private readonly List<string> _filterByFields;
@@ -70,7 +71,7 @@ namespace InfluxDB.Client.Linq.Internal
         internal QueryAggregator()
         {
             _resultFunction = ResultFunction.None;
-            _limitNOffsetAssignments = new List<LimitOffsetAssignment>();
+            _limitTailNOffsetAssignments = new List<LimitOffsetAssignment>();
             _filterByTags = new List<string>();
             _filterByFields = new List<string>();
             _orders = new List<(string, string, bool, string)>();
@@ -100,27 +101,28 @@ namespace InfluxDB.Client.Linq.Internal
         }
 
 
-        internal void AddLimitN(string limitNAssignment)
+        internal void AddLimitTailN(string limitNAssignment, string fluxFunction)
         {
-            if (_limitNOffsetAssignments.Count > 0 && _limitNOffsetAssignments.Last().N == null)
+            if (_limitTailNOffsetAssignments.Count > 0 && _limitTailNOffsetAssignments.Last().N == null)
             {
-                _limitNOffsetAssignments.Last().N = limitNAssignment;
+                _limitTailNOffsetAssignments.Last().FluxFunction = fluxFunction;
+                _limitTailNOffsetAssignments.Last().N = limitNAssignment;
             }
             else
             {
-                _limitNOffsetAssignments.Add(new LimitOffsetAssignment { N = limitNAssignment });
+                _limitTailNOffsetAssignments.Add(new LimitOffsetAssignment { FluxFunction = fluxFunction, N = limitNAssignment });
             }
         }
 
-        internal void AddLimitOffset(string limitOffsetAssignment)
+        internal void AddLimitTailOffset(string limitOffsetAssignment)
         {
-            if (_limitNOffsetAssignments.Count > 0)
+            if (_limitTailNOffsetAssignments.Count > 0)
             {
-                _limitNOffsetAssignments.Last().Offset = limitOffsetAssignment;
+                _limitTailNOffsetAssignments.Last().Offset = limitOffsetAssignment;
             }
             else
             {
-                _limitNOffsetAssignments.Add(new LimitOffsetAssignment { Offset = limitOffsetAssignment });
+                _limitTailNOffsetAssignments.Add(new LimitOffsetAssignment { Offset = limitOffsetAssignment });
             }
         }
 
@@ -193,10 +195,10 @@ namespace InfluxDB.Client.Linq.Internal
             }
 
             // https://docs.influxdata.com/flux/v0.x/stdlib/universe/limit/
-            foreach (var limitNOffsetAssignment in _limitNOffsetAssignments)
+            foreach (var limitNOffsetAssignment in _limitTailNOffsetAssignments)
                 if (limitNOffsetAssignment.N != null)
                 {
-                    parts.Add(BuildOperator("limit",
+                    parts.Add(BuildOperator(limitNOffsetAssignment.FluxFunction,
                         "n", limitNOffsetAssignment.N,
                         "offset", limitNOffsetAssignment.Offset));
                 }

--- a/Client.Linq/Internal/QueryVisitor.cs
+++ b/Client.Linq/Internal/QueryVisitor.cs
@@ -6,6 +6,7 @@ using System.Linq.Expressions;
 using System.Text;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Linq.Internal.Expressions;
+using InfluxDB.Client.Linq.Internal.NodeTypes;
 using Remotion.Linq;
 using Remotion.Linq.Clauses;
 using Remotion.Linq.Clauses.ResultOperators;
@@ -135,12 +136,17 @@ namespace InfluxDB.Client.Linq.Internal
             {
                 case TakeResultOperator takeResultOperator:
                     var takeVariable = GetFluxExpression(takeResultOperator.Count, takeResultOperator);
-                    _context.QueryAggregator.AddLimitN(takeVariable);
+                    _context.QueryAggregator.AddLimitTailN(takeVariable, "limit");
                     break;
 
+                case TakeLastResultOperator takeLastResultOperator:
+                    var takeLastVariable = GetFluxExpression(takeLastResultOperator.Count, takeLastResultOperator);
+                    _context.QueryAggregator.AddLimitTailN(takeLastVariable, "tail");
+                    break;
+                
                 case SkipResultOperator skipResultOperator:
                     var skipVariable = GetFluxExpression(skipResultOperator.Count, skipResultOperator);
-                    _context.QueryAggregator.AddLimitOffset(skipVariable);
+                    _context.QueryAggregator.AddLimitTailOffset(skipVariable);
                     break;
 
                 case AnyResultOperator _:

--- a/Client.Linq/Internal/QueryVisitor.cs
+++ b/Client.Linq/Internal/QueryVisitor.cs
@@ -143,7 +143,7 @@ namespace InfluxDB.Client.Linq.Internal
                     var takeLastVariable = GetFluxExpression(takeLastResultOperator.Count, takeLastResultOperator);
                     _context.QueryAggregator.AddLimitTailN(takeLastVariable, "tail");
                     break;
-                
+
                 case SkipResultOperator skipResultOperator:
                     var skipVariable = GetFluxExpression(skipResultOperator.Count, skipResultOperator);
                     _context.QueryAggregator.AddLimitTailOffset(skipVariable);

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -32,6 +32,7 @@ This section contains links to the client library documentation.
     - [Or](#or)
     - [Any](#any)
     - [Take](#take)
+    - [TakeLast](#takelast)
     - [Skip](#skip)
     - [OrderBy](#orderby)
     - [Count](#count)
@@ -848,6 +849,24 @@ from(bucket: "my-bucket")
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> limit(n: 10)
+```
+
+### TakeLast
+
+```c#
+var query = (from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi)
+    select s)
+    .TakeLast(10);
+```
+
+Flux Query:
+
+```flux
+from(bucket: "my-bucket") 
+    |> range(start: 0) 
+    |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
+    |> drop(columns: ["_start", "_stop", "_measurement"])
+    |> tail(n: 10)
 ```
 
 ### Skip


### PR DESCRIPTION
Closes #307

## Proposed Changes

Added support for `TakeLast` LINQ expression:

```c#
var query = (from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi)
    select s)
    .TakeLast(10);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
