### PR TITLE
fix: designe `HealthAsync()` as obsolete in interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 1. [#353](https://github.com/influxdata/influxdb-client-csharp/pull/353): Support for `double` types in LINQ expression [LINQ]
+2. [#359](https://github.com/influxdata/influxdb-client-csharp/issues/359): Designated `HealthAsync` as obsolete in `IInfluxDBClient`
 
 ### Dependencies
 Update dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 ### Bug Fixes
 1. [#353](https://github.com/influxdata/influxdb-client-csharp/pull/353): Support for `double` types in LINQ expression [LINQ]
-2. [#359](https://github.com/influxdata/influxdb-client-csharp/issues/359): Designated `HealthAsync` as obsolete in `IInfluxDBClient`
+2. [#360](https://github.com/influxdata/influxdb-client-csharp/pull/360): Designated `HealthAsync` as obsolete in `IInfluxDBClient`
 
 ### Dependencies
 Update dependencies:

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -181,6 +181,7 @@ namespace InfluxDB.Client
         /// Get the health of an instance.
         /// </summary>
         /// <returns>health of an instance</returns>
+        [Obsolete("This method is obsolete. Call 'PingAsync()' instead.", false)]
         Task<HealthCheck> HealthAsync();
 
         /// <summary>


### PR DESCRIPTION
Closes #359

## Proposed Changes

Designates HealthAsync() as obsolete in interface as well

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
