### PR TITLE
chore: update RestSharp to `108.0.1` and other dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ### Features
 1. [#327](https://github.com/influxdata/influxdb-client-csharp/pull/327): Add interfaces to client's APIs
 
+### Dependencies
+1. [#326](https://github.com/influxdata/influxdb-client-csharp/pull/326): Update dependencies:
+
+#### Build:
+    - RestSharp to 108.0.1
+    - NodaTime to 3.1.0
+    - JsonSubTypes to 1.9.0
+    - Microsoft.Extensions.ObjectPool to 6.0.5
+
 ## 4.2.0 [2022-05-20]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@
     - JsonSubTypes to 1.9.0
     - Microsoft.Extensions.ObjectPool to 6.0.5
 
+#### Test:
+    - Microsoft.NET.Test.Sdk to 17.2.0
+    - NUnit to 3.13.3
+    - WireMock.Net to 1.4.43
+    - Moq to 4.18.1
+    - Tomlyn.Signed to 0.14.3
+
 ## 4.2.0 [2022-05-20]
 
 ### Features

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -13,10 +13,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="WireMock.Net" Version="1.4.34" />
+        <PackageReference Include="WireMock.Net" Version="1.4.43" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="NodaTime" Version="3.0.9" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="RestSharp" Version="107.3.0" />
+      <PackageReference Include="RestSharp" Version="108.0.1" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -34,7 +34,7 @@
     <ItemGroup>
       <PackageReference Include="CsvHelper" Version="27.2.1" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-      <PackageReference Include="NodaTime" Version="3.0.9" />
+      <PackageReference Include="NodaTime" Version="3.1.0" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
       <PackageReference Include="RestSharp" Version="108.0.1" />
     </ItemGroup>

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -171,8 +171,6 @@ namespace InfluxDB.Client.Core.Internal
                 BeforeIntercept(query);
 
                 var restResponse = RestClient.ExecuteSync(query, cancellationToken);
-                // var restResponse = RestClient.ExecuteAsync(query, cancellationToken).ConfigureAwait(false)
-                    // .GetAwaiter().GetResult();
                 if (restResponse.ErrorException != null)
                 {
                     throw restResponse.ErrorException;

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -170,8 +170,9 @@ namespace InfluxDB.Client.Core.Internal
 
                 BeforeIntercept(query);
 
-                var restResponse = RestClient.ExecuteAsync(query, Method.Post, cancellationToken).ConfigureAwait(false)
-                    .GetAwaiter().GetResult();
+                var restResponse = RestClient.ExecuteSync(query, cancellationToken);
+                // var restResponse = RestClient.ExecuteAsync(query, cancellationToken).ConfigureAwait(false)
+                    // .GetAwaiter().GetResult();
                 if (restResponse.ErrorException != null)
                 {
                     throw restResponse.ErrorException;

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
 using RestSharp;
 
 namespace InfluxDB.Client.Core.Internal
@@ -33,6 +35,14 @@ namespace InfluxDB.Client.Core.Internal
             field!.SetValue(restRequest, advancedResponseWriter);
 
             return restRequest;
+        }
+
+        //
+        internal static RestResponse ExecuteSync(this RestClient client,
+            RestRequest request, CancellationToken cancellationToken = default)
+        {
+            // return client.Execute(request);
+            return client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
         }
     }
 }

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -37,7 +37,6 @@ namespace InfluxDB.Client.Core.Internal
             return restRequest;
         }
 
-        //
         internal static RestResponse ExecuteSync(this RestClient client,
             RestRequest request, CancellationToken cancellationToken = default)
         {

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     </ItemGroup>
 

--- a/Client.Legacy.Test/FluxClientTest.cs
+++ b/Client.Legacy.Test/FluxClientTest.cs
@@ -28,9 +28,9 @@ namespace Client.Legacy.Test
         [Test]
         public void ProxyDefault()
         {
-            var restClient = GetRestClientOptions(_fluxClient);
+            var restClient = GetRestClient(_fluxClient).Options;
 
-            Assert.AreEqual(null, restClient?.Proxy);
+            Assert.AreEqual(null, restClient.Proxy);
         }
 
         [Test]
@@ -44,7 +44,7 @@ namespace Client.Legacy.Test
 
             var fluxClient = FluxClientFactory.Create(options);
 
-            Assert.AreEqual(webProxy, GetRestClientOptions(fluxClient).Proxy);
+            Assert.AreEqual(webProxy, GetRestClient(fluxClient).Options.Proxy);
         }
 
         [Test]
