### PR TITLE
chore(ci): migrate Scheduled workflow to Scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,6 +195,9 @@ jobs:
 workflows:
   version: 2
   build:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - check-compilation-warnings
       - check-code-formatting
@@ -227,12 +230,7 @@ workflows:
               only: master
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-dotnet


### PR DESCRIPTION
## Proposed Changes

The **Scheduled Workflows** uses client for nightly builds but the scheduled workflows will be phased out by the end of 2022. The CircleCI's configuration has to be migrate to **Scheduled pipelines**.

- https://circleci.com/docs/workflows/#scheduling-a-workflow
- https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

Configured trigger:

![image](https://user-images.githubusercontent.com/455137/194826367-b5fb21a0-9dba-4abf-94cf-a433417d7f0f.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
