### PR TITLE
fix: append task option at the end of script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.5.0 [unreleased]
 
+### Bug Fixes
+1. [#348](https://github.com/influxdata/influxdb-client-csharp/pull/348): Append `task option` at the end of script
+
 ### Dependencies
 Update dependencies:
 

--- a/Client/TasksApi.cs
+++ b/Client/TasksApi.cs
@@ -1324,7 +1324,7 @@ namespace InfluxDB.Client
                 repetition += "\"" + cron + "\"";
             }
 
-            task.Flux = $"option task = {{name: \"{name}\", {repetition}}} \n {flux}";
+            task.Flux = $"{flux}\n\noption task = {{name: \"{name}\", {repetition}}}";
 
             return task;
         }


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-python/issues/490

## Proposed Changes

Append `task option` at the end of script. It allows create task with following Flux:

```
procTotal = from(bucket: "example-bucket")
    |> range(start: -5m)
    |> filter(fn: (r) => r._measurement == "processes" and r._field == "total")

procTotal
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
