### PR TITLE
feat: add interfaces to client's APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.3.0 [unreleased]
 
+### Features
+1. [#327](https://github.com/influxdata/influxdb-client-csharp/pull/327): Add interfaces to client's APIs
+
 ## 4.2.0 [2022-05-20]
 
 ### Features

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -25,7 +25,7 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class InfluxDbClientTest : AbstractMockServerTest
     {
-        private IInfluxDBClient _client;
+        private InfluxDBClient _client;
 
         [SetUp]
         public new void SetUp()

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -1,15 +1,19 @@
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Reflection;
+using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Client;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Api.Service;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Exceptions;
+using InfluxDB.Client.Core.Flux.Domain;
 using InfluxDB.Client.Core.Test;
+using Moq;
 using NUnit.Framework;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -21,7 +25,7 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class InfluxDbClientTest : AbstractMockServerTest
     {
-        private InfluxDBClient _client;
+        private IInfluxDBClient _client;
 
         [SetUp]
         public new void SetUp()
@@ -392,6 +396,25 @@ namespace InfluxDB.Client.Test
             await _client.VersionAsync();
 
             Assert.IsTrue(reached);
+        }
+
+        [Test]
+        public void TestMocking()
+        {
+            var mockClient = new Mock<IInfluxDBClient>();
+            var mockQueryApi = new Mock<IQueryApiSync>();
+
+            mockClient
+                .Setup(library => library.GetQueryApiSync(null))
+                .Returns(mockQueryApi.Object);
+
+            var mockTables = new List<FluxTable> { new FluxTable() };
+            mockQueryApi
+                .Setup(api => api.QuerySync("from(...", "my-org", CancellationToken.None))
+                .Returns(mockTables);
+
+            var tables = mockClient.Object.GetQueryApiSync().QuerySync("from(...", "my-org");
+            Assert.AreEqual(mockTables, tables);
         }
     }
 }

