### PR TITLE
fix: decompress Gzipped data

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ jobs:
       - restore_cache:
           name: Restoring reSharper Cache
           keys:
-              - &cache-key reSharper-cache-2021_3_3
+              - &cache-key reSharper-cache-2022_1_0
       - run:
           name: Check code formatting
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 
 ### Bug Fixes
 1. [#313](https://github.com/influxdata/influxdb-client-csharp/pull/313): Using default `org` and `bucket` in `WriteApiAsync`
+1. [#317](https://github.com/influxdata/influxdb-client-csharp/pull/317): Decompress Gzipped data
+1. [#317](https://github.com/influxdata/influxdb-client-csharp/pull/317): Logging HTTP headers from streaming request
 
 ### Documentation
 1. [#315](https://github.com/influxdata/influxdb-client-csharp/pull/315): Clarify `timeout` option

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading;
@@ -394,7 +396,13 @@ namespace InfluxDB.Client.Core.Internal
 # else
             var readAsStreamAsync = response.Content.ReadAsStreamAsync();
 #endif
-            return readAsStreamAsync.ConfigureAwait(false).GetAwaiter().GetResult();
+            var streamFromResponse = readAsStreamAsync.ConfigureAwait(false).GetAwaiter().GetResult();
+            if (response.Content.Headers.ContentEncoding.Any(x => "gzip".Equals(x, StringComparison.OrdinalIgnoreCase)))
+            {
+                streamFromResponse = new GZipStream(streamFromResponse, CompressionMode.Decompress);
+            }
+
+            return streamFromResponse;
         }
     }
 }

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -114,7 +114,8 @@ namespace InfluxDB.Client.Core.Internal
                 var query = queryFn.Invoke(response =>
                 {
                     var result = GetStreamFromResponse(response, cancellationToken);
-                    result = AfterIntercept((int)response.StatusCode, () => response.Headers.ToHeaderParameters(),
+                    result = AfterIntercept((int)response.StatusCode,
+                        () => response.Headers.ToHeaderParameters(response.Content.Headers),
                         result);
 
                     RaiseForInfluxError(response, result);
@@ -157,7 +158,8 @@ namespace InfluxDB.Client.Core.Internal
                 var query = queryFn.Invoke(response =>
                 {
                     var result = GetStreamFromResponse(response, cancellationToken);
-                    result = AfterIntercept((int)response.StatusCode, () => response.Headers.ToHeaderParameters(),
+                    result = AfterIntercept((int)response.StatusCode,
+                        () => response.Headers.ToHeaderParameters(response.Content.Headers),
                         result);
 
                     RaiseForInfluxError(response, result);
@@ -196,7 +198,8 @@ namespace InfluxDB.Client.Core.Internal
             var query = queryFn.Invoke(response =>
             {
                 stream = GetStreamFromResponse(response, cancellationToken);
-                stream = AfterIntercept((int)response.StatusCode, () => response.Headers.ToHeaderParameters(), stream);
+                stream = AfterIntercept((int)response.StatusCode,
+                    () => response.Headers.ToHeaderParameters(response.Content.Headers), stream);
 
                 RaiseForInfluxError(response, stream);
 

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -10,9 +10,17 @@ namespace InfluxDB.Client.Core.Internal
 {
     internal static class RestSharpExtensions
     {
-        internal static IEnumerable<HeaderParameter> ToHeaderParameters(this HttpHeaders httpHeaders)
+        /// <summary>
+        /// Transform `HttpHeaders` to `HeaderParameter` type.
+        /// </summary>
+        /// <param name="httpHeaders"></param>
+        /// <param name="httpContentHeaders">Additionally content Headers</param>
+        /// <returns>IEnumerable&lt;HeaderParameter&gt;</returns>
+        internal static IEnumerable<HeaderParameter> ToHeaderParameters(this HttpHeaders httpHeaders,
+            HttpContentHeaders? httpContentHeaders = null)
         {
             return httpHeaders
+                .Concat(httpContentHeaders ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
                 .SelectMany(x => x.Value.Select(y => (x.Key, y)))
                 .Select(x => new HeaderParameter(x.Key, x.y));
         }

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -17,7 +17,7 @@ namespace InfluxDB.Client.Core.Internal
         /// <param name="httpContentHeaders">Additionally content Headers</param>
         /// <returns>IEnumerable&lt;HeaderParameter&gt;</returns>
         internal static IEnumerable<HeaderParameter> ToHeaderParameters(this HttpHeaders httpHeaders,
-            HttpContentHeaders? httpContentHeaders = null)
+            HttpContentHeaders httpContentHeaders = null)
         {
             return httpHeaders
                 .Concat(httpContentHeaders ?? Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -925,17 +925,14 @@ namespace InfluxDB.Client.Test
         public async Task GzipWithLargeAmountOfData()
         {
             Client.EnableGzip();
-            
+
             var records = new List<string>();
-            for (var i = 0; i < 1000; i++)
-            {
-                records.Add($"mem{i},tag=a value={i}i {i}");
-            }
+            for (var i = 0; i < 1000; i++) records.Add($"mem{i},tag=a value={i}i {i}");
             await Client.GetWriteApiAsync().WriteRecordsAsync(records);
-            
+
             var tables = await _queryApi.QueryAsync(
                 $"from(bucket:\"{_bucket.Name}\") |> range(start: 0)");
-            
+
             Assert.AreEqual(1000, tables.Count);
             Assert.AreEqual(1, tables[0].Records.Count);
         }

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -920,5 +920,24 @@ namespace InfluxDB.Client.Test
             foreach (var successEvent in successEvents)
                 Assert.AreEqual(50_000, successEvent.LineProtocol.Split("\n").Length);
         }
+
+        [Test]
+        public async Task GzipWithLargeAmountOfData()
+        {
+            Client.EnableGzip();
+            
+            var records = new List<string>();
+            for (var i = 0; i < 1000; i++)
+            {
+                records.Add($"mem{i},tag=a value={i}i {i}");
+            }
+            await Client.GetWriteApiAsync().WriteRecordsAsync(records);
+            
+            var tables = await _queryApi.QueryAsync(
+                $"from(bucket:\"{_bucket.Name}\") |> range(start: 0)");
+            
+            Assert.AreEqual(1000, tables.Count);
+            Assert.AreEqual(1, tables[0].Records.Count);
+        }
     }
 }

--- a/Client.Test/QueryApiTest.cs
+++ b/Client.Test/QueryApiTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
@@ -125,6 +126,23 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(
                 "Expecting a non-empty string for 'org' parameter. Please specify the organization as a method parameter or use default configuration at 'InfluxDBClientOptions.Org'.",
                 ae.Message);
+        }
+
+        [Test]
+        public async Task LoggedContentType()
+        {
+            var writer = new StringWriter();
+            Trace.Listeners.Add(new TextWriterTraceListener(writer));
+
+            _influxDbClient.SetLogLevel(LogLevel.Headers);
+
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/query").UsingPost())
+                .RespondWith(CreateResponse(Data));
+
+            await _queryApi.QueryAsync("from(...");
+
+            StringAssert.Contains("Content-Type=text/csv; charset=utf-8", writer.ToString());
         }
 
         private class SyncPoco

--- a/Scripts/reformat-code.sh
+++ b/Scripts/reformat-code.sh
@@ -8,7 +8,7 @@ cd "$SCRIPT_PATH"/..
 #
 # Install ReSharper command line tools
 #
-dotnet tool install --tool-path="./reSharperCLI" JetBrains.ReSharper.GlobalTools --version 2021.3.3 || true
+dotnet tool install --tool-path="./reSharperCLI" JetBrains.ReSharper.GlobalTools --version 2022.1.0 || true
 
 #
 # Reformat code


### PR DESCRIPTION
Closes #310

## Proposed Changes

1. Fixed decompressing Gzipped data
2. Updated JetBrains.ReSharper.GlobalTools (code formatter) to 2022.1.0 3. 
3. Fixed logging HTTP headers from streaming request

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
