### PR TITLE
feat: Add callback function for handling the SSL Certificate Validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 1. [#319](https://github.com/influxdata/influxdb-client-csharp/pull/319): Optionally align `limit()` and `tail()` before `pivot()` function [LINQ]
 1. [#322](https://github.com/influxdata/influxdb-client-csharp/pull/322): Possibility to specify default value for `start` and `stop` parameter of range function [LINQ]
+1. [#323](https://github.com/influxdata/influxdb-client-csharp/pull/323): Add callback function for handling the SSL Certificate Validation
 
 ### Breaking Changes
 1. [#316](https://github.com/influxdata/influxdb-client-csharp/pull/316): Rename `InvocableScripts` to `InvokableScripts`

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -378,19 +378,19 @@ namespace InfluxDB.Client.Test
             });
 
             var reached = false;
-            
+
             _client.Dispose();
             _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
                 .Url(mockServerSsl.Urls[0])
                 .RemoteCertificateValidationCallback((sender, certificate, chain, errors) => reached = true)
                 .Build());
-            
+
             mockServerSsl.Given(Request.Create().WithPath("/ping").UsingGet())
                 .RespondWith(Response.Create().WithStatusCode(204)
                     .WithHeader("x-influxdb-version", "2.0.0"));
 
             await _client.VersionAsync();
-            
+
             Assert.IsTrue(reached);
         }
     }

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Configuration;
 using System.Net;
+using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
 using System.Web;
@@ -41,6 +42,8 @@ namespace InfluxDB.Client
         public PointSettings PointSettings { get; }
 
         public bool VerifySsl { get; }
+        
+        public RemoteCertificateValidationCallback VerifySslCallback { get; }
 
         public X509CertificateCollection ClientCertificates { get; }
 
@@ -66,6 +69,7 @@ namespace InfluxDB.Client
             PointSettings = builder.PointSettings;
 
             VerifySsl = builder.VerifySslCertificates;
+            VerifySslCallback = builder.VerifySslCallback;
             ClientCertificates = builder.CertificateCollection;
         }
 
@@ -110,6 +114,7 @@ namespace InfluxDB.Client
             internal IWebProxy WebProxy;
             internal bool AllowHttpRedirects;
             internal bool VerifySslCertificates = true;
+            internal RemoteCertificateValidationCallback VerifySslCallback;
             internal X509CertificateCollection CertificateCollection;
 
             internal PointSettings PointSettings = new PointSettings();
@@ -283,7 +288,7 @@ namespace InfluxDB.Client
             }
 
             /// <summary>
-            /// Ignore Certificate Validation Errors when false
+            /// Ignore Certificate Validation Errors when `false`.
             /// </summary>
             /// <param name="verifySsl">validates Certificates</param>
             /// <returns><see cref="Builder"/></returns>
@@ -293,6 +298,19 @@ namespace InfluxDB.Client
 
                 VerifySslCertificates = verifySsl;
 
+                return this;
+            }
+            
+            /// <summary>
+            /// Callback function for handling the Certificate Validation of remote certificates to InfluxDB.
+            /// The callback takes precedence over `VerifySsl`. 
+            /// </summary>
+            /// <param name="callback"></param>
+            /// <returns></returns>
+            public Builder RemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
+            {
+                VerifySslCallback = callback;
+                
                 return this;
             }
 

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -302,7 +302,7 @@ namespace InfluxDB.Client
             }
 
             /// <summary>
-            /// Callback function for handling the Certificate Validation of remote certificates to InfluxDB.
+            /// Callback function for handling the remote SSL Certificate Validation.
             /// The callback takes precedence over `VerifySsl`. 
             /// </summary>
             /// <param name="callback"></param>

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client
         public PointSettings PointSettings { get; }
 
         public bool VerifySsl { get; }
-        
+
         public RemoteCertificateValidationCallback VerifySslCallback { get; }
 
         public X509CertificateCollection ClientCertificates { get; }
@@ -300,7 +300,7 @@ namespace InfluxDB.Client
 
                 return this;
             }
-            
+
             /// <summary>
             /// Callback function for handling the Certificate Validation of remote certificates to InfluxDB.
             /// The callback takes precedence over `VerifySsl`. 
@@ -310,7 +310,7 @@ namespace InfluxDB.Client
             public Builder RemoteCertificateValidationCallback(RemoteCertificateValidationCallback callback)
             {
                 VerifySslCallback = callback;
-                
+
                 return this;
             }
 

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -47,6 +47,11 @@ namespace InfluxDB.Client.Api.Client
                     (sender, certificate, chain, sslPolicyErrors) => true;
             }
 
+            if (options.VerifySslCallback != null)
+            {
+                RestClientOptions.RemoteCertificateValidationCallback = options.VerifySslCallback;
+            }
+
             if (options.ClientCertificates != null)
             {
                 RestClientOptions.ClientCertificates ??= new X509CertificateCollection();

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -48,6 +48,11 @@ then
 fi
 
 #
+# Generate testing certificates
+#
+dotnet dev-certs https
+
+#
 # Install testing tools
 #
 dotnet tool install --tool-path="./trx2junit/" trx2junit --version ${TRX2JUNIT_VERSION}


### PR DESCRIPTION
Closes #321

## Proposed Changes

Add possibility to custom validation of SSL certificates:

```c#
var cert = new X509Certificate2("path_to_file");

var options = new InfluxDBClientOptions.Builder()
    .Url("http://localhost:8086")
    .AuthenticateToken("my-token")
    .RemoteCertificateValidationCallback((sender, certificate, chain, errors) => 
        errors == SslPolicyErrors.None || string.Equals(cert.Thumbprint, certificate?.GetCertHashString(), StringComparison.InvariantCultureIgnoreCase))
    .Build();

using var client = InfluxDBClientFactory.Create(options);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