--- a/Client/AuthorizationsApi.cs
+++ b/Client/AuthorizationsApi.cs
@@ -9,7 +9,134 @@ using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client
 {
-    public class AuthorizationsApi
+    public interface IAuthorizationsApi
+    {
+        /// <summary>
+        /// Create an authorization with defined permissions.
+        /// </summary>
+        /// <param name="organization">the owner of the authorization</param>
+        /// <param name="permissions">the permissions for the authorization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the created authorization</returns>
+        Task<Authorization> CreateAuthorizationAsync(Organization organization, List<Permission> permissions,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create an authorization with defined permissions.
+        /// </summary>
+        /// <param name="orgId">the owner id of the authorization</param>
+        /// <param name="permissions">the permissions for the authorization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the created authorization</returns>
+        Task<Authorization> CreateAuthorizationAsync(string orgId, List<Permission> permissions,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create an authorization with defined permissions.
+        /// </summary>
+        /// <param name="authorization">authorization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the created authorization</returns>
+        Task<Authorization> CreateAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create an authorization with defined permissions.
+        /// </summary>
+        /// <param name="authorization">authorization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the created authorization</returns>
+        Task<Authorization> CreateAuthorizationAsync(AuthorizationPostRequest authorization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Updates the status of the authorization. Useful for setting an authorization to inactive or active.
+        /// </summary>
+        /// <param name="authorization">the authorization with updated status</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the updated authorization</returns>
+        Task<Authorization> UpdateAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an authorization.
+        /// </summary>
+        /// <param name="authorization">authorization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>authorization deleted</returns>
+        Task DeleteAuthorizationAsync(Authorization authorization, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an authorization.
+        /// </summary>
+        /// <param name="authorizationId">ID of authorization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>authorization deleted</returns>
+        Task DeleteAuthorizationAsync(string authorizationId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an authorization.
+        /// </summary>
+        /// <param name="authorizationId">ID of authorization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned authorization</returns>
+        Task<Authorization> CloneAuthorizationAsync(string authorizationId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an authorization.
+        /// </summary>
+        /// <param name="authorization">authorization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned authorization</returns>
+        Task<Authorization> CloneAuthorizationAsync(Authorization authorization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve an authorization.
+        /// </summary>
+        /// <param name="authorizationId">ID of authorization to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>authorization details</returns>
+        Task<Authorization> FindAuthorizationByIdAsync(string authorizationId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all authorizations.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List all authorizations.</returns>
+        Task<List<Authorization>> FindAuthorizationsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all authorizations belonging to specified user.
+        /// </summary>
+        /// <param name="user">user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of authorizations</returns>
+        Task<List<Authorization>> FindAuthorizationsByUserAsync(User user,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all authorizations belonging to specified user.
+        /// </summary>
+        /// <param name="userId">ID of user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of authorizations</returns>
+        Task<List<Authorization>> FindAuthorizationsByUserIdAsync(string userId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all authorizations belonging to specified user.
+        /// </summary>
+        /// <param name="userName">Name of User</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of authorizations</returns>
+        Task<List<Authorization>> FindAuthorizationsByUserNameAsync(string userName,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class AuthorizationsApi : IAuthorizationsApi
     {
         private readonly AuthorizationsService _service;
 

--- a/Client/BucketsApi.cs
+++ b/Client/BucketsApi.cs
@@ -10,7 +10,333 @@ using InfluxDB.Client.Domain;
 
 namespace InfluxDB.Client
 {
-    public class BucketsApi
+    public interface IBucketsApi
+    {
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="bucket">bucket to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="bucket">bucket to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(PostBucketRequest bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">name of the bucket</param>
+        /// <param name="organization">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(string name, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">name of the bucket</param>
+        /// <param name="bucketRetentionRules">retention rule of the bucket</param>
+        /// <param name="organization">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules,
+            Organization organization, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">name of the bucket</param>
+        /// <param name="orgId">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(string name, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new bucket and sets <see cref="Bucket.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">name of the bucket</param>
+        /// <param name="bucketRetentionRules">retention rule of the bucket</param>
+        /// <param name="orgId">owner of the bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Bucket</returns>
+        Task<Bucket> CreateBucketAsync(string name, BucketRetentionRules bucketRetentionRules, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a bucket name and retention.
+        /// </summary>
+        /// <param name="bucket">bucket update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>bucket updated</returns>
+        Task<Bucket> UpdateBucketAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a bucket.
+        /// </summary>
+        /// <param name="bucketId">ID of bucket to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteBucketAsync(string bucketId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a bucket.
+        /// </summary>
+        /// <param name="bucket">bucket to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteBucketAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a bucket.
+        /// </summary>
+        /// <param name="clonedName">name of cloned bucket</param>
+        /// <param name="bucketId">ID of bucket to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned bucket</returns>
+        Task<Bucket> CloneBucketAsync(string clonedName, string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a bucket.
+        /// </summary>
+        /// <param name="clonedName">name of cloned bucket</param>
+        /// <param name="bucket">bucket to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned bucket</returns>
+        Task<Bucket> CloneBucketAsync(string clonedName, Bucket bucket,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a bucket.
+        /// </summary>
+        /// <param name="bucketId">ID of bucket to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Bucket Details</returns>
+        Task<Bucket> FindBucketByIdAsync(string bucketId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a bucket.
+        /// </summary>
+        /// <param name="bucketName">Name of bucket to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Bucket Details</returns>
+        Task<Bucket> FindBucketByNameAsync(string bucketName,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all buckets for specified organization.
+        /// </summary>
+        /// <param name="organization">filter buckets to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of buckets</returns>
+        Task<List<Bucket>> FindBucketsByOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all buckets for specified orgId.
+        /// </summary>
+        /// <param name="orgName">filter buckets to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of buckets</returns>
+        Task<List<Bucket>> FindBucketsByOrgNameAsync(string orgName,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all buckets.
+        /// </summary>
+        /// <param name="offset"> (optional)</param>
+        /// <param name="limit"> (optional, default to 20)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
+        /// <param name="org">The name of the organization. (optional)</param>
+        /// <param name="orgID">The organization ID. (optional)</param>
+        /// <param name="name">Only returns buckets with a specific name. (optional)</param>
+        /// <param name="id">Only returns buckets with a specific ID. (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List all buckets</returns>
+        Task<List<Bucket>> FindBucketsAsync(int? offset = null, int? limit = null, string after = null,
+            string org = null, string orgID = null, string name = null, string id = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all buckets.
+        /// </summary>
+        /// <param name="findOptions">the find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List all buckets</returns>
+        Task<Buckets> FindBucketsAsync(FindOptions findOptions, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a bucket.
+        /// </summary>
+        /// <param name="bucket">bucket of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a bucket</returns>
+        Task<List<ResourceMember>> GetMembersAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a bucket.
+        /// </summary>
+        /// <param name="bucketId">ID of bucket to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a bucket</returns>
+        Task<List<ResourceMember>> GetMembersAsync(string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket member.
+        /// </summary>
+        /// <param name="member">the member of a bucket</param>
+        /// <param name="bucket">the bucket of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(User member, Bucket bucket,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket member.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(string memberId, string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a bucket.
+        /// </summary>
+        /// <param name="member">the member of a bucket</param>
+        /// <param name="bucket">the bucket of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(User member, Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a bucket.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(string memberId, string bucketId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a bucket.
+        /// </summary>
+        /// <param name="bucket">bucket of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a bucket</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a bucket.
+        /// </summary>
+        /// <param name="bucketId">ID of a bucket to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a bucket</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket owner.
+        /// </summary>
+        /// <param name="owner">the owner of a bucket</param>
+        /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(User owner, Bucket bucket,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket owner.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(string ownerId, string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a bucket.
+        /// </summary>
+        /// <param name="owner">the owner of a bucket</param>
+        /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(User owner, Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a bucket.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(string ownerId, string bucketId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a bucket.
+        /// </summary>
+        /// <param name="bucket">bucket of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a bucket</returns>
+        Task<List<Label>> GetLabelsAsync(Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a bucket.
+        /// </summary>
+        /// <param name="bucketId">ID of a bucket to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a bucket</returns>
+        Task<List<Label>> GetLabelsAsync(string bucketId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket label.
+        /// </summary>
+        /// <param name="label">the label of a bucket</param>
+        /// <param name="bucket">the bucket of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(Label label, Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a bucket label.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(string labelId, string bucketId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a bucket.
+        /// </summary>
+        /// <param name="label">the label of a bucket</param>
+        /// <param name="bucket">the bucket of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(Label label, Bucket bucket, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a bucket.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="bucketId">the ID of a bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(string labelId, string bucketId, CancellationToken cancellationToken = default);
+    }
+
+    public class BucketsApi : IBucketsApi
     {
         private readonly BucketsService _service;
 

--- a/Client/ChecksApi.cs
+++ b/Client/ChecksApi.cs
@@ -9,10 +9,180 @@ using InfluxDB.Client.Domain;
 
 namespace InfluxDB.Client
 {
+    public interface IChecksApi
+    {
+        /// <summary>
+        /// Add new Threshold check.
+        /// </summary>
+        /// <param name="name">the check name</param>
+        /// <param name="query">The text of the flux query</param>
+        /// <param name="every">Check repetition interval</param>
+        /// <param name="messageTemplate">template that is used to generate and write a status message</param>
+        /// <param name="threshold">condition for that specific status</param>
+        /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>ThresholdCheck created</returns>
+        Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query, string every,
+            string messageTemplate, Threshold threshold, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new Threshold check.
+        /// </summary>
+        /// <param name="name">the check name</param>
+        /// <param name="query">The text of the flux query</param>
+        /// <param name="every">Check repetition interval</param>
+        /// <param name="messageTemplate">template that is used to generate and write a status message</param>
+        /// <param name="thresholds">conditions for that specific status</param>
+        /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>ThresholdCheck created</returns>
+        Task<ThresholdCheck> CreateThresholdCheckAsync(string name, string query, string every,
+            string messageTemplate, List<Threshold> thresholds, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new Deadman check.
+        /// </summary>
+        /// <param name="name">the check name</param>
+        /// <param name="query">The text of the flux query</param>
+        /// <param name="every">Check repetition interval</param>
+        /// <param name="timeSince">string duration before deadman triggers</param>
+        /// <param name="staleTime">string duration for time that a series is considered stale and should not trigger deadman</param>
+        /// <param name="messageTemplate">template that is used to generate and write a status message</param>
+        /// <param name="level">the state to record if check matches a criteria</param>
+        /// <param name="orgId">the organization that owns this check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>DeadmanCheck created</returns>
+        Task<DeadmanCheck> CreateDeadmanCheckAsync(string name, string query, string every,
+            string timeSince, string staleTime, string messageTemplate, CheckStatusLevel level, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new check.
+        /// </summary>
+        /// <param name="check">check to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Check created</returns>
+        Task<Check> CreateCheckAsync(Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a check.
+        /// </summary>
+        /// <param name="check">check update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated check</returns>
+        Task<Check> UpdateCheckAsync(Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a check.
+        /// </summary>
+        /// <param name="checkId">ID of check</param>
+        /// <param name="patch">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated check</returns>
+        Task<Check> UpdateCheckAsync(string checkId, CheckPatch patch,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a check.
+        /// </summary>
+        /// <param name="check">the check to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteCheckAsync(Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a check.
+        /// </summary>
+        /// <param name="checkId">checkID the ID of check to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteCheckAsync(string checkId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a check.
+        /// </summary>
+        /// <param name="checkId">ID of check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the check requested</returns>
+        Task<Check> FindCheckByIdAsync(string checkId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get checks.
+        /// </summary>
+        /// <param name="orgId">only show checks belonging to specified organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of checks</returns>
+        Task<List<Check>> FindChecksAsync(string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all checks.
+        /// </summary>
+        /// <param name="orgId">only show checks belonging to specified organization</param>
+        /// <param name="findOptions">find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of checks</returns>
+        Task<Checks> FindChecksAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a check.
+        /// </summary>
+        /// <param name="check"> the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a check</returns>
+        Task<List<Label>> GetLabelsAsync(Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a check.
+        /// </summary>
+        /// <param name="checkId">ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a check</returns>
+        Task<List<Label>> GetLabelsAsync(string checkId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a check.
+        /// </summary>
+        /// <param name="label">label to add</param>
+        /// <param name="check">the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the label was added to the check</returns>
+        Task<Label> AddLabelAsync(Label label, Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a check.
+        /// </summary>
+        /// <param name="labelId">ID of label to add</param>
+        /// <param name="checkId">ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the label was added to the check</returns>
+        Task<Label> AddLabelAsync(string labelId, string checkId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a check.
+        /// </summary>
+        /// <param name="label">the label to delete</param>
+        /// <param name="check">the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteLabelAsync(Label label, Check check, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a check.
+        /// </summary>
+        /// <param name="labelId">labelID the label id to delete</param>
+        /// <param name="checkId">checkID ID of the check</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteLabelAsync(string labelId, string checkId, CancellationToken cancellationToken = default);
+    }
+
     /// <summary>
     /// The client of the InfluxDB 2.x that implement Check Api.
     /// </summary>
-    public class ChecksApi
+    public class ChecksApi : IChecksApi
     {
         private readonly ChecksService _service;
 

--- a/Client/DeleteApi.cs
+++ b/Client/DeleteApi.cs
@@ -7,7 +7,44 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class DeleteApi
+    public interface IDeleteApi
+    {
+        /// <summary>
+        /// Delete Time series data from InfluxDB.
+        /// </summary>
+        /// <param name="start">Start time</param>
+        /// <param name="stop">Stop time</param>
+        /// <param name="predicate">Sql where like delete statement</param>
+        /// <param name="bucket">The bucket from which data will be deleted</param>
+        /// <param name="org">The organization of the above bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task Delete(DateTime start, DateTime stop, string predicate, Bucket bucket, Organization org,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete Time series data from InfluxDB.
+        /// </summary>
+        /// <param name="start">Start time</param>
+        /// <param name="stop">Stop time</param>
+        /// <param name="predicate">Sql where like delete statement</param>
+        /// <param name="bucket">The bucket from which data will be deleted</param>
+        /// <param name="org">The organization of the above bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task Delete(DateTime start, DateTime stop, string predicate, string bucket, string org,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete Time series data from InfluxDB.
+        /// </summary>
+        /// <param name="predicate">Predicate delete request</param>
+        /// <param name="bucket">The bucket from which data will be deleted</param>
+        /// <param name="org">The organization of the above bucket</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task Delete(DeletePredicateRequest predicate, string bucket, string org,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class DeleteApi : IDeleteApi
     {
         private readonly DeleteService _service;
 

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -14,7 +14,210 @@ using InfluxDB.Client.Internal;
 
 namespace InfluxDB.Client
 {
-    public class InfluxDBClient : AbstractRestClient, IDisposable
+    public interface IInfluxDBClient : IDisposable
+    {
+        /// <summary>
+        /// Get the Query client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping FluxResults to POCO</param>
+        /// <returns>the new client instance for the Query API</returns>
+        IQueryApi GetQueryApi(IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Get the synchronous version of Query client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping FluxResults to POCO</param>
+        /// <returns>the new synchronous client instance for the Query API</returns>
+        IQueryApiSync GetQueryApiSync(IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Get the Write client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API</returns>
+        IWriteApi GetWriteApi(IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Get the Write client.
+        /// </summary>
+        /// <param name="writeOptions">the configuration for a write client</param>
+        /// <param name="mapper">the converter used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API</returns>
+        IWriteApi GetWriteApi(WriteOptions writeOptions, IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Get the Write async client.
+        /// </summary>
+        /// <param name="mapper">the converter used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API Async without batching</returns>
+        IWriteApiAsync GetWriteApiAsync(IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Get the <see cref="Organization" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Organization API</returns>
+        IOrganizationsApi GetOrganizationsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.User" /> client.
+        /// </summary>
+        /// <returns>the new client instance for User API</returns>
+        IUsersApi GetUsersApi();
+
+        /// <summary>
+        /// Get the <see cref="Bucket" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Bucket API</returns>
+        IBucketsApi GetBucketsApi();
+
+        /// <summary>
+        /// Get the <see cref="Source" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Source API</returns>
+        ISourcesApi GetSourcesApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Authorization" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Authorization API</returns>
+        IAuthorizationsApi GetAuthorizationsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.TaskType" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Task API</returns>
+        ITasksApi GetTasksApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.ScraperTargetResponse" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Scraper API</returns>
+        IScraperTargetsApi GetScraperTargetsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Telegraf" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Telegrafs API</returns>
+        ITelegrafsApi GetTelegrafsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Label" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Label API</returns>
+        ILabelsApi GetLabelsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.NotificationEndpoint" /> client.
+        /// </summary>
+        /// <returns>the new client instance for NotificationEndpoint API</returns>
+        INotificationEndpointsApi GetNotificationEndpointsApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.NotificationRules" /> client.
+        /// </summary>
+        /// <returns>the new client instance for NotificationRules API</returns>
+        INotificationRulesApi GetNotificationRulesApi();
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Check" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Checks API</returns>
+        IChecksApi GetChecksApi();
+
+        /// <summary>
+        /// Get the Delete client.
+        /// </summary>
+        /// <returns>the new client instance for Delete API</returns>
+        IDeleteApi GetDeleteApi();
+
+        /// <summary>
+        /// Create an InvokableScripts API instance.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping invocation results to POCO</param>
+        /// <returns>New instance of InvokableScriptsApi.</returns>
+        IInvokableScriptsApi GetInvokableScriptsApi(IDomainObjectMapper mapper = null);
+
+        /// <summary>
+        /// Create a service for specified type.
+        /// </summary>
+        /// <param name="serviceType">type of service</param>
+        /// <typeparam name="TS">type of service</typeparam>
+        /// <returns>new instance of service</returns>
+        TS CreateService<TS>(Type serviceType) where TS : IApiAccessor;
+
+        /// <summary>
+        /// Set the log level for the request and response information.
+        /// </summary>
+        /// <param name="logLevel">the log level to set</param>
+        void SetLogLevel(LogLevel logLevel);
+
+        /// <summary>
+        /// Set the <see cref="LogLevel" /> that is used for logging requests and responses.
+        /// </summary>
+        /// <returns>Log Level</returns>
+        LogLevel GetLogLevel();
+
+        /// <summary>
+        /// Enable Gzip compress for http requests.
+        ///
+        /// <para>Currently only the "Write" and "Query" endpoints supports the Gzip compression.</para>
+        /// </summary>
+        /// <returns></returns>
+        IInfluxDBClient EnableGzip();
+
+        /// <summary>
+        /// Disable Gzip compress for http request body.
+        /// </summary>
+        /// <returns>this</returns>
+        IInfluxDBClient DisableGzip();
+
+        /// <summary>
+        /// Returns whether Gzip compress for http request body is enabled.
+        /// </summary>
+        /// <returns>true if gzip is enabled.</returns>
+        bool IsGzipEnabled();
+
+        /// <summary>
+        /// Get the health of an instance.
+        /// </summary>
+        /// <returns>health of an instance</returns>
+        Task<HealthCheck> HealthAsync();
+
+        /// <summary>
+        /// Check the status of InfluxDB Server.
+        /// </summary>
+        /// <returns>true if server is healthy otherwise return false</returns>
+        Task<bool> PingAsync();
+
+        /// <summary>
+        ///  Return the version of the connected InfluxDB Server.
+        /// </summary>
+        /// <returns>the version String, otherwise unknown</returns>
+        /// <exception cref="InfluxException">throws when request did not succesfully ends</exception>
+        Task<string> VersionAsync();
+
+        /// <summary>
+        /// Check the readiness of InfluxDB Server at startup. It is not supported by InfluxDB Cloud. 
+        /// </summary>
+        /// <returns>return null if the InfluxDB is not ready</returns>
+        Task<Ready> ReadyAsync();
+
+        /// <summary>
+        /// Post onboarding request, to setup initial user, org and bucket.
+        /// </summary>
+        /// <param name="onboarding">to setup defaults</param>
+        /// <exception cref="HttpException">With status code 422 when an onboarding has already been completed</exception>
+        /// <returns>defaults for first run</returns>
+        Task<OnboardingResponse> OnboardingAsync(OnboardingRequest onboarding);
+
+        /// <summary>
+        /// Check if database has default user, org, bucket created, returns true if not.
+        /// </summary>
+        /// <returns>True if onboarding has already been completed otherwise false</returns>
+        Task<bool> IsOnboardingAllowedAsync();
+    }
+
+    public class InfluxDBClient : AbstractRestClient, IInfluxDBClient
     {
         private readonly ApiClient _apiClient;
         private readonly ExceptionFactory _exceptionFactory;
@@ -91,6 +294,16 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="mapper">the mapper used for mapping FluxResults to POCO</param>
         /// <returns>the new client instance for the Query API</returns>
+        IQueryApi IInfluxDBClient.GetQueryApi(IDomainObjectMapper mapper)
+        {
+            return GetQueryApi(mapper);
+        }
+
+        /// <summary>
+        /// Get the Query client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping FluxResults to POCO</param>
+        /// <returns>the new client instance for the Query API</returns>
         public QueryApi GetQueryApi(IDomainObjectMapper mapper = null)
         {
             var service = new QueryService((Configuration)_apiClient.Configuration)
@@ -99,6 +312,16 @@ namespace InfluxDB.Client
             };
 
             return new QueryApi(_options, service, mapper ?? new DefaultDomainObjectMapper());
+        }
+
+        /// <summary>
+        /// Get the synchronous version of Query client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping FluxResults to POCO</param>
+        /// <returns>the new synchronous client instance for the Query API</returns>
+        IQueryApiSync IInfluxDBClient.GetQueryApiSync(IDomainObjectMapper mapper)
+        {
+            return GetQueryApiSync(mapper);
         }
 
         /// <summary>
@@ -121,9 +344,29 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="mapper">the mapper used for mapping to PointData</param>
         /// <returns>the new client instance for the Write API</returns>
+        IWriteApi IInfluxDBClient.GetWriteApi(IDomainObjectMapper mapper)
+        {
+            return GetWriteApi(mapper);
+        }
+
+        /// <summary>
+        /// Get the Write client.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API</returns>
         public WriteApi GetWriteApi(IDomainObjectMapper mapper = null)
         {
             return GetWriteApi(WriteOptions.CreateNew().Build(), mapper);
+        }
+
+        /// <summary>
+        /// Get the Write async client.
+        /// </summary>
+        /// <param name="mapper">the converter used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API Async without batching</returns>
+        IWriteApiAsync IInfluxDBClient.GetWriteApiAsync(IDomainObjectMapper mapper)
+        {
+            return GetWriteApiAsync(mapper);
         }
 
         /// <summary>
@@ -139,6 +382,17 @@ namespace InfluxDB.Client
             };
 
             return new WriteApiAsync(_options, service, mapper ?? new DefaultDomainObjectMapper(), this);
+        }
+
+        /// <summary>
+        /// Get the Write client.
+        /// </summary>
+        /// <param name="writeOptions">the configuration for a write client</param>
+        /// <param name="mapper">the converter used for mapping to PointData</param>
+        /// <returns>the new client instance for the Write API</returns>
+        IWriteApi IInfluxDBClient.GetWriteApi(WriteOptions writeOptions, IDomainObjectMapper mapper)
+        {
+            return GetWriteApi(writeOptions, mapper);
         }
 
         /// <summary>
@@ -164,6 +418,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="Organization" /> client.
         /// </summary>
         /// <returns>the new client instance for Organization API</returns>
+        IOrganizationsApi IInfluxDBClient.GetOrganizationsApi()
+        {
+            return GetOrganizationsApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="Organization" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Organization API</returns>
         public OrganizationsApi GetOrganizationsApi()
         {
             var service = new OrganizationsService((Configuration)_apiClient.Configuration)
@@ -176,6 +439,15 @@ namespace InfluxDB.Client
             };
 
             return new OrganizationsApi(service, secretService);
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.User" /> client.
+        /// </summary>
+        /// <returns>the new client instance for User API</returns>
+        IUsersApi IInfluxDBClient.GetUsersApi()
+        {
+            return GetUsersApi();
         }
 
         /// <summary>
@@ -196,6 +468,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="Bucket" /> client.
         /// </summary>
         /// <returns>the new client instance for Bucket API</returns>
+        IBucketsApi IInfluxDBClient.GetBucketsApi()
+        {
+            return GetBucketsApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="Bucket" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Bucket API</returns>
         public BucketsApi GetBucketsApi()
         {
             var service = new BucketsService((Configuration)_apiClient.Configuration)
@@ -204,6 +485,15 @@ namespace InfluxDB.Client
             };
 
             return new BucketsApi(service);
+        }
+
+        /// <summary>
+        /// Get the <see cref="Source" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Source API</returns>
+        ISourcesApi IInfluxDBClient.GetSourcesApi()
+        {
+            return GetSourcesApi();
         }
 
         /// <summary>
@@ -224,6 +514,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="InfluxDB.Client.Api.Domain.Authorization" /> client.
         /// </summary>
         /// <returns>the new client instance for Authorization API</returns>
+        IAuthorizationsApi IInfluxDBClient.GetAuthorizationsApi()
+        {
+            return GetAuthorizationsApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Authorization" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Authorization API</returns>
         public AuthorizationsApi GetAuthorizationsApi()
         {
             var service = new AuthorizationsService((Configuration)_apiClient.Configuration)
@@ -235,7 +534,16 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
-        /// Get the <see cref="InfluxDB.Client.Api.Domain.Task" /> client.
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.TaskType" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Task API</returns>
+        ITasksApi IInfluxDBClient.GetTasksApi()
+        {
+            return GetTasksApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.TaskType" /> client.
         /// </summary>
         /// <returns>the new client instance for Task API</returns>
         public TasksApi GetTasksApi()
@@ -246,6 +554,15 @@ namespace InfluxDB.Client
             };
 
             return new TasksApi(service);
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.ScraperTargetResponse" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Scraper API</returns>
+        IScraperTargetsApi IInfluxDBClient.GetScraperTargetsApi()
+        {
+            return GetScraperTargetsApi();
         }
 
         /// <summary>
@@ -266,6 +583,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="InfluxDB.Client.Api.Domain.Telegraf" /> client.
         /// </summary>
         /// <returns>the new client instance for Telegrafs API</returns>
+        ITelegrafsApi IInfluxDBClient.GetTelegrafsApi()
+        {
+            return GetTelegrafsApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Telegraf" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Telegrafs API</returns>
         public TelegrafsApi GetTelegrafsApi()
         {
             var service = new TelegrafsService((Configuration)_apiClient.Configuration)
@@ -274,6 +600,15 @@ namespace InfluxDB.Client
             };
 
             return new TelegrafsApi(service);
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Label" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Label API</returns>
+        ILabelsApi IInfluxDBClient.GetLabelsApi()
+        {
+            return GetLabelsApi();
         }
 
         /// <summary>
@@ -294,6 +629,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="InfluxDB.Client.Api.Domain.NotificationEndpoint" /> client.
         /// </summary>
         /// <returns>the new client instance for NotificationEndpoint API</returns>
+        INotificationEndpointsApi IInfluxDBClient.GetNotificationEndpointsApi()
+        {
+            return GetNotificationEndpointsApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.NotificationEndpoint" /> client.
+        /// </summary>
+        /// <returns>the new client instance for NotificationEndpoint API</returns>
         public NotificationEndpointsApi GetNotificationEndpointsApi()
         {
             var service = new NotificationEndpointsService((Configuration)_apiClient.Configuration)
@@ -302,6 +646,15 @@ namespace InfluxDB.Client
             };
 
             return new NotificationEndpointsApi(service);
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.NotificationRules" /> client.
+        /// </summary>
+        /// <returns>the new client instance for NotificationRules API</returns>
+        INotificationRulesApi IInfluxDBClient.GetNotificationRulesApi()
+        {
+            return GetNotificationRulesApi();
         }
 
         /// <summary>
@@ -322,6 +675,15 @@ namespace InfluxDB.Client
         /// Get the <see cref="InfluxDB.Client.Api.Domain.Check" /> client.
         /// </summary>
         /// <returns>the new client instance for Checks API</returns>
+        IChecksApi IInfluxDBClient.GetChecksApi()
+        {
+            return GetChecksApi();
+        }
+
+        /// <summary>
+        /// Get the <see cref="InfluxDB.Client.Api.Domain.Check" /> client.
+        /// </summary>
+        /// <returns>the new client instance for Checks API</returns>
         public ChecksApi GetChecksApi()
         {
             var service = new ChecksService((Configuration)_apiClient.Configuration)
@@ -336,6 +698,15 @@ namespace InfluxDB.Client
         /// Get the Delete client.
         /// </summary>
         /// <returns>the new client instance for Delete API</returns>
+        IDeleteApi IInfluxDBClient.GetDeleteApi()
+        {
+            return GetDeleteApi();
+        }
+
+        /// <summary>
+        /// Get the Delete client.
+        /// </summary>
+        /// <returns>the new client instance for Delete API</returns>
         public DeleteApi GetDeleteApi()
         {
             var service = new DeleteService((Configuration)_apiClient.Configuration)
@@ -344,6 +715,16 @@ namespace InfluxDB.Client
             };
 
             return new DeleteApi(service);
+        }
+
+        /// <summary>
+        /// Create an InvokableScripts API instance.
+        /// </summary>
+        /// <param name="mapper">the mapper used for mapping invocation results to POCO</param>
+        /// <returns>New instance of InvokableScriptsApi.</returns>
+        IInvokableScriptsApi IInfluxDBClient.GetInvokableScriptsApi(IDomainObjectMapper mapper)
+        {
+            return GetInvokableScriptsApi(mapper);
         }
 
         /// <summary>
@@ -401,11 +782,31 @@ namespace InfluxDB.Client
         /// <para>Currently only the "Write" and "Query" endpoints supports the Gzip compression.</para>
         /// </summary>
         /// <returns></returns>
+        IInfluxDBClient IInfluxDBClient.EnableGzip()
+        {
+            return EnableGzip();
+        }
+
+        /// <summary>
+        /// Enable Gzip compress for http requests.
+        ///
+        /// <para>Currently only the "Write" and "Query" endpoints supports the Gzip compression.</para>
+        /// </summary>
+        /// <returns></returns>
         public InfluxDBClient EnableGzip()
         {
             _gzipHandler.EnableGzip();
 
             return this;
+        }
+
+        /// <summary>
+        /// Disable Gzip compress for http request body.
+        /// </summary>
+        /// <returns>this</returns>
+        IInfluxDBClient IInfluxDBClient.DisableGzip()
+        {
+            return DisableGzip();
         }
 
         /// <summary>

--- a/Client/InvokableScriptsApi.cs
+++ b/Client/InvokableScriptsApi.cs
@@ -14,7 +14,101 @@ using RestSharp;
 
 namespace InfluxDB.Client
 {
-    public class InvokableScriptsApi : AbstractQueryClient
+    public interface IInvokableScriptsApi
+    {
+        /// <summary>
+        /// Create a script.
+        /// </summary>
+        /// <param name="createRequest">The script to create.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The created script.</returns>
+        Task<Script> CreateScriptAsync(ScriptCreateRequest createRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a script.
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to update. (required)</param>
+        /// <param name="updateRequest">Script updates to apply (required)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The updated script.</returns>
+        Task<Script> UpdateScriptAsync(string scriptId, ScriptUpdateRequest updateRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a script.
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to delete. (required)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteScriptAsync(string scriptId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List scripts.
+        /// </summary>
+        /// <param name="offset">The offset for pagination.</param>
+        /// <param name="limit">The number of scripts to return.</param>
+        /// <param name="cancellationToken"></param>
+        /// <returns>[Script]</returns>
+        Task<List<Script>> FindScriptsAsync(int? offset = null, int? limit = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invoke a script and return result as a [FluxTable].
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to invoke. (required)</param>
+        /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>[FluxTable]</returns>
+        Task<List<FluxTable>> InvokeScriptAsync(string scriptId,
+            Dictionary<string, object> bindParams = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invoke a script and return result as a [T].
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to invoke. (required)</param>
+        /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>[T]</returns>
+        Task<List<T>> InvokeScriptMeasurementsAsync<T>(string scriptId,
+            Dictionary<string, object> bindParams = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invoke a script and return result as a raw string.
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to invoke. (required)</param>
+        /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>String</returns>
+        Task<string> InvokeScriptRawAsync(string scriptId, Dictionary<string, object> bindParams = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invoke a script and return result as a stream of FluxRecord.
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to invoke. (required)</param>
+        /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>stream of FluxRecord</returns>
+        IAsyncEnumerable<FluxRecord> InvokeScriptEnumerableAsync(string scriptId,
+            Dictionary<string, object> bindParams = default,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Invoke a script and return result as a stream of Measurement.
+        /// </summary>
+        /// <param name="scriptId">The ID of the script to invoke. (required)</param>
+        /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>stream of Measurement</returns>
+        IAsyncEnumerable<T> InvokeScriptMeasurementsEnumerableAsync<T>(string scriptId,
+            Dictionary<string, object> bindParams = default,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class InvokableScriptsApi : AbstractQueryClient, IInvokableScriptsApi
     {
         private readonly InvokableScriptsService _service;
 

--- a/Client/LabelsApi.cs
+++ b/Client/LabelsApi.cs
@@ -8,7 +8,117 @@ using Task = System.Threading.Tasks.Task;
 
 namespace InfluxDB.Client
 {
-    public class LabelsApi
+    public interface ILabelsApi
+    {
+        /// <summary>
+        /// Create a label
+        /// </summary>
+        /// <param name="request">label to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Added label</returns>
+        Task<Label> CreateLabelAsync(LabelCreateRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a label
+        /// </summary>
+        /// <param name="name">name of a label</param>
+        /// <param name="properties">properties of a label</param>
+        /// <param name="orgId">owner of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Added label</returns>
+        Task<Label> CreateLabelAsync(string name, Dictionary<string, string> properties,
+            string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a single label
+        /// </summary>
+        /// <param name="label">label to update</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Updated label</returns>
+        Task<Label> UpdateLabelAsync(Label label, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a single label
+        /// </summary>
+        /// <param name="labelId">ID of label to update</param>
+        /// <param name="labelUpdate">label update</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Updated label</returns>
+        Task<Label> UpdateLabelAsync(string labelId, LabelUpdate labelUpdate,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a label.
+        /// </summary>
+        /// <param name="label">label to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(Label label, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a label.
+        /// </summary>
+        /// <param name="labelId">ID of label to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(string labelId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a label.
+        /// </summary>
+        /// <param name="clonedName">name of cloned label</param>
+        /// <param name="labelId">ID of label to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned label</returns>
+        Task<Label> CloneLabelAsync(string clonedName, string labelId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a label.
+        /// </summary>
+        /// <param name="clonedName">name of cloned label</param>
+        /// <param name="label">label to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned label</returns>
+        Task<Label> CloneLabelAsync(string clonedName, Label label,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a label.
+        /// </summary>
+        /// <param name="labelId">ID of a label to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Label detail</returns>
+        Task<Label> FindLabelByIdAsync(string labelId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels.
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// </summary>
+        /// <returns>List all labels.</returns>
+        Task<List<Label>> FindLabelsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all labels.
+        /// </summary>
+        /// <param name="organization">specifies the organization of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>all labels</returns>
+        Task<List<Label>> FindLabelsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all labels.
+        /// </summary>
+        /// <param name="orgId">specifies the organization ID of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>all labels</returns>
+        Task<List<Label>> FindLabelsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class LabelsApi : ILabelsApi
     {
         private readonly LabelsService _service;
 

--- a/Client/NotificationEndpointsApi.cs
+++ b/Client/NotificationEndpointsApi.cs
@@ -9,7 +9,325 @@ using InfluxDB.Client.Domain;
 
 namespace InfluxDB.Client
 {
-    public class NotificationEndpointsApi
+    public interface INotificationEndpointsApi
+    {
+        /// <summary>
+        /// Add new Slack notification endpoint. The 'url' should be defined.
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="url">Slack WebHook URL</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Slack notification endpoint</returns>
+        Task<SlackNotificationEndpoint> CreateSlackEndpointAsync(string name, string url, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        ///  Add new Slack notification endpoint. The 'url' should be defined.
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="url">Slack WebHook URL</param>
+        /// <param name="token">Slack WebHook Token</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Slack notification endpoint</returns>
+        Task<SlackNotificationEndpoint> CreateSlackEndpointAsync(string name, string url, string token,
+            string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new PagerDuty notification endpoint.
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="clientUrl">Client URL</param>
+        /// <param name="routingKey">Routing Key</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created PagerDuty notification endpoint</returns>
+        Task<PagerDutyNotificationEndpoint> CreatePagerDutyEndpointAsync(string name, string clientUrl,
+            string routingKey, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new HTTP notification endpoint without authentication.
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="url">URL</param>
+        /// <param name="method">HTTP Method</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created HTTP notification endpoint</returns>
+        Task<HTTPNotificationEndpoint> CreateHttpEndpointAsync(string name, string url,
+            HTTPNotificationEndpoint.MethodEnum method, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="url">URL</param>
+        /// <param name="method">HTTP Method</param>
+        /// <param name="username">HTTP Basic Username</param>
+        /// <param name="password">HTTP Basic Password</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created HTTP notification endpoint</returns>
+        Task<HTTPNotificationEndpoint> CreateHttpEndpointBasicAuthAsync(string name, string url,
+            HTTPNotificationEndpoint.MethodEnum method, string username, string password, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name">Endpoint name</param>
+        /// <param name="url">URL</param>
+        /// <param name="method">HTTP Method</param>
+        /// <param name="token">Bearer token</param>
+        /// <param name="orgId">Owner of an endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created HTTP notification endpoint</returns>
+        Task<HTTPNotificationEndpoint> CreateHttpEndpointBearerAsync(string name, string url,
+            HTTPNotificationEndpoint.MethodEnum method, string token, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add new notification endpoint.
+        /// </summary>
+        /// <param name="notificationEndpoint">notificationEndpoint to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint created</returns>
+        Task<NotificationEndpoint> CreateEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a notification endpoint. The updates is used for fields from <see cref="NotificationEndpointUpdate"/>.
+        /// </summary>
+        /// <param name="notificationEndpoint">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated notification endpoint</returns>
+        Task<NotificationEndpoint> UpdateEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a notification endpoint.
+        /// </summary>
+        /// <param name="endpointId">ID of notification endpoint</param>
+        /// <param name="notificationEndpointUpdate">update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated notification endpoint</returns>
+        Task<NotificationEndpoint> UpdateEndpointAsync(string endpointId,
+            NotificationEndpointUpdate notificationEndpointUpdate, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a notification endpoint.
+        /// </summary>
+        /// <param name="notificationEndpoint">notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted></returns>
+        Task DeleteNotificationEndpointAsync(NotificationEndpoint notificationEndpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a notification endpoint.
+        /// </summary>
+        /// <param name="endpointId">ID of notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteNotificationEndpointAsync(string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get notification endpoints.
+        /// </summary>
+        /// <param name="orgId">only show notification endpoints belonging to specified organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of notification endpoint</returns>
+        Task<List<NotificationEndpoint>> FindNotificationEndpointsAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all notification endpoints.
+        /// </summary>
+        /// <param name="orgId">only show notification endpoints belonging to specified organization</param>
+        /// <param name="findOptions">the find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task<NotificationEndpoints> FindNotificationEndpointsAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a notification endpoint.
+        /// </summary>
+        /// <param name="endpointId">ID of notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the notification endpoint requested</returns>
+        Task<NotificationEndpoint> FindNotificationEndpointByIdAsync(string endpointId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Slack Notification endpoint.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="token">Slack WebHook Token</param>
+        /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<SlackNotificationEndpoint> CloneSlackEndpointAsync(string name, string token,
+            string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Slack Notification endpoint.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="token"></param>
+        /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<SlackNotificationEndpoint> CloneSlackEndpointAsync(string name, string token,
+            SlackNotificationEndpoint endpoint, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a PagerDuty Notification endpoint.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="routingKey">Routing Key</param>
+        /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<PagerDutyNotificationEndpoint> ClonePagerDutyEndpointAsync(string name, string routingKey,
+            string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a PagerDuty Notification endpoint.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="routingKey">Routing Key</param>
+        /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<PagerDutyNotificationEndpoint> ClonePagerDutyEndpointAsync(string name, string routingKey,
+            PagerDutyNotificationEndpoint endpoint, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint without authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpointAsync(string name, string endpointId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint without authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpoint(string name, HTTPNotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint with Http Basic authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="username">HTTP Basic Username</param>
+        /// <param name="password">HTTP Basic Password</param>
+        /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpointBasicAuthAsync(string name, string username,
+            string password, string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint with Http Basic authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="username">HTTP Basic Username</param>
+        /// <param name="password">HTTP Basic Password</param>
+        /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpointBasicAuthAsync(string name, string username,
+            string password, HTTPNotificationEndpoint endpoint, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint with Bearer authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="token">Bearer token</param>
+        /// <param name="endpointId">ID of endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpointBearerAsync(string name, string token,
+            string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a Http Notification endpoint with Bearer authentication.
+        /// </summary>
+        /// <param name="name">name of cloned endpoint</param>
+        /// <param name="token">Bearer token</param>
+        /// <param name="endpoint">endpoint to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification endpoint cloned</returns>
+        Task<HTTPNotificationEndpoint> CloneHttpEndpointBearerAsync(string name, string token,
+            HTTPNotificationEndpoint endpoint, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a notification endpoint.
+        /// </summary>
+        /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a notification endpoint</returns>
+        Task<List<Label>> GetLabelsAsync(NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a notification endpoint.
+        /// </summary>
+        /// <param name="endpointId">ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a notification endpoint</returns>
+        Task<List<Label>> GetLabelsAsync(string endpointId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a notification endpoint.
+        /// </summary>
+        /// <param name="label">label to add</param>
+        /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task<Label> AddLabelAsync(Label label, NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a notification endpoint.
+        /// </summary>
+        /// <param name="labelId">the ID of label to add</param>
+        /// <param name="endpointId">the ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task<Label> AddLabelAsync(string labelId, string endpointId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a notification endpoint.
+        /// </summary>
+        /// <param name="label">the label to delete</param>
+        /// <param name="endpoint">the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteLabelAsync(Label label, NotificationEndpoint endpoint,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a notification endpoint.
+        /// </summary>
+        /// <param name="labelId">the label id to delete</param>
+        /// <param name="endpointId">ID of the notification endpoint</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteLabelAsync(string labelId, string endpointId, CancellationToken cancellationToken = default);
+    }
+
+    public class NotificationEndpointsApi : INotificationEndpointsApi
     {
         private readonly NotificationEndpointsService _service;
 

--- a/Client/NotificationRulesApi.cs
+++ b/Client/NotificationRulesApi.cs
@@ -9,7 +9,196 @@ using InfluxDB.Client.Domain;
 
 namespace InfluxDB.Client
 {
-    public class NotificationRulesApi
+    public interface INotificationRulesApi
+    {
+        /// <summary>
+        /// Add a Slack notification rule.
+        /// </summary>
+        /// <param name="name">Human-readable name describing the notification rule.</param>
+        /// <param name="every">The notification repetition interval.</param>
+        /// <param name="messageTemplate">The template used to generate notification.</param>
+        /// <param name="status">Status rule the notification rule attempts to match.</param>
+        /// <param name="endpoint">The endpoint to use for notification.</param>
+        /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification rule created</returns>
+        Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
+            RuleStatusLevel status, SlackNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a Slack notification rule.
+        /// </summary>
+        /// <param name="name">Human-readable name describing the notification rule.</param>
+        /// <param name="every">The notification repetition interval.</param>
+        /// <param name="messageTemplate">The template used to generate notification.</param>
+        /// <param name="status">Status rule the notification rule attempts to match.</param>
+        /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
+        /// <param name="endpoint">The endpoint to use for notification.</param>
+        /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification rule created</returns>
+        Task<SlackNotificationRule> CreateSlackRuleAsync(string name, string every, string messageTemplate,
+            RuleStatusLevel status, List<TagRule> tagRules, SlackNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a PagerDuty notification rule. 
+        /// </summary>
+        /// <param name="name">Human-readable name describing the notification rule.</param>
+        /// <param name="every">The notification repetition interval.</param>
+        /// <param name="messageTemplate">The template used to generate notification.</param>
+        /// <param name="status">Status rule the notification rule attempts to match.</param>
+        /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
+        /// <param name="endpoint">The endpoint to use for notification.</param>
+        /// <param name="orgId">The ID of the organization that owns this notification rule</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification rule created</returns>
+        Task<PagerDutyNotificationRule> CreatePagerDutyRuleAsync(string name, string every,
+            string messageTemplate, RuleStatusLevel status, List<TagRule> tagRules,
+            PagerDutyNotificationEndpoint endpoint, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a HTTP notification rule.
+        /// </summary>
+        /// <param name="name">Human-readable name describing the notification rule.</param>
+        /// <param name="every">The notification repetition interval.</param>
+        /// <param name="status">Status rule the notification rule attempts to match.</param>
+        /// <param name="tagRules">List of tag rules the notification rule attempts to match.</param>
+        /// <param name="endpoint">The endpoint to use for notification.</param>
+        /// <param name="orgId">The ID of the organization that owns this notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification rule created</returns>
+        Task<HTTPNotificationRule> CreateHttpRuleAsync(string name, string every, RuleStatusLevel status,
+            List<TagRule> tagRules, HTTPNotificationEndpoint endpoint, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a notification rule.
+        /// </summary>
+        /// <param name="rule">Notification rule to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Notification rule created</returns>
+        Task<NotificationRule> CreateRuleAsync(NotificationRule rule,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a notification rule.
+        /// </summary>
+        /// <param name="rule">Notification rule update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated notification rule</returns>
+        Task<NotificationRule> UpdateNotificationRuleAsync(NotificationRule rule,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a notification rule.
+        /// </summary>
+        /// <param name="ruleId">The notification rule ID.</param>
+        /// <param name="update">Notification rule update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated notification rule</returns>
+        Task<NotificationRule> UpdateNotificationRuleAsync(string ruleId, NotificationRuleUpdate update,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a notification rule.
+        /// </summary>
+        /// <param name="rule">The notification rule</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteNotificationRuleAsync(NotificationRule rule, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a notification rule.
+        /// </summary>
+        /// <param name="ruleId">The notification rule ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteNotificationRuleAsync(string ruleId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a notification rule.
+        /// </summary>
+        /// <param name="ruleId">The notification rule ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The notification rule requested</returns>
+        Task<NotificationRule> FindNotificationRuleByIdAsync(string ruleId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get notification rules.
+        /// </summary>
+        /// <param name="orgId">Only show notification rules that belong to a specific organization ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of notification rules</returns>
+        Task<List<NotificationRule>> FindNotificationRulesAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all notification rules.
+        /// </summary>
+        /// <param name="orgId">Only show notification rules that belong to a specific organization ID.</param>
+        /// <param name="findOptions">find options</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task<NotificationRules> FindNotificationRulesAsync(string orgId, FindOptions findOptions,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a notification rule.
+        /// </summary>
+        /// <param name="rule">The notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of all labels for a notification rule</returns>
+        Task<List<Label>> GetLabelsAsync(NotificationRule rule, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a notification rule
+        /// </summary>
+        /// <param name="ruleId"> The notification rule ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of all labels for a notification rule</returns>
+        Task<List<Label>> GetLabelsAsync(string ruleId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a notification rule.
+        /// </summary>
+        /// <param name="label">Label to add</param>
+        /// <param name="rule">The notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The label was added to the notification rule</returns>
+        Task<Label> AddLabelAsync(Label label, NotificationRule rule,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a notification rule.
+        /// </summary>
+        /// <param name="labelId">Label to add</param>
+        /// <param name="ruleId">The notification rule ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The label was added to the notification rule</returns>
+        Task<Label> AddLabelAsync(string labelId, string ruleId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a notification rule.
+        /// </summary>
+        /// <param name="label">The label to delete.</param>
+        /// <param name="rule">The notification rule.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task DeleteLabelAsync(Label label, NotificationRule rule, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete label from a notification rule.
+        /// </summary>
+        /// <param name="labelId">The ID of the label to delete.</param>
+        /// <param name="ruleId">The notification rule ID.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        Task DeleteLabelAsync(string labelId, string ruleId, CancellationToken cancellationToken = default);
+    }
+
+    public class NotificationRulesApi : INotificationRulesApi
     {
         private readonly NotificationRulesService _service;
 

--- a/Client/OrganizationsApi.cs
+++ b/Client/OrganizationsApi.cs
@@ -7,7 +7,285 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class OrganizationsApi
+    public interface IOrganizationsApi
+    {
+        /// <summary>
+        /// Creates a new organization and sets <see cref="InfluxDB.Client.Api.Domain.Organization.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created organization</returns>
+        Task<Organization> CreateOrganizationAsync(string name, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new organization and sets <see cref="Organization.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="organization">the organization to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created organization</returns>
+        Task<Organization> CreateOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update an organization.
+        /// </summary>
+        /// <param name="organization">organization update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>updated organization</returns>
+        Task<Organization> UpdateOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an organization.
+        /// </summary>
+        /// <param name="orgId">ID of organization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteOrganizationAsync(string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an organization.
+        /// </summary>
+        /// <param name="organization">organization to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteOrganizationAsync(Organization organization, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an organization.
+        /// </summary>
+        /// <param name="clonedName">name of cloned organization</param>
+        /// <param name="orgId">ID of organization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned organization</returns>
+        Task<Organization> CloneOrganizationAsync(string clonedName, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an organization.
+        /// </summary>
+        /// <param name="clonedName">name of cloned organization</param>
+        /// <param name="organization">organization to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned organization</returns>
+        Task<Organization> CloneOrganizationAsync(string clonedName, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve an organization.
+        /// </summary>
+        /// <param name="orgId">ID of organization to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>organization details</returns>
+        Task<Organization> FindOrganizationByIdAsync(string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all organizations.
+        /// </summary>
+        /// <param name="limit"> (optional, default to 20)</param>
+        /// <param name="offset"> (optional)</param>
+        /// <param name="descending"> (optional, default to false)</param>
+        /// <param name="org">Filter organizations to a specific organization name. (optional)</param>
+        /// <param name="orgID">Filter organizations to a specific organization ID. (optional)</param>
+        /// <param name="userID">Filter organizations to a specific user ID. (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List all organizations</returns>
+        Task<List<Organization>> FindOrganizationsAsync(int? limit = null, int? offset = null,
+            bool? descending = null, string org = null, string orgID = null, string userID = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List of secret keys the are stored for Organization. For example:
+        /// <code>
+        /// github_api_key,
+        /// some_other_key,
+        /// a_secret_key
+        /// </code>
+        /// </summary>
+        /// <param name="organization">the organization for get secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the secret keys</returns>
+        Task<List<string>> GetSecretsAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List of secret keys the are stored for Organization. For example:
+        /// <code>
+        /// github_api_key,
+        /// some_other_key,
+        /// a_secret_key
+        /// </code>
+        /// </summary>
+        /// <param name="orgId">the organization for get secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the secret keys</returns>
+        Task<List<string>> GetSecretsAsync(string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Patches all provided secrets and updates any previous values.
+        /// </summary>
+        /// <param name="secrets">secrets to update/add</param>
+        /// <param name="organization">the organization for put secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task PutSecretsAsync(Dictionary<string, string> secrets, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Patches all provided secrets and updates any previous values.
+        /// </summary>
+        /// <param name="secrets">secrets to update/add</param>
+        /// <param name="orgId">the organization for put secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task PutSecretsAsync(Dictionary<string, string> secrets, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete provided secrets.
+        /// </summary>
+        /// <param name="secrets">secrets to delete</param>
+        /// <param name="organization">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>keys successfully patched</returns>
+        Task DeleteSecretsAsync(List<string> secrets, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete provided secrets.
+        /// </summary>
+        /// <param name="secrets">secrets to delete</param>
+        /// <param name="orgId">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>keys successfully patched</returns>
+        Task DeleteSecretsAsync(List<string> secrets, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete provided secrets.
+        /// </summary>
+        /// <param name="secrets">secrets to delete</param>
+        /// <param name="orgId">the organization for delete secrets</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>keys successfully patched</returns>
+        Task DeleteSecretsAsync(SecretKeys secrets, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of an organization.
+        /// </summary>
+        /// <param name="organization">organization of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of an organization</returns>
+        Task<List<ResourceMember>> GetMembersAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of an organization.
+        /// </summary>
+        /// <param name="orgId">ID of organization to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of an organization</returns>
+        Task<List<ResourceMember>> GetMembersAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add organization member.
+        /// </summary>
+        /// <param name="member">the member of an organization</param>
+        /// <param name="organization">the organization of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(User member, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add organization member.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(string memberId, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from an organization.
+        /// </summary>
+        /// <param name="member">the member of an organization</param>
+        /// <param name="organization">the organization of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteMemberAsync(User member, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from an organization.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteMemberAsync(string memberId, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of an organization.
+        /// </summary>
+        /// <param name="organization">organization of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of an organization</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of an organization.
+        /// </summary>
+        /// <param name="orgId">ID of organization to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of an organization</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add organization owner.
+        /// </summary>
+        /// <param name="owner">the owner of an organization</param>
+        /// <param name="organization">the organization of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(User owner, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add organization owner.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(string ownerId, string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from an organization.
+        /// </summary>
+        /// <param name="owner">the owner of an organization</param>
+        /// <param name="organization">the organization of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteOwnerAsync(User owner, Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from an organization.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="orgId">the ID of an organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task DeleteOwnerAsync(string ownerId, string orgId, CancellationToken cancellationToken = default);
+    }
+
+    public class OrganizationsApi : IOrganizationsApi
     {
         private readonly OrganizationsService _service;
         private readonly SecretsService _secretsService;

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -14,7 +14,295 @@ using RestSharp;
 
 namespace InfluxDB.Client
 {
-    public class QueryApi : AbstractQueryClient
+    public interface IQueryApi
+    {
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync(string,System.Action{InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        Task<List<FluxTable>> QueryAsync(string query, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync(string,System.Action{InfluxDB.Client.Core.Flux.Domain.FluxRecord},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        Task<List<FluxTable>> QueryAsync(Query query, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync{T}(string,System.Action{T},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        Task<List<T>> QueryAsync<T>(string query, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync{T}(string,System.Action{T},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        Task<List<T>> QueryAsync<T>(Query query, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream <see cref="FluxRecord"/>
+        /// to <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the FluxRecord result</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>async task</returns>
+        Task QueryAsync(string query, Action<FluxRecord> onNext, Action<Exception> onError = null,
+            Action onComplete = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream <see cref="FluxRecord"/>
+        /// to <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the FluxRecord result</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>async task</returns>
+        Task QueryAsync(Query query, Action<FluxRecord> onNext, Action<Exception> onError = null,
+            Action onComplete = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>async task</returns>
+        Task QueryAsync<T>(string query, Action<T> onNext, Action<Exception> onError = null,
+            Action onComplete = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>async task</returns>
+        Task QueryAsync<T>(Query query, Action<T> onNext, Action<Exception> onError = null,
+            Action onComplete = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync(string,System.Type,System.Action{object},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <param name="org">the organization</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>Measurements which are matched the query</returns>
+        Task<List<object>> QueryAsync(string query, Type pocoType, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryAsync(string,System.Type,System.Action{object},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <param name="org">the organization</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>Measurements which are matched the query</returns>
+        Task<List<object>> QueryAsync(Query query, Type pocoType, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>async task</returns>
+        Task QueryAsync(string query, Type pocoType, Action<object> onNext,
+            Action<Exception> onError = null, Action onComplete = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream Measurements
+        /// to a <see cref="onNext"/> consumer.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="pocoType">the type of measurement</param>
+        /// <param name="onNext">the callback to consume the mapped Measurements</param>
+        /// <param name="onError">the callback to consume any error notification</param>
+        /// <param name="onComplete">the callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>async task</returns>
+        Task QueryAsync(Query query, Type pocoType, Action<object> onNext,
+            Action<Exception> onError = null, Action onComplete = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously maps
+        /// response to enumerable of objects of type <typeparamref name="T"/>.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        IAsyncEnumerable<T> QueryAsyncEnumerable<T>(string query, string org = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously maps
+        /// response to enumerable of objects of type <typeparamref name="T"/>. 
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">cancellation token</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        IAsyncEnumerable<T> QueryAsyncEnumerable<T>(Query query, string org = null,
+            [EnumeratorCancellation] CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryRawAsync(string,System.Action{string},InfluxDB.Client.Api.Domain.Dialect,System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// 
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="dialect">Dialect is an object defining the options to use when encoding the response. <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>the raw response that matched the query</returns>
+        Task<string> QueryRawAsync(string query, Dialect dialect = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.
+        /// 
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// Use <see cref="QueryApi.QueryRawAsync(InfluxDB.Client.Api.Domain.Query,System.Action{string},System.Action{System.Exception},System.Action,string,System.Threading.CancellationToken)"/>
+        /// for large data streaming.
+        /// </para>
+        /// 
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>the raw response that matched the query</returns>
+        Task<string> QueryRawAsync(Query query, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
+        /// (line by line) to <see cref="onResponse"/>.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onResponse">the callback to consume the response line by line</param>
+        /// <param name="dialect">Dialect is an object defining the options to use when encoding the response. <a href="http://bit.ly/flux-dialect">See dialect SPEC.</a></param>
+        /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns></returns>
+        Task QueryRawAsync(string query, Action<string> onResponse, Dialect dialect = null,
+            Action<Exception> onError = null, Action onComplete = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and asynchronously stream response
+        /// (line by line) to <see cref="onResponse"/>.
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="onResponse">the callback to consume the response line by line</param>
+        /// <param name="onError">callback to consume any error notification</param>
+        /// <param name="onComplete">callback to consume a notification about successfully end of stream</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns></returns>
+        Task QueryRawAsync(Query query, Action<string> onResponse, Action<Exception> onError = null,
+            Action onComplete = null, string org = null, CancellationToken cancellationToken = default);
+    }
+
+    public class QueryApi : AbstractQueryClient, IQueryApi
     {
         public static readonly Dialect Dialect = new Dialect
         {

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -222,7 +222,7 @@ namespace InfluxDB.Client
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
         IAsyncEnumerable<T> QueryAsyncEnumerable<T>(string query, string org = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB 2.x and asynchronously maps
@@ -234,7 +234,7 @@ namespace InfluxDB.Client
         /// <typeparam name="T">the type of measurement</typeparam>
         /// <returns>Measurements which are matched the query</returns>
         IAsyncEnumerable<T> QueryAsyncEnumerable<T>(Query query, string org = null,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default);
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Executes the Flux query against the InfluxDB and synchronously map whole response to <see cref="string"/> result.

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -12,10 +12,71 @@ using RestSharp;
 
 namespace InfluxDB.Client
 {
+    public interface IQueryApiSync
+    {
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        List<T> QuerySync<T>(string query, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to list of object with given type.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <typeparam name="T">the type of measurement</typeparam>
+        /// <returns>Measurements which are matched the query</returns>
+        List<T> QuerySync<T>(Query query, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        List<FluxTable> QuerySync(string query, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Executes the Flux query against the InfluxDB 2.x and synchronously map whole response
+        /// to <see cref="FluxTable"/>s.
+        ///
+        /// <para>
+        /// NOTE: This method is not intended for large query results.
+        /// </para>
+        /// </summary>
+        /// <param name="query">the flux query to execute</param>
+        /// <param name="org">specifies the source organization. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">Token that enables callers to cancel the request.</param>
+        /// <returns>FluxTables that are matched the query</returns>
+        List<FluxTable> QuerySync(Query query, string org = null, CancellationToken cancellationToken = default);
+    }
+
     /// <summary>
     /// The synchronous version of QueryApi.
     /// </summary>
-    public class QueryApiSync : AbstractQueryClient
+    public class QueryApiSync : AbstractQueryClient, IQueryApiSync
     {
         private readonly InfluxDBClientOptions _options;
         private readonly QueryService _service;

--- a/Client/ScraperTargetsApi.cs
+++ b/Client/ScraperTargetsApi.cs
@@ -7,7 +7,296 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class ScraperTargetsApi
+    public interface IScraperTargetsApi
+    {
+        /// <summary>
+        /// Creates a new ScraperTarget and sets <see cref="ScraperTargetResponse.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="scraperTargetRequest">the scraper to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created ScraperTarget</returns>
+        Task<ScraperTargetResponse> CreateScraperTargetAsync(ScraperTargetRequest scraperTargetRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new ScraperTarget and sets <see cref="ScraperTargetResponse.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">the name of the new ScraperTarget</param>
+        /// <param name="url">the url of the new ScraperTarget</param>
+        /// <param name="bucketId">the id of the bucket that its use to writes</param>
+        /// <param name="orgId">the id of the organization that owns new ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created ScraperTarget</returns>
+        Task<ScraperTargetResponse> CreateScraperTargetAsync(string name, string url,
+            string bucketId, string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetResponse">ScraperTarget update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>updated ScraperTarget</returns>
+        Task<ScraperTargetResponse> UpdateScraperTargetAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">id of the scraper target (required)</param>
+        /// <param name="scraperTargetRequest">ScraperTargetRequest update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>updated ScraperTarget</returns>
+        Task<ScraperTargetResponse> UpdateScraperTargetAsync(string scraperTargetId,
+            ScraperTargetRequest scraperTargetRequest, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">ID of ScraperTarget to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>scraper target deleted</returns>
+        Task DeleteScraperTargetAsync(string scraperTargetId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetResponse">ScraperTarget to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>scraper target deleted</returns>
+        Task DeleteScraperTargetAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a ScraperTarget.
+        /// </summary>
+        /// <param name="clonedName">name of cloned ScraperTarget</param>
+        /// <param name="scraperTargetId">ID of ScraperTarget to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned ScraperTarget</returns>
+        Task<ScraperTargetResponse> CloneScraperTargetAsync(string clonedName, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a ScraperTarget.
+        /// </summary>
+        /// <param name="clonedName">name of cloned ScraperTarget</param>
+        /// <param name="scraperTargetResponse">ScraperTarget to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned ScraperTarget</returns>
+        Task<ScraperTargetResponse> CloneScraperTargetAsync(string clonedName,
+            ScraperTargetResponse scraperTargetResponse, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">ID of ScraperTarget to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>ScraperTarget details</returns>
+        Task<ScraperTargetResponse> FindScraperTargetByIdAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all ScraperTargets.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of ScraperTargets</returns>
+        Task<List<ScraperTargetResponse>> FindScraperTargetsAsync(
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all ScraperTargets.
+        /// </summary>
+        /// <param name="organization">specifies the organization of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of ScraperTargets</returns>
+        Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all ScraperTargets.
+        /// </summary>
+        /// <param name="orgId">specifies the organization ID of the resource</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of ScraperTargets</returns>
+        Task<List<ScraperTargetResponse>> FindScraperTargetsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetResponse">ScraperTarget of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a ScraperTarget</returns>
+        Task<List<ResourceMember>> GetMembersAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">ID of ScraperTarget to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a ScraperTarget</returns>
+        Task<List<ResourceMember>> GetMembersAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget member.
+        /// </summary>
+        /// <param name="member">the member of a scraperTarget</param>
+        /// <param name="scraperTargetResponse">the ScraperTarget of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(User member, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget member.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="scraperTargetId">the ID of a scraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(string memberId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a ScraperTarget.
+        /// </summary>
+        /// <param name="member">the member of a ScraperTarget</param>
+        /// <param name="scraperTargetResponse">the ScraperTarget of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteMemberAsync(User member, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a ScraperTarget.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteMemberAsync(string memberId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetResponse">ScraperTarget of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a ScraperTarget</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">ID of a ScraperTarget to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a scraperTarget</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget owner.
+        /// </summary>
+        /// <param name="owner">the owner of a ScraperTarget</param>
+        /// <param name="scraperTargetResponse">the ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget owner.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(string ownerId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a ScraperTarget.
+        /// </summary>
+        /// <param name="owner">the owner of a scraperTarget</param>
+        /// <param name="scraperTargetResponse">the ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteOwnerAsync(User owner, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a ScraperTarget.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteOwnerAsync(string ownerId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetResponse">a ScraperTarget of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a ScraperTarget</returns>
+        Task<List<Label>> GetLabelsAsync(ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a ScraperTarget.
+        /// </summary>
+        /// <param name="scraperTargetId">ID of a ScraperTarget to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a ScraperTarget</returns>
+        Task<List<Label>> GetLabelsAsync(string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget label.
+        /// </summary>
+        /// <param name="label">the label of a ScraperTarget</param>
+        /// <param name="scraperTargetResponse">a ScraperTarget of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a ScraperTarget label.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(string labelId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a ScraperTarget.
+        /// </summary>
+        /// <param name="label">the label of a ScraperTarget</param>
+        /// <param name="scraperTargetResponse">a ScraperTarget of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(Label label, ScraperTargetResponse scraperTargetResponse,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a ScraperTarget.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="scraperTargetId">the ID of a ScraperTarget</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(string labelId, string scraperTargetId,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class ScraperTargetsApi : IScraperTargetsApi
     {
         private readonly ScraperTargetsService _service;
 

--- a/Client/SourcesApi.cs
+++ b/Client/SourcesApi.cs
@@ -7,7 +7,110 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class SourcesApi
+    public interface ISourcesApi
+    {
+        /// <summary>
+        /// Creates a new Source and sets <see cref="InfluxDB.Client.Api.Domain.Source.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="source">source to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created Source</returns>
+        Task<Source> CreateSourceAsync(Source source, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a Source.
+        /// </summary>
+        /// <param name="source">source update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>updated source</returns>
+        Task<Source> UpdateSourceAsync(Source source, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a source.
+        /// </summary>
+        /// <param name="sourceId">ID of source to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteSourceAsync(string sourceId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a source.
+        /// </summary>
+        /// <param name="source">source to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteSourceAsync(Source source, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a source.
+        /// </summary>
+        /// <param name="clonedName">name of cloned source</param>
+        /// <param name="sourceId">ID of source to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned source</returns>
+        Task<Source> CloneSourceAsync(string clonedName, string sourceId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a source.
+        /// </summary>
+        /// <param name="clonedName">name of cloned source</param>
+        /// <param name="source">source to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned source</returns>
+        Task<Source> CloneSourceAsync(string clonedName, Source source,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a source.
+        /// </summary>
+        /// <param name="sourceId">ID of source to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>source details</returns>
+        Task<Source> FindSourceByIdAsync(string sourceId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get all sources.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of sources</returns>
+        Task<List<Source>> FindSourcesAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a sources buckets (will return dbrps in the form of buckets if it is a v1 source).
+        /// </summary>
+        /// <param name="source">filter buckets to a specific source</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The buckets for source. If source does not exist than return null.</returns>
+        Task<List<Bucket>> FindBucketsBySourceAsync(Source source, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a sources buckets (will return dbrps in the form of buckets if it is a v1 source).
+        /// </summary>
+        /// <param name="sourceId">filter buckets to a specific source ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>The buckets for source. If source does not exist than return null.</returns>
+        Task<List<Bucket>> FindBucketsBySourceIdAsync(string sourceId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a sources health.
+        /// </summary>
+        /// <param name="source">source to check health</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>health of source</returns>
+        Task<HealthCheck> HealthAsync(Source source, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Get a sources health.
+        /// </summary>
+        /// <param name="sourceId">source to check health</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>health of source</returns>
+        Task<HealthCheck> HealthAsync(string sourceId, CancellationToken cancellationToken = default);
+    }
+
+    public class SourcesApi : ISourcesApi
     {
         private readonly SourcesService _service;
 

--- a/Client/TasksApi.cs
+++ b/Client/TasksApi.cs
@@ -8,7 +8,491 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class TasksApi
+    public interface ITasksApi
+    {
+        /// <summary>
+        /// Creates a new task. The <see cref="InfluxDB.Client.Api.Domain.TaskType"/> has to have defined a cron or a every repetition
+        /// by the <a href="http://bit.ly/option-statement">option statement</a>.
+        /// <example>
+        ///     This sample shows how to specify every repetition
+        ///     <code>
+        /// option task = {
+        /// name: "mean",
+        /// every: 1h,
+        /// }
+        /// 
+        /// from(bucket:"metrics/autogen")
+        /// |&gt; range(start:-task.every)
+        /// |&gt; group(columns:["level"])
+        /// |&gt; mean()
+        /// |&gt; yield(name:"mean")
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="task">task to create (required)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<TaskType> CreateTaskAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a new task.
+        /// </summary>
+        /// <param name="taskCreateRequest">task to create (required)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
+        Task<TaskType> CreateTaskAsync(TaskCreateRequest taskCreateRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new task with task repetition by cron. The <see cref="TaskType.Flux" /> is without a cron or a every
+        /// repetition.
+        /// The repetition is automatically append to the <a href="http://bit.ly/option-statement">option statement</a>.
+        /// </summary>
+        /// <param name="name">description of the task</param>
+        /// <param name="flux">the Flux script to run for this task</param>
+        /// <param name="cron">a task repetition schedule in the form '* * * * * *'</param>
+        /// <param name="organization">the organization that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
+            Organization organization, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new task with task repetition by cron. The <see cref="TaskType.Flux" /> is without a cron or a every
+        /// repetition.
+        /// The repetition is automatically append to the <a href="http://bit.ly/option-statement">option statement</a>.
+        /// </summary>
+        /// <param name="name">description of the task</param>
+        /// <param name="flux">the Flux script to run for this task</param>
+        /// <param name="cron">a task repetition schedule in the form '* * * * * *'</param>
+        /// <param name="orgId">the organization ID that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<TaskType> CreateTaskCronAsync(string name, string flux, string cron,
+            string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new task with task repetition by duration expression ("1h", "30s"). The <see cref="TaskType.Flux" /> is
+        /// without a cron or a every repetition.
+        /// The repetition is automatically append to the <a href="http://bit.ly/option-statement">option statement</a>.
+        /// </summary>
+        /// <param name="name">description of the task</param>
+        /// <param name="flux">the Flux script to run for this task</param>
+        /// <param name="every">a task repetition by duration expression</param>
+        /// <param name="organization">the organization that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
+            Organization organization, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new task with task repetition by duration expression ("1h", "30s"). The <see cref="TaskType.Flux" /> is
+        /// without a cron or a every repetition.
+        /// The repetition is automatically append to the <a href="http://bit.ly/option-statement">option statement</a>.
+        /// </summary>
+        /// <param name="name">description of the task</param>
+        /// <param name="flux">the Flux script to run for this task</param>
+        /// <param name="every">a task repetition by duration expression</param>
+        /// <param name="orgId">the organization ID that owns this Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created Task</returns>
+        /// <exception cref="NotImplementedException"></exception>
+        Task<TaskType> CreateTaskEveryAsync(string name, string flux, string every,
+            string orgId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a task. This will cancel all queued runs.
+        /// </summary>
+        /// <param name="task">task update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>task updated</returns>
+        Task<TaskType> UpdateTaskAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a task. This will cancel all queued runs.
+        /// </summary>
+        /// <param name="taskId">ID of task to get</param>
+        /// <param name="request">task update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>task updated</returns>
+        Task<TaskType> UpdateTaskAsync(string taskId, TaskUpdateRequest request,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>task deleted</returns>
+        Task DeleteTaskAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a task.
+        /// </summary>
+        /// <param name="task">task to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>task deleted</returns>
+        Task DeleteTaskAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned task</returns>
+        Task<TaskType> CloneTaskAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a task.
+        /// </summary>
+        /// <param name="task">task to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned task</returns>
+        Task<TaskType> CloneTaskAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>task details</returns>
+        Task<TaskType> FindTaskByIdAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists tasks, limit 100.
+        /// </summary>
+        /// <param name="user">filter tasks to a specific user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of tasks</returns>
+        Task<List<TaskType>> FindTasksByUserAsync(User user, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists tasks, limit 100.
+        /// </summary>
+        /// <param name="userId">filter tasks to a specific user ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of tasks</returns>
+        Task<List<TaskType>> FindTasksByUserIdAsync(string userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists tasks, limit 100.
+        /// </summary>
+        /// <param name="organization">filter tasks to a specific organization</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of tasks</returns>
+        Task<List<TaskType>> FindTasksByOrganizationAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists tasks, limit 100.
+        /// </summary>
+        /// <param name="orgId">filter tasks to a specific organization ID</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of tasks</returns>
+        Task<List<TaskType>> FindTasksByOrganizationIdAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Lists tasks, limit 100.
+        /// </summary>
+        /// <param name="afterId">returns tasks after specified ID</param>
+        /// <param name="userId">filter tasks to a specific user ID</param>
+        /// <param name="orgId">filter tasks to a specific organization ID</param>
+        /// <param name="org">Filter tasks to a specific organization name. (optional)</param>
+        /// <param name="name">Returns task with a specific name. (optional)</param>
+        /// <param name="limit">The number of tasks to return (optional, default to 100)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of tasks</returns>
+        Task<List<TaskType>> FindTasksAsync(string afterId = null, string userId = null,
+            string orgId = null, string org = null, string name = null, int? limit = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a task.
+        /// </summary>
+        /// <param name="task">task of the members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a task</returns>
+        Task<List<ResourceMember>> GetMembersAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all members of a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get members</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all members of a task</returns>
+        Task<List<ResourceMember>> GetMembersAsync(string taskId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a task member.
+        /// </summary>
+        /// <param name="member">the member of a task</param>
+        /// <param name="task">the task of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(User member, TaskType task,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a task member.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceMember> AddMemberAsync(string memberId, string taskId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a task.
+        /// </summary>
+        /// <param name="member">the member of a task</param>
+        /// <param name="task">the task of a member</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(User member, TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a task.
+        /// </summary>
+        /// <param name="memberId">the ID of a member</param>
+        /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(string memberId, string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a task.
+        /// </summary>
+        /// <param name="task">task of the owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a task</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a task.
+        /// </summary>
+        /// <param name="taskId">ID of a task to get owners</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all owners of a task</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(string taskId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a task owner.
+        /// </summary>
+        /// <param name="owner">the owner of a task</param>
+        /// <param name="task">the task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(User owner, TaskType task,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a task owner.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>created mapping</returns>
+        Task<ResourceOwner> AddOwnerAsync(string ownerId, string taskId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a task.
+        /// </summary>
+        /// <param name="owner">the owner of a task</param>
+        /// <param name="task">the task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(User owner, TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a owner from a task.
+        /// </summary>
+        /// <param name="ownerId">the ID of a owner</param>
+        /// <param name="taskId">the ID of a task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(string ownerId, string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve all logs for a task.
+        /// </summary>
+        /// <param name="task">task to get logs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of all logs for a task</returns>
+        Task<List<LogEvent>> GetLogsAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve all logs for a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get logs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of all logs for a task</returns>
+        Task<List<LogEvent>> GetLogsAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve list of run records for a task.
+        /// </summary>
+        /// <param name="task"> task to get runs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of run records for a task</returns>
+        Task<List<Run>> GetRunsAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve list of run records for a task.
+        /// </summary>
+        /// <param name="task"> task to get runs for</param>
+        /// <param name="afterTime">filter runs to those scheduled after this time</param>
+        /// <param name="beforeTime">filter runs to those scheduled before this time</param>
+        /// <param name="limit">the number of runs to return. Default value: 20.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of run records for a task</returns>
+        Task<List<Run>> GetRunsAsync(TaskType task, DateTime? afterTime,
+            DateTime? beforeTime, int? limit, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve list of run records for a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get runs for</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of run records for a task</returns>
+        Task<List<Run>> GetRunsAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve list of run records for a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get runs for</param>
+        /// <param name="afterTime">filter runs to those scheduled after this time</param>
+        /// <param name="beforeTime">filter runs to those scheduled before this time</param>
+        /// <param name="limit">the number of runs to return. Default value: 20.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of run records for a task</returns>
+        Task<List<Run>> GetRunsAsync(string taskId,
+            DateTime? afterTime, DateTime? beforeTime, int? limit, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a single run record for a task.
+        /// </summary>
+        /// <param name="taskId">ID of task to get runs for</param>
+        /// <param name="runId">ID of run</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a single run record for a task</returns>
+        Task<Run> GetRunAsync(string taskId, string runId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retry a task run.
+        /// </summary>
+        /// <param name="run">the run to retry</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the executed run</returns>
+        Task<Run> RetryRunAsync(Run run, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retry a task run.
+        /// </summary>
+        /// <param name="taskId">ID of task with the run to retry</param>
+        /// <param name="runId">ID of run to retry</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the executed run</returns>
+        Task<Run> RetryRunAsync(string taskId, string runId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels a currently running run.
+        /// </summary>
+        /// <param name="run">the run to cancel</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task CancelRunAsync(Run run, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Cancels a currently running run.
+        /// </summary>
+        /// <param name="taskId">ID of task with the run to cancel</param>
+        /// <param name="runId">ID of run to cancel</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns></returns>
+        Task CancelRunAsync(string taskId, string runId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve all logs for a run.
+        /// </summary>
+        /// <param name="run">the run to gets logs for it</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of all logs for a run</returns>
+        Task<List<LogEvent>> GetRunLogsAsync(Run run, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve all logs for a run.
+        /// </summary>
+        /// <param name="taskId">ID of task to get run logs for it</param>
+        /// <param name="runId">ID of run to get logs for it</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the list of all logs for a run</returns>
+        Task<List<LogEvent>> GetRunLogsAsync(string taskId, string runId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a Task.
+        /// </summary>
+        /// <param name="task">a Task of the labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a Task</returns>
+        Task<List<Label>> GetLabelsAsync(TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels of a Task.
+        /// </summary>
+        /// <param name="taskId">ID of a Task to get labels</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>the List all labels of a Task</returns>
+        Task<List<Label>> GetLabelsAsync(string taskId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a Task label.
+        /// </summary>
+        /// <param name="label">the label of a Task</param>
+        /// <param name="task">a Task of a label</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(Label label, TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a Task label.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="taskId">the ID of a Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(string labelId, string taskId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a Task.
+        /// </summary>
+        /// <param name="label">the label of a Task</param>
+        /// <param name="task">a Task of a owner</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(Label label, TaskType task, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a label from a Task.
+        /// </summary>
+        /// <param name="labelId">the ID of a label</param>
+        /// <param name="taskId">the ID of a Task</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(string labelId, string taskId, CancellationToken cancellationToken = default);
+    }
+
+    public class TasksApi : ITasksApi
     {
         private readonly TasksService _service;
 

--- a/Client/TelegrafsApi.cs
+++ b/Client/TelegrafsApi.cs
@@ -9,10 +9,390 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
+    public interface ITelegrafsApi
+    {
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="org">The organization that owns this config</param>
+        /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+            List<TelegrafPlugin> plugins, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="org">The organization that owns this config</param>
+        /// <param name="agentConfiguration">The telegraf agent config</param>
+        /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="orgId">The organization that owns this config</param>
+        /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+            List<TelegrafPlugin> plugins, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="orgId">The organization that owns this config</param>
+        /// <param name="agentConfiguration">The telegraf agent config</param>
+        /// <param name="plugins">The telegraf plugins config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+            Dictionary<string, object> agentConfiguration, List<TelegrafPlugin> plugins,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="org">The organization that owns this config</param>
+        /// <param name="config">ConfigTOML contains the raw toml config</param>
+        /// <param name="metadata">Metadata for the config</param>
+        /// <param name="plugins">Plugins to use.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, Organization org,
+            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="name">Telegraf Configuration Name</param>
+        /// <param name="description">Telegraf Configuration Description</param>
+        /// <param name="orgId">The organization that owns this config</param>
+        /// <param name="config">ConfigTOML contains the raw toml config</param>
+        /// <param name="metadata">Metadata for the config</param>
+        /// <param name="plugins">Plugins to use.</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(string name, string description, string orgId,
+            string config, TelegrafRequestMetadata metadata, List<TelegrafPluginRequestPlugins> plugins = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Create a telegraf config.
+        /// </summary>
+        /// <param name="telegrafRequest">Telegraf Configuration to create</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Telegraf config created</returns>
+        Task<Telegraf> CreateTelegrafAsync(TelegrafPluginRequest telegrafRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Created default Telegraf Agent configuration.
+        /// <example>
+        /// [agent]
+        ///    interval = "10s"
+        ///    round_interval = true
+        ///    metric_batch_size = 1000
+        ///    metric_buffer_limit = 10000
+        ///    collection_jitter = "0s"
+        ///    flush_jitter = "0s"
+        ///    precision = ""
+        ///    omit_hostname = false
+        /// </example>
+        /// </summary>
+        /// <returns>default configuration</returns>
+        Dictionary<string, object> CreateAgentConfiguration();
+
+        /// <summary>
+        /// Update a telegraf config.
+        /// </summary>
+        /// <param name="telegraf">telegraf config update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated telegraf</returns>
+        Task<Telegraf> UpdateTelegrafAsync(Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of telegraf config</param>
+        /// <param name="telegrafRequest">telegraf config update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>An updated telegraf</returns>
+        Task<Telegraf> UpdateTelegrafAsync(string telegrafId, TelegrafPluginRequest telegrafRequest,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a telegraf config.
+        /// </summary>
+        /// <param name="telegraf">telegraf config to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteTelegrafAsync(Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of telegraf config to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteTelegrafAsync(string telegrafId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a telegraf config.
+        /// </summary>
+        /// <param name="clonedName">name of cloned telegraf config</param>
+        /// <param name="telegrafId">ID of telegraf config to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned telegraf config</returns>
+        Task<Telegraf> CloneTelegrafAsync(string clonedName, string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone a telegraf config.
+        /// </summary>
+        /// <param name="clonedName">name of cloned telegraf config</param>
+        /// <param name="telegraf">telegraf config to clone></param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned telegraf config</returns>
+        Task<Telegraf> CloneTelegrafAsync(string clonedName, Telegraf telegraf,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>telegraf config details</returns>
+        Task<Telegraf> FindTelegrafByIdAsync(string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns a list of telegraf configs.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of telegraf configs</returns>
+        Task<List<Telegraf>> FindTelegrafsAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns a list of telegraf configs for specified organization.
+        /// </summary>
+        /// <param name="organization">specifies the organization of the telegraf configs</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of telegraf configs</returns>
+        Task<List<Telegraf>> FindTelegrafsByOrgAsync(Organization organization,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns a list of telegraf configs for specified organization.
+        /// </summary>
+        /// <param name="orgId">specifies the organization of the telegraf configs</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>A list of telegraf configs</returns>
+        Task<List<Telegraf>> FindTelegrafsByOrgIdAsync(string orgId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a telegraf config in TOML.
+        /// </summary>
+        /// <param name="telegraf">telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>telegraf config details in TOML format</returns>
+        Task<string> GetTOMLAsync(Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve a telegraf config in TOML.
+        /// </summary>
+        /// <param name="telegrafId">ID of telegraf config to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>telegraf config details in TOML format</returns>
+        Task<string> GetTOMLAsync(string telegrafId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all users with member privileges for a telegraf config.
+        /// </summary>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of telegraf config members</returns>
+        Task<List<ResourceMember>> GetMembersAsync(Telegraf telegraf,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all users with member privileges for a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of telegraf config members</returns>
+        Task<List<ResourceMember>> GetMembersAsync(string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add telegraf config member.
+        /// </summary>
+        /// <param name="member">user to add as member</param>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member added to telegraf</returns>
+        Task<ResourceMember> AddMemberAsync(User member, Telegraf telegraf,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add telegraf config member.
+        /// </summary>
+        /// <param name="memberId">user ID to add as member</param>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member added to telegraf</returns>
+        Task<ResourceMember> AddMemberAsync(string memberId, string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a telegraf config.
+        /// </summary>
+        /// <param name="member">member to remove</param>
+        /// <param name="telegraf">the telegraf</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(User member, Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes a member from a telegraf config.
+        /// </summary>
+        /// <param name="memberId">ID of member to remove</param>
+        /// <param name="telegrafId">ID of the telegraf</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>member removed</returns>
+        Task DeleteMemberAsync(string memberId, string telegrafId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a telegraf config.
+        /// </summary>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of telegraf config owners</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(Telegraf telegraf,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all owners of a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of telegraf config owners</returns>
+        Task<List<ResourceOwner>> GetOwnersAsync(string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add telegraf config owner.
+        /// </summary>
+        /// <param name="owner">user to add as owner</param>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>telegraf config owner added</returns>
+        Task<ResourceOwner> AddOwnerAsync(User owner, Telegraf telegraf,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add telegraf config owner.
+        /// </summary>
+        /// <param name="ownerId">ID of user to add as owner</param>
+        /// <param name="telegrafId"> ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>telegraf config owner added</returns>
+        Task<ResourceOwner> AddOwnerAsync(string ownerId, string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes an owner from a telegraf config.
+        /// </summary>
+        /// <param name="owner">owner to remove</param>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(User owner, Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Removes an owner from a telegraf config.
+        /// </summary>
+        /// <param name="ownerId">ID of owner to remove</param>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>owner removed</returns>
+        Task DeleteOwnerAsync(string ownerId, string telegrafId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a telegraf config.
+        /// </summary>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a telegraf config</returns>
+        Task<List<Label>> GetLabelsAsync(Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all labels for a telegraf config.
+        /// </summary>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>a list of all labels for a telegraf config</returns>
+        Task<List<Label>> GetLabelsAsync(string telegrafId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a telegraf config.
+        /// </summary>
+        /// <param name="label">label to add</param>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(Label label, Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Add a label to a telegraf config.
+        /// </summary>
+        /// <param name="labelId">ID of label to add</param>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>added label</returns>
+        Task<Label> AddLabelAsync(string labelId, string telegrafId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a label from a telegraf config.
+        /// </summary>
+        /// <param name="label">label to delete</param>
+        /// <param name="telegraf">the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(Label label, Telegraf telegraf, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete a label from a telegraf config.
+        /// </summary>
+        /// <param name="labelId">ID of label to delete</param>
+        /// <param name="telegrafId">ID of the telegraf config</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>delete has been accepted</returns>
+        Task DeleteLabelAsync(string labelId, string telegrafId, CancellationToken cancellationToken = default);
+    }
+
     /// <summary>
     /// The client of the InfluxDB 2.x that implement Telegrafs HTTP API endpoint.
     /// </summary>
-    public class TelegrafsApi
+    public class TelegrafsApi : ITelegrafsApi
     {
         private readonly TelegrafsService _service;
 

--- a/Client/UsersApi.cs
+++ b/Client/UsersApi.cs
@@ -9,7 +9,129 @@ using InfluxDB.Client.Core;
 
 namespace InfluxDB.Client
 {
-    public class UsersApi
+    public interface IUsersApi
+    {
+        /// <summary>
+        /// Creates a new user and sets <see cref="User.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="name">name of the user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created user</returns>
+        Task<User> CreateUserAsync(string name, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Creates a new user and sets <see cref="User.Id" /> with the new identifier.
+        /// </summary>
+        /// <param name="user">name of the user</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>Created user</returns>
+        Task<User> CreateUserAsync(User user, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update an user.
+        /// </summary>
+        /// <param name="user">user update to apply</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>user updated</returns>
+        Task<User> UpdateUserAsync(User user, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update password to an user.
+        /// </summary>
+        /// <param name="user">user to update password</param>
+        /// <param name="oldPassword">old password</param>
+        /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>user updated</returns>
+        Task UpdateUserPasswordAsync(User user, string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update password to an user.
+        /// </summary>
+        /// <param name="userId">ID of user to update password</param>
+        /// <param name="oldPassword">old password</param>
+        /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>user updated</returns>
+        Task UpdateUserPasswordAsync(string userId, string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an user.
+        /// </summary>
+        /// <param name="userId">ID of user to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteUserAsync(string userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Delete an user.
+        /// </summary>
+        /// <param name="user">user to delete</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>async task</returns>
+        Task DeleteUserAsync(User user, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an user.
+        /// </summary>
+        /// <param name="clonedName">name of cloned user</param>
+        /// <param name="userId">ID of user to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned user</returns>
+        Task<User> CloneUserAsync(string clonedName, string userId,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Clone an user.
+        /// </summary>
+        /// <param name="clonedName">name of cloned user</param>
+        /// <param name="user">user to clone</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>cloned user</returns>
+        Task<User> CloneUserAsync(string clonedName, User user, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Returns currently authenticated user.
+        /// </summary>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>currently authenticated user</returns>
+        Task<User> MeAsync(CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Update the password to a currently authenticated user.
+        /// </summary>
+        /// <param name="oldPassword">old password</param>
+        /// <param name="newPassword">new password</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>currently authenticated user</returns>
+        Task MeUpdatePasswordAsync(string oldPassword, string newPassword,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Retrieve an user.
+        /// </summary>
+        /// <param name="userId">ID of user to get</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>User Details</returns>
+        Task<User> FindUserByIdAsync(string userId, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// List all users.
+        /// </summary>
+        /// <param name="offset"> (optional)</param>
+        /// <param name="limit"> (optional, default to 20)</param>
+        /// <param name="after">The last resource ID from which to seek from (but not including). This is to be used instead of &#x60;offset&#x60;. (optional)</param>
+        /// <param name="name"> (optional)</param>
+        /// <param name="id"> (optional)</param>
+        /// <param name="cancellationToken">Cancellation token</param>
+        /// <returns>List all users</returns>
+        Task<List<User>> FindUsersAsync(int? offset = null, int? limit = null, string after = null,
+            string name = null, string id = null, CancellationToken cancellationToken = default);
+    }
+
+    public class UsersApi : IUsersApi
     {
         private readonly UsersService _service;
 

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -20,7 +20,105 @@ using RestSharp;
 
 namespace InfluxDB.Client
 {
-    public class WriteApi : IDisposable
+    public interface IWriteApi : IDisposable
+    {
+        /// <summary>
+        /// Write Line Protocol record into specified bucket.
+        /// </summary>
+        /// <param name="record">
+        ///     specifies the record in InfluxDB Line Protocol.
+        ///     The <see cref="record" /> is considered as one batch unit.
+        /// </param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WriteRecord(string record, WritePrecision precision = WritePrecision.Ns, string bucket = null,
+            string org = null);
+
+        /// <summary>
+        /// Write Line Protocol records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WriteRecords(List<string> records, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write Line Protocol records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WriteRecords(string[] records, WritePrecision precision = WritePrecision.Ns, string bucket = null,
+            string org = null);
+
+        /// <summary>
+        /// Write a Data point into specified bucket.
+        /// </summary>
+        /// <param name="point">specifies the Data point to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WritePoint(PointData point, string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WritePoints(List<PointData> points, string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        void WritePoints(PointData[] points, string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write a Measurement into specified bucket.
+        /// </summary>
+        /// <param name="measurement">specifies the Measurement to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        void WriteMeasurement<TM>(TM measurement, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        void WriteMeasurements<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null);
+
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        void WriteMeasurements<TM>(TM[] measurements, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null);
+
+        /// <summary>
+        /// Forces the client to flush all pending writes from the buffer to the InfluxDB via HTTP.
+        /// </summary>
+        void Flush();
+    }
+
+    public class WriteApi : IWriteApi
     {
         private readonly Subject<IObservable<BatchWriteData>> _flush = new Subject<IObservable<BatchWriteData>>();
 

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -13,7 +13,148 @@ using RestSharp;
 
 namespace InfluxDB.Client
 {
-    public class WriteApiAsync
+    public interface IWriteApiAsync
+    {
+        /// <summary>
+        /// Write Line Protocol record into specified bucket.
+        /// </summary>
+        /// <param name="record">specifies the record in InfluxDB Line Protocol. The <see cref="record" /> is considered as one batch unit. </param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WriteRecordAsync(string record, WritePrecision precision = WritePrecision.Ns, string bucket = null,
+            string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Line Protocol records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WriteRecordsAsync(List<string> records, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Line Protocol records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WriteRecordsAsync(string[] records, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Line Protocols records into specified bucket.
+        /// </summary>
+        /// <param name="records">specifies the record in InfluxDB Line Protocol</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <returns>Write Task with IRestResponse</returns>
+        Task<RestResponse> WriteRecordsAsyncWithIRestResponse(IEnumerable<string> records,
+            WritePrecision precision = WritePrecision.Ns, string bucket = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write a Data point into specified bucket.
+        /// </summary>
+        /// <param name="point">specifies the Data point to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WritePointAsync(PointData point, string bucket = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WritePointsAsync(List<PointData> points, string bucket = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        Task WritePointsAsync(PointData[] points, string bucket = null, string org = null,
+            CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Data points into specified bucket.
+        /// </summary>
+        /// <param name="points">specifies the Data points to write into bucket</param>
+        /// <param name="bucket">specifies the destination bucket for writes.
+        /// If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />. </param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <returns>Write Tasks with IRestResponses.</returns>
+        Task<RestResponse[]> WritePointsAsyncWithIRestResponse(IEnumerable<PointData> points,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write a Measurement into specified bucket.
+        /// </summary>
+        /// <param name="measurement">specifies the Measurement to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        Task WriteMeasurementAsync<TM>(TM measurement, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        Task WriteMeasurementsAsync<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        Task WriteMeasurementsAsync<TM>(TM[] measurements, WritePrecision precision = WritePrecision.Ns,
+            string bucket = null, string org = null, CancellationToken cancellationToken = default);
+
+        /// <summary>
+        /// Write Measurements into specified bucket.
+        /// </summary>
+        /// <param name="measurements">specifies Measurements to write into bucket</param>
+        /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
+        /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
+        /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
+        /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
+        /// <typeparam name="TM">measurement type</typeparam>
+        /// <returns>Write Task with IRestResponse</returns>
+        Task<RestResponse> WriteMeasurementsAsyncWithIRestResponse<TM>(IEnumerable<TM> measurements,
+            WritePrecision precision = WritePrecision.Ns, string bucket = null, string org = null,
+            CancellationToken cancellationToken = default);
+    }
+
+    public class WriteApiAsync : IWriteApiAsync
     {
         private readonly InfluxDBClient _influxDbClient;
         private readonly InfluxDBClientOptions _options;


### PR DESCRIPTION
Closes #325 

## Proposed Changes

Added interfaces to APIs to be able to use `moq` library:

```c#
var mockClient = new Mock<IInfluxDBClient>();
var mockQueryApi = new Mock<IQueryApiSync>();

mockClient
    .Setup(library => library.GetQueryApiSync(null))
    .Returns(mockQueryApi.Object);

var mockTables = new List<FluxTable> { new FluxTable() };
mockQueryApi
    .Setup(api => api.QuerySync("from(...", "my-org", CancellationToken.None))
    .Returns(mockTables);

var tables = mockClient.Object.GetQueryApiSync().QuerySync("from(...", "my-org");
Assert.AreEqual(mockTables, tables);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
