### PR TITLE
fix(linq): query expression for inline joins of binary operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#101](https://github.com/influxdata/influxdb-client-csharp/pull/304): Add `InvocableScriptsApi` to create, update, list, delete and invoke scripts by seamless way
 
+### Bug Fixes
+1. [#309](https://github.com/influxdata/influxdb-client-csharp/pull/309): Query expression for joins of binary operators [LINQ]
+
 ## 4.0.0 [2022-03-18]
 
 :warning: The underlying `RestSharp` library was updated the latest major version `v107`. The new version of `RestSharp` switched from the legacy `HttpWebRequest` class to the standard well-known `System.Net.Http.HttpClient` instead. This improves performance and solves lots of issues, like hanging connections, updated protocols support, and many other problems.

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1075,7 +1075,7 @@ namespace Client.Linq.Test
         {
             var start = new DateTime(2019, 11, 16, 8, 20, 15, DateTimeKind.Utc);
             var stop = new DateTime(2021, 01, 10, 5, 10, 0, DateTimeKind.Utc);
-            
+
             var query = from s in InfluxDBQueryable<SensorDateTimeOffset>.Queryable("my-bucket", "my-org", _queryApi)
                 where s.Timestamp >= start && s.Timestamp < stop && s.SensorId == "id-1"
                 select s;
@@ -1088,7 +1088,7 @@ namespace Client.Linq.Test
                                     "|> filter(fn: (r) => (r[\"sensor_id\"] == p5)) " +
                                     "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
                                     "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])";
-            
+
             Console.WriteLine(visitor.BuildFluxQuery());
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());

--- a/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
+++ b/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
@@ -395,7 +395,8 @@ namespace InfluxDB.Client.Linq.Internal
                     .Where(i => parts[i] is LeftParenthesis)
                     .ToList();
 
-                foreach (var index in indexes) {
+                foreach (var index in indexes)
+                {
                     // ()
                     if (parts.Count > index + 1 && parts[index + 1] is RightParenthesis)
                     {
@@ -405,11 +406,12 @@ namespace InfluxDB.Client.Linq.Internal
                         NormalizeExpressions(parts);
                         return;
                     }
+
                     // (
                     if (parts.Count == 1 && parts[index] is LeftParenthesis)
                     {
                         parts.RemoveAt(index);
-                        
+
                         NormalizeExpressions(parts);
                         return;
                     }

--- a/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
+++ b/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
@@ -395,7 +395,7 @@ namespace InfluxDB.Client.Linq.Internal
                     .Where(i => parts[i] is LeftParenthesis)
                     .ToList();
 
-                foreach (var index in indexes)
+                foreach (var index in indexes) {
                     // ()
                     if (parts.Count > index + 1 && parts[index + 1] is RightParenthesis)
                     {
@@ -405,6 +405,15 @@ namespace InfluxDB.Client.Linq.Internal
                         NormalizeExpressions(parts);
                         return;
                     }
+                    // (
+                    if (parts.Count == 1 && parts[index] is LeftParenthesis)
+                    {
+                        parts.RemoveAt(index);
+                        
+                        NormalizeExpressions(parts);
+                        return;
+                    }
+                }
 
                 // (( ))
                 if (parts.Count >= 4 && parts[0] is LeftParenthesis && parts[1] is LeftParenthesis &&


### PR DESCRIPTION
Closes #306

## Proposed Changes

Fixed generated Flux Query for inline joins of binary operator:

```c#
var query = from s in InfluxDBQueryable<SensorDateTimeOffset>.Queryable("my-bucket", "my-org", _queryApi)
                where s.Timestamp >= start && s.Timestamp < stop && s.SensorId == "id-1"
                select s;
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
