### PR TITLE
fix: use default org and bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.2.0 [unreleased]
 
+### Bug Fixes
+1. [#313](https://github.com/influxdata/influxdb-client-csharp/pull/313): Using default `org` and `bucket` in `WriteApiAsync`
+
 ## 4.1.0 [2022-04-19]
 
 ### Features

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -245,9 +245,9 @@ namespace InfluxDB.Client.Test
             MockServer
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
-            
+
             _influxDbClient.Dispose();
-            
+
             var options = InfluxDBClientOptions.Builder
                 .CreateNew()
                 .Url(MockServerUrl)
@@ -257,10 +257,11 @@ namespace InfluxDB.Client.Test
                 .Build();
 
             _influxDbClient = InfluxDBClientFactory.Create(options);
-            
+
             var writeApi = _influxDbClient.GetWriteApiAsync();
             await writeApi.WriteRecordsAsyncWithIRestResponse(new[] { "mem,location=a level=1.0 1" });
-            await writeApi.WritePointsAsyncWithIRestResponse(new[] { PointData.Measurement("h2o").Field("water_level", 9.0D) });
+            await writeApi.WritePointsAsyncWithIRestResponse(new[]
+                { PointData.Measurement("h2o").Field("water_level", 9.0D) });
         }
 
         private string GetRequestBody(RestResponse restResponse)

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -239,6 +239,30 @@ namespace InfluxDB.Client.Test
                 ae.Message);
         }
 
+        [Test]
+        public async Task UseDefaultOrganizationAndBucket()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+                .RespondWith(CreateResponse("{}"));
+            
+            _influxDbClient.Dispose();
+            
+            var options = InfluxDBClientOptions.Builder
+                .CreateNew()
+                .Url(MockServerUrl)
+                .AuthenticateToken("token")
+                .Bucket("my-bucket")
+                .Org("my-org")
+                .Build();
+
+            _influxDbClient = InfluxDBClientFactory.Create(options);
+            
+            var writeApi = _influxDbClient.GetWriteApiAsync();
+            await writeApi.WriteRecordsAsyncWithIRestResponse(new[] { "mem,location=a level=1.0 1" });
+            await writeApi.WritePointsAsyncWithIRestResponse(new[] { PointData.Measurement("h2o").Field("water_level", 9.0D) });
+        }
+
         private string GetRequestBody(RestResponse restResponse)
         {
             var bytes = (byte[])restResponse.Request?.Parameters

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -99,7 +99,8 @@ namespace InfluxDB.Client
             var batch = records
                 .Select(it => new BatchWriteRecord(options, it));
 
-            return WriteDataAsyncWithIRestResponse(batch, options.Bucket, options.OrganizationId, precision, cancellationToken);
+            return WriteDataAsyncWithIRestResponse(batch, options.Bucket, options.OrganizationId, precision,
+                cancellationToken);
         }
 
         /// <summary>
@@ -175,7 +176,8 @@ namespace InfluxDB.Client
                     .Select(it => new BatchWritePoint(options, _options, it))
                     .ToList();
 
-                tasks.Add(WriteDataAsyncWithIRestResponse(groupedPoints, options.Bucket, options.OrganizationId, grouped.Key, cancellationToken));
+                tasks.Add(WriteDataAsyncWithIRestResponse(groupedPoints, options.Bucket, options.OrganizationId,
+                    grouped.Key, cancellationToken));
             }
 
             return Task.WhenAll(tasks);


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/issues/311

## Proposed Changes

Fixed using default `org` and `bucket` in `WriteApiAsync`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
