### PR TITLE
feat(linq) add possibility to specify default value for `start` and `stop` parameter of range function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#319](https://github.com/influxdata/influxdb-client-csharp/pull/319): Optionally align `limit()` and `tail()` before `pivot()` function [LINQ]
+1. [#322](https://github.com/influxdata/influxdb-client-csharp/pull/322): Possibility to specify default value for `start` and `stop` parameter of range function [LINQ]
 
 ### Breaking Changes
 1. [#316](https://github.com/influxdata/influxdb-client-csharp/pull/316): Rename `InvocableScripts` to `InvokableScripts`

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -447,6 +447,19 @@ namespace Client.Linq.Test
             Assert.AreEqual(43, sensors.Last().Value);
         }
 
+        [Test]
+        public void RangeValue()
+        {
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _client.GetQueryApiSync(),
+                    new QueryableOptimizerSettings
+                        { RangeStartValue = new DateTime(2020, 11, 17, 8, 20, 15, DateTimeKind.Utc) })
+                select s;
+
+            var sensors = query.ToList();
+
+            Assert.AreEqual(2, sensors.Count);
+        }
+
         [TearDown]
         protected void After()
         {

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -25,6 +25,8 @@ namespace InfluxDB.Client.Linq
             DropMeasurementColumn = true;
             DropStartColumn = true;
             DropStopColumn = true;
+            RangeStartValue = null;
+            RangeStopValue = null;
         }
 
         /// <summary>
@@ -78,6 +80,20 @@ namespace InfluxDB.Client.Linq
         /// </list>
         /// </summary>
         public bool DropStopColumn { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value for a start parameter of a <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/range/">range function</a>.
+        /// The `start` is earliest time to include in results. Results include points that match the specified start time.
+        /// Defaults to `0`.
+        /// </summary>
+        public DateTime? RangeStartValue { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default value for a stop parameter of a <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/range/">range function</a>.
+        /// The `start` is latest time to include in results. Results exclude points that match the specified stop time.
+        /// Defaults to `now()`.
+        /// </summary>
+        public DateTime? RangeStopValue { get; set; }
     }
 
     /// <summary>

--- a/Client.Linq/InfluxDBQueryable.cs
+++ b/Client.Linq/InfluxDBQueryable.cs
@@ -90,7 +90,7 @@ namespace InfluxDB.Client.Linq
 
         /// <summary>
         /// Gets or sets the default value for a stop parameter of a <a href="https://docs.influxdata.com/flux/v0.x/stdlib/universe/range/">range function</a>.
-        /// The `start` is latest time to include in results. Results exclude points that match the specified stop time.
+        /// The `stop` is latest time to include in results. Results exclude points that match the specified stop time.
         /// Defaults to `now()`.
         /// </summary>
         public DateTime? RangeStopValue { get; set; }

--- a/Client.Linq/Internal/QueryVisitor.cs
+++ b/Client.Linq/Internal/QueryVisitor.cs
@@ -21,14 +21,22 @@ namespace InfluxDB.Client.Linq.Internal
         internal InfluxDBQueryVisitor(
             string bucket,
             IMemberNameResolver memberResolver,
-            QueryableOptimizerSettings queryableOptimizerSettings) :
-            this(new QueryGenerationContext(new QueryAggregator(), new VariableAggregator(), memberResolver,
-                queryableOptimizerSettings))
+            QueryableOptimizerSettings settings) :
+            this(new QueryGenerationContext(new QueryAggregator(), new VariableAggregator(), memberResolver, settings))
         {
             var bucketVariable = _context.Variables.AddNamedVariable(bucket);
             _context.QueryAggregator.AddBucket(bucketVariable);
-            var rangeVariable = _context.Variables.AddNamedVariable(0);
-            _context.QueryAggregator.AddRangeStart(rangeVariable, RangeExpressionType.GreaterThanOrEqual);
+
+            // default range start
+            var rangeStart = _context.Variables.AddNamedVariable(settings.RangeStartValue as object ?? 0);
+            _context.QueryAggregator.AddRangeStart(rangeStart, RangeExpressionType.GreaterThanOrEqual);
+
+            // default range stop
+            if (settings.RangeStopValue != null)
+            {
+                var rangeStop = _context.Variables.AddNamedVariable(settings.RangeStopValue);
+                _context.QueryAggregator.AddRangeStop(rangeStop, RangeExpressionType.LessThan);
+            }
         }
 
         internal InfluxDBQueryVisitor(QueryGenerationContext context)

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -492,6 +492,18 @@ from(bucket: "my-bucket")
     |> drop(columns: ["_start", "_stop", "_measurement"])
 ```
 
+There is an also possibility to specify default value for `start` and `stop` parameter:
+
+```c#
+var settings = new QueryableOptimizerSettings
+{
+    RangeStartValue = DateTime.UtcNow.AddHours(-24),
+    RangeStopValue = DateTime.UtcNow.AddHours(1)
+};
+var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi, settings)
+    select s;
+```
+
 ### TD;LR
 
 - [Optimize Flux queries](https://docs.influxdata.com/influxdb/cloud/query-data/optimize-queries/)

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -492,7 +492,7 @@ from(bucket: "my-bucket")
     |> drop(columns: ["_start", "_stop", "_measurement"])
 ```
 
-There is an also possibility to specify default value for `start` and `stop` parameter:
+There is also a possibility to specify the default value for `start` and `stop` parameter. This is useful when you need to include data with future timestamps when no time bounds are explicitly set.
 
 ```c#
 var settings = new QueryableOptimizerSettings


### PR DESCRIPTION
Closes #320 

## Proposed Changes

Possibility to specify default value for `start` and `stop` parameter of range function:

```c#
var settings = new QueryableOptimizerSettings
{
    RangeStartValue = DateTime.UtcNow.AddHours(-24),
    RangeStopValue = DateTime.UtcNow.AddHours(1)
};
var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi, settings)
    select s;
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