@@ -69,14 +69,6 @@ namespace Client.Legacy.Test
                 fluxClient.GetType().BaseType!.GetField("RestClient", BindingFlags.NonPublic | BindingFlags.Instance);
             var restClient = (RestClient)restClientInfo!.GetValue(fluxClient);
             return restClient;
-        }
-
-        private RestClientOptions GetRestClientOptions(FluxClient fluxClient)
-        {
-            var restClient = GetRestClient(fluxClient);
-            var restClientOptionsInfo = restClient!.GetType()
-                .GetProperty("Options", BindingFlags.NonPublic | BindingFlags.Instance);
-            return (RestClientOptions)restClientOptionsInfo!.GetValue(restClient);
         }
     }
 }

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -133,7 +133,7 @@ namespace InfluxDB.Client.Flux
             var version = AssemblyHelper.GetVersion(typeof(FluxClient));
             var restClientOptions = new RestClientOptions(options.Url)
             {
-                Timeout = (int)options.Timeout.TotalMilliseconds,
+                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy
             };

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -11,8 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Moq" Version="4.18.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
         <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     </ItemGroup>

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -12,10 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
-        <PackageReference Include="Moq" Version="4.16.1" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+        <PackageReference Include="Moq" Version="4.18.1" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
-        <PackageReference Include="Tomlyn.Signed" Version="0.10.2" />
+        <PackageReference Include="Tomlyn.Signed" Version="0.14.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -33,8 +33,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="JsonSubTypes" Version="1.8.0" />
-        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.1" />
+        <PackageReference Include="JsonSubTypes" Version="1.9.0" />
+        <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="6.0.5" />
         <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
         <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />

--- a/Client/InfluxDB.Client.Api/Client/ApiClient.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiClient.cs
@@ -14,12 +14,11 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Text.RegularExpressions;
 using System.IO;
-using System.Web;
 using System.Linq;
-using System.Net;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
+using InfluxDB.Client.Core.Internal;
 using Newtonsoft.Json;
 using RestSharp;
 
@@ -173,7 +172,7 @@ namespace InfluxDB.Client.Api.Client
                 pathParams, contentType);
 
             InterceptRequest(request);
-            var response = RestClient.ExecuteAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+            var response = RestClient.ExecuteSync(request);
             InterceptResponse(request, response);
 
             return (object)response;

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -35,7 +35,7 @@ namespace InfluxDB.Client.Api.Client
             var version = AssemblyHelper.GetVersion(typeof(InfluxDBClient));
             RestClientOptions = new RestClientOptions(options.Url)
             {
-                Timeout = (int)options.Timeout.TotalMilliseconds,
+                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy,
                 FollowRedirects = options.AllowHttpRedirects,
@@ -121,7 +121,7 @@ namespace InfluxDB.Client.Api.Client
                     var request = new RestRequest("/api/v2/signin", Method.Post)
                         .AddHeader("Authorization", header);
 
-                    authResponse = RestClient.ExecuteAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
+                    authResponse = RestClient.ExecuteSync(request);
                 }
                 catch (IOException e)
                 {


### PR DESCRIPTION
## Proposed Changes

Updated `RestSharp` to `108.0.1` and

    - NodaTime to 3.1.0
    - JsonSubTypes to 1.9.0
    - Microsoft.Extensions.ObjectPool to 6.0.5
    - Microsoft.NET.Test.Sdk to 17.2.0
    - NUnit to 3.13.3
    - WireMock.Net to 1.4.43
    - Moq to 4.18.1
    - Tomlyn.Signed to 0.14.3

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
