### PR TITLE
fix: redact the Authorization HTTP header from log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.4.0 [unreleased]
 
+### Bug Fixes
+1. [#330](https://github.com/influxdata/influxdb-client-csharp/pull/330): Redact the `Authorization` HTTP header from log
+
 ## 4.3.0 [2022-06-24]
 
 ### Features

--- a/Client.Core/Internal/LoggingHandler.cs
+++ b/Client.Core/Internal/LoggingHandler.cs
@@ -126,7 +126,13 @@ namespace InfluxDB.Client.Core.Internal
                 return;
             }
 
-            foreach (var emp in headers) Trace.WriteLine($"{direction} {type}: {emp.Name}={emp.Value}");
+            foreach (var emp in headers)
+            {
+                var value = string.Equals(emp.Name, "Authorization", StringComparison.OrdinalIgnoreCase)
+                    ? "***"
+                    : emp.Value;
+                Trace.WriteLine($"{direction} {type}: {emp.Name}={value}");
+            }
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

Redacted `Authorization` HTTP header from log.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
