### PR TITLE
feat: Optionally align limit() and tail() before pivot() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.2.0 [unreleased]
 
+### Features
+1. [#319](https://github.com/influxdata/influxdb-client-csharp/pull/319): Optionally align `limit()` and `tail()` before `pivot()` function [LINQ]
+
 ### Breaking Changes
 1. [#316](https://github.com/influxdata/influxdb-client-csharp/pull/316): Rename `InvocableScripts` to `InvokableScripts`
 

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1107,7 +1107,7 @@ namespace Client.Linq.Test
 
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
         }
-        
+
         [Test]
         public void AlignLimitFunctionBeforePivot()
         {
@@ -1126,11 +1126,11 @@ namespace Client.Linq.Test
 
             visitor = BuildQueryVisitor(query, MakeExpression(query, q => q.Take(10)));
             expected = "start_shifted = int(v: time(v: p2))\n\n" +
-                "from(bucket: p1) " +
-                "|> range(start: time(v: start_shifted)) " +
-                "|> limit(n: p3) " +
-                "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
-                "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])";
+                       "from(bucket: p1) " +
+                       "|> range(start: time(v: start_shifted)) " +
+                       "|> limit(n: p3) " +
+                       "|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\") " +
+                       "|> drop(columns: [\"_start\", \"_stop\", \"_measurement\"])";
             Assert.AreEqual(expected, visitor.BuildFluxQuery());
         }
 

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client.Linq
         /// to align fields to tabular way.
         /// </summary>
         public bool AlignFieldsWithPivot { get; set; }
-        
+
         /// <summary>
         /// Gets or set whether the drive should align <a>limit()</a> and <a>tail()</a> functions
         /// after <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/pivot/">pivot()</a> function.

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -21,6 +21,7 @@ namespace InfluxDB.Client.Linq
         {
             QueryMultipleTimeSeries = false;
             AlignFieldsWithPivot = true;
+            AlignLimitFunctionAfterPivot = true;
             DropMeasurementColumn = true;
             DropStartColumn = true;
             DropStopColumn = true;
@@ -41,6 +42,12 @@ namespace InfluxDB.Client.Linq
         /// to align fields to tabular way.
         /// </summary>
         public bool AlignFieldsWithPivot { get; set; }
+        
+        /// <summary>
+        /// Gets or set whether the drive should align <a>limit()</a> and <a>tail()</a> functions
+        /// after <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/pivot/">pivot()</a> function.
+        /// </summary>
+        public bool AlignLimitFunctionAfterPivot { get; set; }
 
         /// <summary>
         /// Gets or sets whether the _measurement column will be dropped from query results.

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -169,16 +169,16 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildAggregateWindow(_aggregateWindow)
             };
 
-            if  (!settings.AlignLimitFunctionAfterPivot)
+            if (!settings.AlignLimitFunctionAfterPivot)
             {
                 AddLimitFunctions(parts);
             }
 
             if (settings.AlignFieldsWithPivot)
             {
-                parts.Add("pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")");                
+                parts.Add("pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")");
             }
-            
+
             var drop = BuildDrop(settings);
             if (!string.IsNullOrEmpty(drop))
             {
@@ -231,14 +231,12 @@ namespace InfluxDB.Client.Linq.Internal
             // https://docs.influxdata.com/flux/latest/stdlib/universe/limit/
             // https://docs.influxdata.com/flux/latest/stdlib/universe/tail/
             foreach (var limitNOffsetAssignment in _limitTailNOffsetAssignments)
-            {
                 if (limitNOffsetAssignment.N != null)
                 {
                     parts.Add(BuildOperator(limitNOffsetAssignment.FluxFunction,
                         "n", limitNOffsetAssignment.N,
                         "offset", limitNOffsetAssignment.Offset));
                 }
-            }
         }
 
         private string BuildAggregateWindow((string Every, string Period, string Fn)? aggregateWindow)

--- a/Client.Linq/Internal/QueryAggregator.cs
+++ b/Client.Linq/Internal/QueryAggregator.cs
@@ -166,12 +166,19 @@ namespace InfluxDB.Client.Linq.Internal
                 BuildOperator("from", "bucket", _bucketAssignment),
                 BuildRange(transforms),
                 BuildFilter(_filterByTags),
-                BuildAggregateWindow(_aggregateWindow),
-                settings.AlignFieldsWithPivot
-                    ? "pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
-                    : ""
+                BuildAggregateWindow(_aggregateWindow)
             };
 
+            if  (!settings.AlignLimitFunctionAfterPivot)
+            {
+                AddLimitFunctions(parts);
+            }
+
+            if (settings.AlignFieldsWithPivot)
+            {
+                parts.Add("pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")");                
+            }
+            
             var drop = BuildDrop(settings);
             if (!string.IsNullOrEmpty(drop))
             {
@@ -195,14 +202,10 @@ namespace InfluxDB.Client.Linq.Internal
                     descendingVariable));
             }
 
