### PR TITLE
chore(deps): upgrade RestSharp, use builtin support for `synchronous` requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 1. [#353](https://github.com/influxdata/influxdb-client-csharp/pull/353): Support for `double` types in LINQ expression [LINQ]
 1. [#360](https://github.com/influxdata/influxdb-client-csharp/pull/360): Designated `HealthAsync` as obsolete in `IInfluxDBClient`
 
+### Others
+1. [#368](https://github.com/influxdata/influxdb-client-csharp/pull/368): Use builtin support for synchronous HTTP requests from `RestSharp`
+
 ### Documentation
 1. [#355](https://github.com/influxdata/influxdb-client-csharp/pull/355): Add an example how to use `EventHandler` for `WriteApi`
 
@@ -13,6 +16,7 @@ Update dependencies:
 #### Build:
   - [#364](https://github.com/influxdata/influxdb-client-csharp/pull/364): `System.Configuration.ConfigurationManager` to `6.0.1`
   - [#365](https://github.com/influxdata/influxdb-client-csharp/pull/365): `Microsoft.Extensions.ObjectPool` to `6.0.9`
+  - [#368](https://github.com/influxdata/influxdb-client-csharp/pull/368): `RestSharp` to `108.0.2`
 
 #### Examples:
   - [#367](https://github.com/influxdata/influxdb-client-csharp/pull/367): `Radzen.Blazor` to `4.0.0`

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
       <PackageReference Include="NodaTime" Version="3.1.2" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.0" />
-      <PackageReference Include="RestSharp" Version="108.0.1" />
+      <PackageReference Include="RestSharp" Version="108.0.2" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -40,8 +40,7 @@ namespace InfluxDB.Client.Core.Internal
         internal static RestResponse ExecuteSync(this RestClient client,
             RestRequest request, CancellationToken cancellationToken = default)
         {
-            // return client.Execute(request);
-            return client.ExecuteAsync(request, cancellationToken).ConfigureAwait(false).GetAwaiter().GetResult();
+            return client.Execute(request, cancellationToken);
         }
     }
 }


### PR DESCRIPTION
## Proposed Changes

1. Updated `RestSharp` to `108.0.2`
2. Use builtin support for synchronous HTTP requests from `RestSharp`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