-            // https://docs.influxdata.com/flux/v0.x/stdlib/universe/limit/
-            foreach (var limitNOffsetAssignment in _limitTailNOffsetAssignments)
-                if (limitNOffsetAssignment.N != null)
-                {
-                    parts.Add(BuildOperator(limitNOffsetAssignment.FluxFunction,
-                        "n", limitNOffsetAssignment.N,
-                        "offset", limitNOffsetAssignment.Offset));
-                }
+            if (settings.AlignLimitFunctionAfterPivot)
+            {
+                AddLimitFunctions(parts);
+            }
 
             if (_resultFunction != ResultFunction.None)
             {
@@ -221,6 +224,21 @@ namespace InfluxDB.Client.Linq.Internal
             query.Append(JoinList(parts, " |> "));
 
             return query.ToString();
+        }
+
+        private void AddLimitFunctions(List<string> parts)
+        {
+            // https://docs.influxdata.com/flux/latest/stdlib/universe/limit/
+            // https://docs.influxdata.com/flux/latest/stdlib/universe/tail/
+            foreach (var limitNOffsetAssignment in _limitTailNOffsetAssignments)
+            {
+                if (limitNOffsetAssignment.N != null)
+                {
+                    parts.Add(BuildOperator(limitNOffsetAssignment.FluxFunction,
+                        "n", limitNOffsetAssignment.N,
+                        "offset", limitNOffsetAssignment.Offset));
+                }
+            }
         }
 
         private string BuildAggregateWindow((string Every, string Period, string Fn)? aggregateWindow)

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -888,7 +888,7 @@ var optimizerSettings =
         AlignLimitFunctionAfterPivot = false
     };
 ```
-
+**_Performance note:_** The `pivot()` is a [“heavy” function](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/#use-heavy-functions-sparingly). Using `limit()` or `tail()` before `pivot()` is much faster but works only if you have consistent data series. See #318 for more details.
 ### Skip
 
 ```c#

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -851,6 +851,16 @@ from(bucket: "my-bucket")
     |> limit(n: 10)
 ```
 
+**_Note:_** the `limit()` function can be align before `pivot()` function by:
+
+```c#
+var optimizerSettings =
+    new QueryableOptimizerSettings
+    {
+        AlignLimitFunctionAfterPivot = false
+    };
+```
+
 ### TakeLast
 
 ```c#
@@ -867,6 +877,16 @@ from(bucket: "my-bucket")
     |> pivot(rowKey:["_time"], columnKey: ["_field"], valueColumn: "_value") 
     |> drop(columns: ["_start", "_stop", "_measurement"])
     |> tail(n: 10)
+```
+
+**_Note:_** the `tail()` function can be align before `pivot()` function by:
+
+```c#
+var optimizerSettings =
+    new QueryableOptimizerSettings
+    {
+        AlignLimitFunctionAfterPivot = false
+    };
 ```
 
 ### Skip

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -861,6 +861,8 @@ var optimizerSettings =
     };
 ```
 
+**_Performance:_** The `pivot()` is a [“heavy” function](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/#use-heavy-functions-sparingly). Using `limit()` before `pivot()` is much faster but works only if you have consistent data series. See [#318](https://github.com/influxdata/influxdb-client-csharp/issues/318) for more details.
+
 ### TakeLast
 
 ```c#
@@ -888,7 +890,8 @@ var optimizerSettings =
         AlignLimitFunctionAfterPivot = false
     };
 ```
-**_Performance note:_** The `pivot()` is a [“heavy” function](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/#use-heavy-functions-sparingly). Using `limit()` or `tail()` before `pivot()` is much faster but works only if you have consistent data series. See #318 for more details.
+**_Performance:_** The `pivot()` is a [“heavy” function](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/#use-heavy-functions-sparingly). Using `tail()` before `pivot()` is much faster but works only if you have consistent data series. See [#318](https://github.com/influxdata/influxdb-client-csharp/issues/318) for more details.
+
 ### Skip
 
 ```c#

--- a/Client.Test/AbstractItClientTest.cs
+++ b/Client.Test/AbstractItClientTest.cs
@@ -3,10 +3,8 @@ using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
-using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Test;
 using NUnit.Framework;
-using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client.Test
 {


### PR DESCRIPTION
Closes #318

## Proposed Changes

Add possibility to align `limit` and `tail` before `pivot`:

Limit():
Before:
![image](https://user-images.githubusercontent.com/42109793/166149916-895b17de-a53a-451b-a5fe-3bb4a1f686ee.png)
After:
![image](https://user-images.githubusercontent.com/42109793/166149933-33a0a542-9b3c-4ccb-b84c-3ee4122d17be.png)

Tail():
Before:
![image](https://user-images.githubusercontent.com/42109793/166149692-09915638-6074-4f78-8659-bf35c7565b7e.png)

After:
![image](https://user-images.githubusercontent.com/42109793/166149731-0320bc0d-1e05-4531-962f-89d7de95798b.png)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
