### PR TITLE
feat: Initialize C# client without InfluxDBClientFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## 4.8.0 [unreleased]
 
-:pushpin: The client can be created without `InfluxDBClientFactory`:
+:warning: The client can be created without `InfluxDBClientFactory`:
 
-> `using var client = new InfluxDBClient("http://localhost:8086", "my-token");`
+    using var client = new InfluxDBClient("http://localhost:8086", "my-token");
 
 ### Features
 1. [#388](https://github.com/influxdata/influxdb-client-csharp/pull/388): Initialize C# client without `InfluxDBClientFactory`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.8.0 [unreleased]
 
+### Features
+1. [#388](https://github.com/influxdata/influxdb-client-csharp/pull/388): Initialize C# client without `InfluxDBClientFactory`
+
 ### CI
 1. [#416](https://github.com/influxdata/influxdb-client-csharp/pull/416): Add build for `.NET 7.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 4.8.0 [unreleased]
 
+:pushpin: The client can be created without `InfluxDBClientFactory`:
+
+> `using var client = new InfluxDBClient("http://localhost:8086", "my-token");`
+
 ### Features
 1. [#388](https://github.com/influxdata/influxdb-client-csharp/pull/388): Initialize C# client without `InfluxDBClientFactory`
 

--- a/Client.Legacy.Test/AbstractFluxClientTest.cs
+++ b/Client.Legacy.Test/AbstractFluxClientTest.cs
@@ -21,7 +21,7 @@ namespace Client.Legacy.Test
         [SetUp]
         public new void SetUp()
         {
-            FluxClient = FluxClientFactory.Create(MockServerUrl);
+            FluxClient = new FluxClient(MockServerUrl);
         }
 
         [TearDown]

--- a/Client.Legacy.Test/AbstractItFluxClientTest.cs
+++ b/Client.Legacy.Test/AbstractItFluxClientTest.cs
@@ -23,7 +23,7 @@ namespace Client.Legacy.Test
 
             var options = new FluxConnectionOptions(influxUrl);
 
-            FluxClient = FluxClientFactory.Create(options);
+            FluxClient = new FluxClient(options);
 
             await InfluxDbQuery("CREATE DATABASE " + DatabaseName, DatabaseName);
         }

--- a/Client.Legacy.Test/FluxClientPingTest.cs
+++ b/Client.Legacy.Test/FluxClientPingTest.cs
@@ -40,7 +40,7 @@ namespace Client.Legacy.Test
         public async Task WithAuthentication()
         {
             FluxClient =
-                FluxClientFactory.Create(new FluxConnectionOptions(MockServerUrl, "my-user",
+                new FluxClient(new FluxConnectionOptions(MockServerUrl, "my-user",
                     "my-password".ToCharArray()));
 
             MockServer.Given(Request.Create()
@@ -56,7 +56,7 @@ namespace Client.Legacy.Test
         [Test]
         public async Task WithBasicAuthentication()
         {
-            FluxClient = FluxClientFactory.Create(new FluxConnectionOptions(MockServerUrl, "my-user",
+            FluxClient = new FluxClient(new FluxConnectionOptions(MockServerUrl, "my-user",
                 "my-password".ToCharArray(), FluxConnectionOptions.AuthenticationType.BasicAuthentication));
 
             var auth = System.Text.Encoding.UTF8.GetBytes("my-user:my-password");

--- a/Client.Legacy.Test/FluxClientQueryTest.cs
+++ b/Client.Legacy.Test/FluxClientQueryTest.cs
@@ -230,7 +230,7 @@ namespace Client.Legacy.Test
         public async Task WithAuthentication()
         {
             FluxClient =
-                FluxClientFactory.Create(new FluxConnectionOptions(MockServerUrl, "my-user",
+                new FluxClient(new FluxConnectionOptions(MockServerUrl, "my-user",
                     "my-password".ToCharArray()));
 
             MockServer.Given(Request.Create()
@@ -248,7 +248,7 @@ namespace Client.Legacy.Test
         [Test]
         public async Task WithBasicAuthentication()
         {
-            FluxClient = FluxClientFactory.Create(new FluxConnectionOptions(MockServerUrl, "my-user",
+            FluxClient = new FluxClient(new FluxConnectionOptions(MockServerUrl, "my-user",
                 "my-password".ToCharArray(), FluxConnectionOptions.AuthenticationType.BasicAuthentication));
 
             var auth = System.Text.Encoding.UTF8.GetBytes("my-user:my-password");

--- a/Client.Legacy.Test/FluxClientTest.cs
+++ b/Client.Legacy.Test/FluxClientTest.cs
@@ -16,7 +16,7 @@ namespace Client.Legacy.Test
         [SetUp]
         public void SetUp()
         {
-            _fluxClient = FluxClientFactory.Create("http://localhost:8093");
+            _fluxClient = new FluxClient("http://localhost:8093");
         }
 
         [Test]
@@ -42,7 +42,7 @@ namespace Client.Legacy.Test
                 TimeSpan.FromSeconds(60),
                 webProxy: webProxy);
 
-            var client = FluxClientFactory.Create(options);
+            var client = new FluxClient(options);
 
             Assert.AreEqual(webProxy, GetRestClient(client).Options.Proxy);
         }

--- a/Client.Legacy.Test/FluxClientTest.cs
+++ b/Client.Legacy.Test/FluxClientTest.cs
@@ -42,9 +42,9 @@ namespace Client.Legacy.Test
                 TimeSpan.FromSeconds(60),
                 webProxy: webProxy);
 
-            var fluxClient = FluxClientFactory.Create(options);
+            var client = FluxClientFactory.Create(options);
 
-            Assert.AreEqual(webProxy, GetRestClient(fluxClient).Options.Proxy);
+            Assert.AreEqual(webProxy, GetRestClient(client).Options.Proxy);
         }
 
         [Test]

--- a/Client.Legacy.Test/ItFluxClientTest.cs
+++ b/Client.Legacy.Test/ItFluxClientTest.cs
@@ -213,9 +213,9 @@ namespace Client.Legacy.Test
         {
             var options = new FluxConnectionOptions("http://localhost:8003");
 
-            var fluxClient = FluxClientFactory.Create(options);
+            var client = FluxClientFactory.Create(options);
 
-            await fluxClient.QueryAsync(FromFluxDatabase + " |> last()",
+            await client.QueryAsync(FromFluxDatabase + " |> last()",
                 record => { },
                 error => CountdownEvent.Signal());
 

--- a/Client.Legacy.Test/ItFluxClientTest.cs
+++ b/Client.Legacy.Test/ItFluxClientTest.cs
@@ -213,7 +213,7 @@ namespace Client.Legacy.Test
         {
             var options = new FluxConnectionOptions("http://localhost:8003");
 
-            var client = FluxClientFactory.Create(options);
+            var client = new FluxClient(options);
 
             await client.QueryAsync(FromFluxDatabase + " |> last()",
                 record => { },

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -136,9 +136,16 @@ namespace InfluxDB.Client.Flux
         /// <item>bucket - default destination bucket for writes</item>
         /// <item>token - the token to use for the authorization</item>
         /// <item>logLevel (default - NONE) - rest client verbosity level</item>
-        /// <item>timeout (default - 10000ms) - The timespan to wait before the HTTP request times out</item>
+        /// <item>timeout (default - 10000) - The timespan to wait before the HTTP request times out in milliseconds</item>
         /// <item>allowHttpRedirects (default - false) - Configure automatically following HTTP 3xx redirects</item>
         /// <item>verifySsl (default - true) - Ignore Certificate Validation Errors when false</item>
+        /// </list>
+        /// Options for logLevel:
+        /// <list type="bullet">
+        /// <item>Basic - Logs request and response lines.</item>
+        /// <item>Body - Logs request and response lines including headers and body (if present). Note that applying the `Body` LogLevel will disable chunking while streaming and will load the whole response into memory.</item>
+        /// <item>Headers - Logs request and response lines including headers.</item>
+        /// <item>None - Disable logging.</item>
         /// </list>
         /// </para>
         /// </summary>

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -126,6 +126,18 @@ namespace InfluxDB.Client.Flux
     {
         private readonly LoggingHandler _loggingHandler;
 
+        /// <summary>
+        /// Create a instance of the Flux client.
+        /// </summary>
+        /// <param name="connectionString">the connectionString to connect to InfluxDB</param>
+        public FluxClient(string connectionString) : this(new FluxConnectionOptions(connectionString))
+        {
+        }
+
+        /// <summary>
+        /// Create a instance of the Flux client.
+        /// </summary>
+        /// <param name="options">the connection configuration</param>
         public FluxClient(FluxConnectionOptions options) : base(new FluxResultMapper())
         {
             _loggingHandler = new LoggingHandler(LogLevel.None);

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -127,7 +127,20 @@ namespace InfluxDB.Client.Flux
         private readonly LoggingHandler _loggingHandler;
 
         /// <summary>
-        /// Create a instance of the Flux client.
+        /// Create a instance of the Flux client. The url could be a connection string with various configurations.
+        /// <para>
+        /// e.g.: "http://localhost:8086?timeout=5000&amp;logLevel=BASIC
+        /// The following options are supported:
+        /// <list type="bullet">
+        /// <item>org - default destination organization for writes and queries</item>
+        /// <item>bucket - default destination bucket for writes</item>
+        /// <item>token - the token to use for the authorization</item>
+        /// <item>logLevel (default - NONE) - rest client verbosity level</item>
+        /// <item>timeout (default - 10000ms) - The timespan to wait before the HTTP request times out</item>
+        /// <item>allowHttpRedirects (default - false) - Configure automatically following HTTP 3xx redirects</item>
+        /// <item>verifySsl (default - true) - Ignore Certificate Validation Errors when false</item>
+        /// </list>
+        /// </para>
         /// </summary>
         /// <param name="connectionString">the connectionString to connect to InfluxDB</param>
         public FluxClient(string connectionString) : this(new FluxConnectionOptions(connectionString))

--- a/Client.Legacy/FluxClientFactory.cs
+++ b/Client.Legacy/FluxClientFactory.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace InfluxDB.Client.Flux
 {
     /// <summary>
@@ -10,6 +12,8 @@ namespace InfluxDB.Client.Flux
         /// </summary>
         /// <param name="connectionString">the connectionString to connect to InfluxDB</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="FluxClient(string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'FluxClient' initializer instead.", false)]
         public static FluxClient Create(string connectionString)
         {
             var options = new FluxConnectionOptions(connectionString);
@@ -22,6 +26,8 @@ namespace InfluxDB.Client.Flux
         /// </summary>
         /// <param name="options">the connection configuration</param>
         /// <returns></returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="FluxClient(FluxConnectionOptions)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'FluxClient' initializer instead.", false)]
         public static FluxClient Create(FluxConnectionOptions options)
         {
             return new FluxClient(options);

--- a/Client.Legacy/README.md
+++ b/Client.Legacy/README.md
@@ -31,9 +31,9 @@ The `FluxClientFactory` creates an instance of a `FluxClient` client that can be
 // client creation
 var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-using var fluxClient = new FluxClient(options);
+using var client = new FluxClient(options);
 
-fluxClient.QueryAsync(...)
+client.QueryAsync(...)
 ...
 ```
 #### Authenticate requests
@@ -43,9 +43,9 @@ fluxClient.QueryAsync(...)
 // client creation
 var options = new FluxConnectionOptions("http://127.0.0.1:8086", "my-user", "my-password".ToCharArray());
 
-using var fluxClient = new FluxClient(options);
+using var client = new FluxClient(options);
 
-fluxClient.QueryAsync(...)
+client.QueryAsync(...)
 ...
 ```
 
@@ -55,9 +55,9 @@ fluxClient.QueryAsync(...)
 var options = new FluxConnectionOptions("http://127.0.0.1:8086", "my-user", "my-password".ToCharArray(),
     FluxConnectionOptions.AuthenticationType.BasicAuthentication);
 
-using var fluxClient = new FluxClient(options);
+using var client = new FluxClient(options);
 
-fluxClient.QueryAsync(...)
+client.QueryAsync(...)
 ...
 ```
 

--- a/Client.Legacy/README.md
+++ b/Client.Legacy/README.md
@@ -123,7 +123,7 @@ The Requests and Responses can be logged by changing the LogLevel. LogLevel valu
 applying the `Body` LogLevel will disable chunking while streaming and will load the whole response into memory.  
 
 ```c#
-fluxClient.SetLogLevel(LogLevel.Body)
+client.SetLogLevel(LogLevel.Body)
 ```
  
 ## Version

--- a/Client.Legacy/README.md
+++ b/Client.Legacy/README.md
@@ -31,7 +31,7 @@ The `FluxClientFactory` creates an instance of a `FluxClient` client that can be
 // client creation
 var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-using var fluxClient = FluxClientFactory.Create(options);
+using var fluxClient = new FluxClient(options);
 
 fluxClient.QueryAsync(...)
 ...
@@ -43,7 +43,7 @@ fluxClient.QueryAsync(...)
 // client creation
 var options = new FluxConnectionOptions("http://127.0.0.1:8086", "my-user", "my-password".ToCharArray());
 
-using var fluxClient = FluxClientFactory.Create(options);
+using var fluxClient = new FluxClient(options);
 
 fluxClient.QueryAsync(...)
 ...
@@ -55,7 +55,7 @@ fluxClient.QueryAsync(...)
 var options = new FluxConnectionOptions("http://127.0.0.1:8086", "my-user", "my-password".ToCharArray(),
     FluxConnectionOptions.AuthenticationType.BasicAuthentication);
 
-using var fluxClient = FluxClientFactory.Create(options);
+using var fluxClient = new FluxClient(options);
 
 fluxClient.QueryAsync(...)
 ...

--- a/Client.Linq.Test/InfluxDBQueryVariableTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVariableTest.cs
@@ -20,7 +20,7 @@ namespace Client.Linq.Test
         [SetUp]
         public new Task SetUp()
         {
-            _client = InfluxDBClientFactory.Create(GetInfluxDb2Url(), "my-token");
+            _client = new InfluxDBClient(GetInfluxDb2Url(), "my-token");
             _client.SetLogLevel(LogLevel.Body);
             return Task.CompletedTask;
         }
@@ -28,7 +28,7 @@ namespace Client.Linq.Test
         [OneTimeSetUp]
         public async Task OneTimeSetUp()
         {
-            _client = InfluxDBClientFactory.Create(GetInfluxDb2Url(), "my-token");
+            _client = new InfluxDBClient(GetInfluxDb2Url(), "my-token");
             _client.SetLogLevel(LogLevel.Body);
 
             _dateTime = DateTime.UtcNow;

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -33,10 +33,7 @@ namespace Client.Linq.Test
         [OneTimeSetUp]
         public void InitQueryApi()
         {
-            var options = new InfluxDBClientOptions.Builder()
-                .Url("http://localhost:8086")
-                .AuthenticateToken("my-token")
-                .Build();
+            var options = new InfluxDBClientOptions("http://localhost:8086") {Token = "my-token"};
             var queryService = new Mock<QueryService>("http://localhost:8086/api/v2");
             _queryApi = new Mock<QueryApiSync>(options, queryService.Object, new FluxResultMapper()).Object;
         }

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -33,7 +33,7 @@ namespace Client.Linq.Test
         [OneTimeSetUp]
         public void InitQueryApi()
         {
-            var options = new InfluxDBClientOptions("http://localhost:8086") {Token = "my-token"};
+            var options = new InfluxDBClientOptions("http://localhost:8086") { Token = "my-token" };
             var queryService = new Mock<QueryService>("http://localhost:8086/api/v2");
             _queryApi = new Mock<QueryApiSync>(options, queryService.Object, new FluxResultMapper()).Object;
         }

--- a/Client.Linq.Test/ItInfluxDBQueryableTest.cs
+++ b/Client.Linq.Test/ItInfluxDBQueryableTest.cs
@@ -18,7 +18,7 @@ namespace Client.Linq.Test
         [SetUp]
         public new async Task SetUp()
         {
-            _client = InfluxDBClientFactory.Create(GetInfluxDb2Url(), "my-token");
+            _client = new InfluxDBClient(GetInfluxDb2Url(), "my-token");
             _client.SetLogLevel(LogLevel.Body);
 
             // DateTime(2020, 10, 15, 8, 20, 15, DateTimeKind.Utc)

--- a/Client.Linq/README.md
+++ b/Client.Linq/README.md
@@ -64,7 +64,7 @@ using InfluxDB.Client.Linq;
 The LINQ query depends on `QueryApiSync`, you could create an instance of `QueryApiSync` by:
 
 ```c#
-var client = InfluxDBClientFactory.Create("http://localhost:8086", "my-token");
+var client = new InfluxDBClient("http://localhost:8086", "my-token");
 var queryApi = client.GetQueryApiSync();
 ```
 
@@ -1170,7 +1170,7 @@ private class InfluxPoint
 The LINQ driver also supports asynchronous querying. For asynchronous queries you have to initialize `InfluxDBQueryable` with asynchronous version of [QueryApi](/Client/QueryApi.cs) and transform `IQueryable<T>` to `IAsyncEnumerable<T>`:
 
 ```c#
-var client = InfluxDBClientFactory.Create("http://localhost:8086", "my-token");
+var client = new InfluxDBClient("http://localhost:8086", "my-token");
 var queryApi = client.GetQueryApi();
 
 var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", queryApi)

--- a/Client.Test/AbstractItClientTest.cs
+++ b/Client.Test/AbstractItClientTest.cs
@@ -18,11 +18,11 @@ namespace InfluxDB.Client.Test
 
             if (!TestContext.CurrentContext.Test.Properties.ContainsKey("basic_auth"))
             {
-                Client = InfluxDBClientFactory.Create(InfluxDbUrl, "my-token");
+                Client = new InfluxDBClient(InfluxDbUrl, "my-token");
             }
             else
             {
-                Client = InfluxDBClientFactory.Create(InfluxDbUrl, "my-user", "my-password".ToCharArray());
+                Client = new InfluxDBClient(InfluxDbUrl, "my-user", "my-password");
             }
         }
 

--- a/Client.Test/ApiClientTest.cs
+++ b/Client.Test/ApiClientTest.cs
@@ -15,10 +15,10 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public void SetUp()
         {
-            var options = new InfluxDBClientOptions.Builder()
-                .Url("http://localhost:8086")
-                .AuthenticateToken("my-token".ToCharArray())
-                .Build();
+            var options = new InfluxDBClientOptions("http://localhost:8086")
+            {
+                Token = "my-token"
+            };
 
             _apiClient = new ApiClient(options, new LoggingHandler(LogLevel.Body), new GzipHandler());
         }
@@ -51,11 +51,11 @@ namespace InfluxDB.Client.Test
         {
             var webProxy = new WebProxy("my-proxy", 8088);
 
-            var options = new InfluxDBClientOptions.Builder()
-                .Url("http://localhost:8086")
-                .AuthenticateToken("my-token".ToCharArray())
-                .Proxy(webProxy)
-                .Build();
+            var options = new InfluxDBClientOptions("http://localhost:8086")
+            {
+                Token = "my-token",
+                WebProxy = webProxy
+            };
 
             _apiClient = new ApiClient(options, new LoggingHandler(LogLevel.Body), new GzipHandler());
 

--- a/Client.Test/GzipHandlerTest.cs
+++ b/Client.Test/GzipHandlerTest.cs
@@ -15,7 +15,7 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            _client = InfluxDBClientFactory.Create(MockServerUrl);
+            _client = new InfluxDBClient(MockServerUrl);
         }
 
         [Test]

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -125,7 +125,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionString()
         {
             _client = new InfluxDBClient("http://localhost:9999?" +
-                                                   "timeout=1000&logLevel=HEADERS&token=my-token&bucket=my-bucket&org=my-org&allowHttpRedirects=true");
+                                         "timeout=1000&logLevel=HEADERS&token=my-token&bucket=my-bucket&org=my-org&allowHttpRedirects=true");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
             Assert.AreEqual("http://localhost:9999/", options.Url);
@@ -164,7 +164,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionStringUnitsMillisecondsSeconds()
         {
             _client = new InfluxDBClient("http://localhost:9999?" +
-                                                   "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+                                         "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
             Assert.AreEqual("http://localhost:9999/", options.Url);
@@ -201,7 +201,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionStringUnitsMinutes()
         {
             _client = new InfluxDBClient("http://localhost:9999?" +
-                      "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+                                         "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
             Assert.AreEqual("http://localhost:9999/", options.Url);
@@ -220,7 +220,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionStringUnitsMinutesFactory()
         {
             _client = InfluxDBClientFactory.Create("http://localhost:9999?" +
-                      "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+                                                   "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
             Assert.AreEqual("http://localhost:9999/", options.Url);
@@ -239,7 +239,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionNotValidDuration()
         {
             var ioe = Assert.Throws<InfluxException>(() => new InfluxDBClient("http://localhost:9999?" +
-                "timeout=x&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
+                                                                              "timeout=x&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
 
             Assert.NotNull(ioe);
             Assert.AreEqual("'x' is not a valid duration", ioe.Message);
@@ -260,7 +260,7 @@ namespace InfluxDB.Client.Test
         public void LoadFromConnectionUnknownUnit()
         {
             var ioe = Assert.Throws<InfluxException>(() => new InfluxDBClient("http://localhost:9999?" +
-                "timeout=1y&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
+                                                                              "timeout=1y&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
 
             Assert.NotNull(ioe);
             Assert.AreEqual("unknown unit for '1y'", ioe.Message);

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -25,6 +25,18 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CreateInstance()
         {
+            _client = new InfluxDBClient("http://localhost:9999");
+
+            Assert.IsNotNull(_client);
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual(false, options.AllowHttpRedirects);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CreateInstanceFactory()
+        {
             _client = InfluxDBClientFactory.Create("http://localhost:9999");
 
             Assert.IsNotNull(_client);
@@ -35,6 +47,18 @@ namespace InfluxDB.Client.Test
 
         [Test]
         public void CreateInstanceVerifySsl()
+        {
+            _client = new InfluxDBClient("http://localhost:9999");
+
+            Assert.IsNotNull(_client);
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual(true, options.VerifySsl);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CreateInstanceVerifySslFactory()
         {
             _client = InfluxDBClientFactory.Create("http://localhost:9999");
 
@@ -47,6 +71,15 @@ namespace InfluxDB.Client.Test
         [Test]
         public void CreateInstanceUsername()
         {
+            _client = new InfluxDBClient("http://localhost:9999", "user", "secret");
+
+            Assert.IsNotNull(_client);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CreateInstanceUsernameFactory()
+        {
             _client = InfluxDBClientFactory.Create("http://localhost:9999", "user", "secret".ToCharArray());
 
             Assert.IsNotNull(_client);
@@ -54,6 +87,15 @@ namespace InfluxDB.Client.Test
 
         [Test]
         public void CreateInstanceToken()
+        {
+            _client = new InfluxDBClient("http://localhost:9999", "xyz");
+
+            Assert.IsNotNull(_client);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CreateInstanceTokenFactory()
         {
             _client = InfluxDBClientFactory.Create("http://localhost:9999", "xyz");
 
@@ -64,6 +106,16 @@ namespace InfluxDB.Client.Test
         public void CreateInstanceEmptyToken()
         {
             var empty = Assert.Throws<ArgumentException>(() =>
+                new InfluxDBClient("http://localhost:9999?", ""));
+            Assert.NotNull(empty);
+            Assert.AreEqual("Expecting a non-empty string for token", empty.Message);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CreateInstanceEmptyTokenFactory()
+        {
+            var empty = Assert.Throws<ArgumentException>(() =>
                 InfluxDBClientFactory.Create("http://localhost:9999?", ""));
             Assert.NotNull(empty);
             Assert.AreEqual("Expecting a non-empty string for token", empty.Message);
@@ -71,6 +123,26 @@ namespace InfluxDB.Client.Test
 
         [Test]
         public void LoadFromConnectionString()
+        {
+            _client = new InfluxDBClient("http://localhost:9999?" +
+                                                   "timeout=1000&logLevel=HEADERS&token=my-token&bucket=my-bucket&org=my-org&allowHttpRedirects=true");
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:9999/", options.Url);
+            Assert.AreEqual("my-org", options.Org);
+            Assert.AreEqual("my-bucket", options.Bucket);
+            Assert.AreEqual("my-token".ToCharArray(), options.Token);
+            Assert.AreEqual(true, options.AllowHttpRedirects);
+            Assert.AreEqual(LogLevel.Headers, options.LogLevel);
+            Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.MaxTimeout);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void LoadFromConnectionStringFactory()
         {
             _client = InfluxDBClientFactory.Create("http://localhost:9999?" +
                                                    "timeout=1000&logLevel=HEADERS&token=my-token&bucket=my-bucket&org=my-org&allowHttpRedirects=true");
@@ -91,6 +163,25 @@ namespace InfluxDB.Client.Test
         [Test]
         public void LoadFromConnectionStringUnitsMillisecondsSeconds()
         {
+            _client = new InfluxDBClient("http://localhost:9999?" +
+                                                   "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:9999/", options.Url);
+            Assert.AreEqual("my-org", options.Org);
+            Assert.AreEqual("my-bucket", options.Bucket);
+            Assert.AreEqual("my-token".ToCharArray(), options.Token);
+            Assert.AreEqual(LogLevel.Headers, options.LogLevel);
+            Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void LoadFromConnectionStringUnitsMillisecondsSecondsFactory()
+        {
             _client = InfluxDBClientFactory.Create("http://localhost:9999?" +
                                                    "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
 
@@ -109,8 +200,8 @@ namespace InfluxDB.Client.Test
         [Test]
         public void LoadFromConnectionStringUnitsMinutes()
         {
-            _client = InfluxDBClientFactory.Create("http://localhost:9999?" +
-                                                   "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+            _client = new InfluxDBClient("http://localhost:9999?" +
+                      "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
             Assert.AreEqual("http://localhost:9999/", options.Url);
@@ -125,7 +216,38 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        [Obsolete("Obsolete")]
+        public void LoadFromConnectionStringUnitsMinutesFactory()
+        {
+            _client = InfluxDBClientFactory.Create("http://localhost:9999?" +
+                      "timeout=1ms&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org");
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:9999/", options.Url);
+            Assert.AreEqual("my-org", options.Org);
+            Assert.AreEqual("my-bucket", options.Bucket);
+            Assert.AreEqual("my-token".ToCharArray(), options.Token);
+            Assert.AreEqual(LogLevel.Headers, options.LogLevel);
+            Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
         public void LoadFromConnectionNotValidDuration()
+        {
+            var ioe = Assert.Throws<InfluxException>(() => new InfluxDBClient("http://localhost:9999?" +
+                "timeout=x&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
+
+            Assert.NotNull(ioe);
+            Assert.AreEqual("'x' is not a valid duration", ioe.Message);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void LoadFromConnectionNotValidDurationFactory()
         {
             var ioe = Assert.Throws<InfluxException>(() => InfluxDBClientFactory.Create("http://localhost:9999?" +
                 "timeout=x&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
@@ -137,6 +259,17 @@ namespace InfluxDB.Client.Test
         [Test]
         public void LoadFromConnectionUnknownUnit()
         {
+            var ioe = Assert.Throws<InfluxException>(() => new InfluxDBClient("http://localhost:9999?" +
+                "timeout=1y&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
+
+            Assert.NotNull(ioe);
+            Assert.AreEqual("unknown unit for '1y'", ioe.Message);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void LoadFromConnectionUnknownUnitFactory()
+        {
             var ioe = Assert.Throws<InfluxException>(() => InfluxDBClientFactory.Create("http://localhost:9999?" +
                 "timeout=1y&logLevel=Headers&token=my-token&bucket=my-bucket&org=my-org"));
 
@@ -145,6 +278,7 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        [Obsolete("Obsolete")]
         public void LoadFromConfiguration()
         {
             CopyAppConfig();
@@ -198,6 +332,29 @@ namespace InfluxDB.Client.Test
         [Test]
         public void V1Configuration()
         {
+            _client = new InfluxDBClient("http://localhost:8086", "my-username",
+                "my-password", "database", "week");
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:8086", options.Url);
+            Assert.AreEqual("-", options.Org);
+            Assert.AreEqual("database/week", options.Bucket);
+            Assert.AreEqual("my-username:my-password".ToCharArray(), options.Token);
+
+            _client.Dispose();
+            _client = new InfluxDBClient("http://localhost:8086", null, null, "database", null);
+
+            options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:8086", options.Url);
+            Assert.AreEqual("-", options.Org);
+            Assert.AreEqual("database/", options.Bucket);
+            Assert.AreEqual(":".ToCharArray(), options.Token);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void V1ConfigurationFactory()
+        {
             _client = InfluxDBClientFactory.CreateV1("http://localhost:8086", "my-username",
                 "my-password".ToCharArray(), "database", "week");
 
@@ -220,6 +377,22 @@ namespace InfluxDB.Client.Test
         [Test]
         public void Timeout()
         {
+            var options = new InfluxDBClientOptions("http://localhost:8086")
+            {
+                Token = "my-token",
+                Timeout = TimeSpan.FromSeconds(20)
+            };
+
+            _client = new InfluxDBClient(options);
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.MaxTimeout);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void TimeoutFactory()
+        {
             var options = new InfluxDBClientOptions.Builder()
                 .Url("http://localhost:8086")
                 .AuthenticateToken("my-token".ToCharArray())
@@ -235,6 +408,14 @@ namespace InfluxDB.Client.Test
         [Test]
         public void AnonymousSchema()
         {
+            var options = new InfluxDBClientOptions("http://localhost:9999");
+            Assert.AreEqual(InfluxDBClientOptions.AuthenticationScheme.Anonymous, options.AuthScheme);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void AnonymousSchemaFactory()
+        {
             var options = new InfluxDBClientOptions.Builder()
                 .Url("http://localhost:9999")
                 .Build();
@@ -243,6 +424,55 @@ namespace InfluxDB.Client.Test
 
         [Test]
         public void Certificates()
+        {
+            const string testingPem = @"MIIFZjCCA04CCQCMEn5e+4xmLTANBgkqhkiG9w0BAQsFADB1MQswCQYDVQQGEwJV
+UzEQMA4GA1UECAwHTmV3WW9yazEQMA4GA1UEBwwHTmV3WW9yazEdMBsGA1UECgwU
+SW5mbHV4REJQeXRob25DbGllbnQxDzANBgNVBAsMBkNsaWVudDESMBAGA1UEAwwJ
+bG9jYWxob3N0MB4XDTIwMDcyMDA2MzA0OVoXDTQ3MTIwNjA2MzA0OVowdTELMAkG
+A1UEBhMCVVMxEDAOBgNVBAgMB05ld1lvcmsxEDAOBgNVBAcMB05ld1lvcmsxHTAb
+BgNVBAoMFEluZmx1eERCUHl0aG9uQ2xpZW50MQ8wDQYDVQQLDAZDbGllbnQxEjAQ
+BgNVBAMMCWxvY2FsaG9zdDCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB
+AMoqURng8JwLYe4IHyIAGlI80utBLq6XbDETY93Pr6ZdHePr2jM+UIfFtdkpqdJw
+56ZxnJPtM1kDQJTsGfkf0/ePKZpnunNk+lkz9l5uQPVcujydplhJgJeHEj49s3Yy
+mWYetcR1Oejnqxgh+9Ev79r1Napu3s80SACPgvTP45CLp1hOGFySRaW7jcG3i+V4
+ljQWVAEse9Vy3e7E1EY2p6z/Zvj2UVOMqdHsivR1XLy5hts5ubIqOqvOCPocJ+0/
+m0AjwCXO4QPy7pLAAa7DA9rWDpzx8jpdfe54NOHuj4SVP45+PPsWvvkN2ZOkC/vb
+zz4DcYVwIqtqej8mvO2kkPIFLdRSKUc5N3xmdvF5awBGfHhb4l/KIDlhRle+L9kF
+LxRgkmBb2FFfL0/GtQlpH0bHHwPij4jPcOY+ueLKmAMgwWdqYae0HS01F7nYeZuP
+StDG+YuCjglOH8xugcV9GBXrRTijyjuml4st3Wl4tPpQClmdoZ2LXp5h/6Zq1aoc
+QlraKjwuTuzQBBHIFh9KXLZANLtMLpGGepFSMqE6YIWl17gi/2NruP8MGXNk+7GM
+ylczKu/Ny67qQ8JCnRLSNUXPg18LjU2voLuzgXWtuTUgRnQBdir6ZB5Bwc2zi0vx
+DNl0yzDhGNFdR5Rng5lAcmclA4QWi7Oc4h/OLN0ma0UzAgMBAAEwDQYJKoZIhvcN
+AQELBQADggIBADsWOWIMvynE2Iwtpv471kROYdqrj6Zj5P8Ye5/0lqedRxIYWDsc
+XDii+ePem+cMhnty8tAqCeHIdBUN86ibP+oqlwySbvdvW121RfedsWpa+TPC+Rnj
+8n5w0urVNpnYuep2f8SOpQ1WdXFMLIsKqcnV5KK3/rxOAUY9cNVumA55/terQMOZ
+RSGfjtoKVkMSOxNlaj4frLNy+I7nyWYrZ9UmUirvGLce5LJ1nrmo2I46FA0XDwu8
+xJqe4mB3GT/t9kFujd3Q/MtgD4J/MjWBfSYV0vlzI+VuoRctikw2SWQckQWNlIhs
+LPafo6D+lOxJtH58WksCxdb8C8sBbRl+irv/ZAlvIiOkmcpHcOQ7AbLTtosZs6nX
+p0ptWENlTM3lkt/Xma8txWXfe29tlf/9oheqXKdYunRyvFPL/gBjjR/VWzIS5sT5
+T6z0Vdk7uW9/wzv45vzjES8a8AAFvEkaRS4JBoTCW69mc8RFR89Vp9axRHY/3ohQ
+8pS9K00FLMTObb8qlW31LfKpCUSxHmU00BhGPduMYQF28Xj02zQ5UaeGOnSO5EjU
+pG0N7yqaVwGv9jYQfmnnD7M5LYVweEZ3OzCbfZuNJ4+EHNdZKcJiu2TaOsyxK25q
+AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
+
+            var certificateCollection = new X509CertificateCollection
+                { new X509Certificate2(Convert.FromBase64String(testingPem)) };
+
+            var options = new InfluxDBClientOptions("http://localhost:8086")
+            {
+                Token = "my-token",
+                ClientCertificates = certificateCollection
+            };
+
+            _client = new InfluxDBClient(options);
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(certificateCollection, apiClient.RestClientOptions.ClientCertificates);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void CertificatesFactory()
         {
             const string testingPem = @"MIIFZjCCA04CCQCMEn5e+4xmLTANBgkqhkiG9w0BAQsFADB1MQswCQYDVQQGEwJV
 UzEQMA4GA1UECAwHTmV3WW9yazEQMA4GA1UEBwwHTmV3WW9yazEdMBsGA1UECgwU

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -306,6 +306,33 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        public void LoadFromConfigurationOptions()
+        {
+            CopyAppConfig();
+
+            _client = new InfluxDBClient(InfluxDBClientOptions.LoadConfig());
+
+            var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
+            Assert.AreEqual("http://localhost:9999/", options.Url);
+            Assert.AreEqual("my-org", options.Org);
+            Assert.AreEqual("my-bucket", options.Bucket);
+            Assert.AreEqual("my-token".ToCharArray(), options.Token);
+            Assert.AreEqual(LogLevel.Body, options.LogLevel);
+            Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
+
+            var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.MaxTimeout);
+
+            var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
+                options.PointSettings, "_defaultTags");
+
+            Assert.AreEqual(4, defaultTags.Count);
+            Assert.AreEqual("132-987-655", defaultTags["id"]);
+            Assert.AreEqual("California Miner", defaultTags["customer"]);
+            Assert.AreEqual("${SensorVersion}", defaultTags["version"]);
+        }
+
+        [Test]
         public void LoadFromConfigurationWithoutUrl()
         {
             CopyAppConfig();

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -336,7 +336,7 @@ namespace InfluxDB.Client.Test
                 "my-password", "database", "week");
 
             var options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
-            Assert.AreEqual("http://localhost:8086", options.Url);
+            Assert.AreEqual("http://localhost:8086/", options.Url);
             Assert.AreEqual("-", options.Org);
             Assert.AreEqual("database/week", options.Bucket);
             Assert.AreEqual("my-username:my-password".ToCharArray(), options.Token);
@@ -345,7 +345,7 @@ namespace InfluxDB.Client.Test
             _client = new InfluxDBClient("http://localhost:8086", null, null, "database", null);
 
             options = GetDeclaredField<InfluxDBClientOptions>(_client.GetType(), _client, "_options");
-            Assert.AreEqual("http://localhost:8086", options.Url);
+            Assert.AreEqual("http://localhost:8086/", options.Url);
             Assert.AreEqual("-", options.Org);
             Assert.AreEqual("database/", options.Bucket);
             Assert.AreEqual(":".ToCharArray(), options.Token);

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -31,7 +31,7 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            _client = InfluxDBClientFactory.Create(MockServerUrl);
+            _client = new InfluxDBClient(MockServerUrl);
         }
 
         [Test]
@@ -185,7 +185,7 @@ namespace InfluxDB.Client.Test
                 request.RequestMessage.AbsoluteUrl);
 
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(MockServerUrl + "/");
+            _client = new InfluxDBClient(MockServerUrl + "/");
 
             using (var writeApi = _client.GetWriteApi())
             {
@@ -198,8 +198,10 @@ namespace InfluxDB.Client.Test
                 request.RequestMessage.AbsoluteUrl);
 
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder().Url(MockServerUrl)
-                .AuthenticateToken("my-token").Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl)
+            {
+                Token = "my-token"
+            });
 
             using (var writeApi = _client.GetWriteApi())
             {
@@ -212,8 +214,10 @@ namespace InfluxDB.Client.Test
                 request.RequestMessage.AbsoluteUrl);
 
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder().Url(MockServerUrl + "/")
-                .AuthenticateToken("my-token").Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl + "/")
+            {
+                Token = "my-token"
+            });
 
             using (var writeApi = _client.GetWriteApi())
             {
@@ -256,11 +260,11 @@ namespace InfluxDB.Client.Test
         public async Task RedirectToken()
         {
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
-                .Url(MockServerUrl)
-                .AuthenticateToken("my-token")
-                .AllowRedirects(true)
-                .Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl)
+            {
+                Token = "my-token",
+                AllowHttpRedirects = true
+            });
 
             var anotherServer = WireMockServer.Start(new WireMockServerSettings
             {
@@ -292,11 +296,12 @@ namespace InfluxDB.Client.Test
         public async Task RedirectCookie()
         {
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
-                .Url(MockServerUrl)
-                .Authenticate("my-username", "my-password".ToCharArray())
-                .AllowRedirects(true)
-                .Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl)
+            {
+                Username = "my-username", 
+                Password = "my-password",
+                AllowHttpRedirects = true
+            });
 
             var anotherServer = WireMockServer.Start(new WireMockServerSettings
             {
@@ -331,9 +336,7 @@ namespace InfluxDB.Client.Test
         public async Task Anonymous()
         {
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
-                .Url(MockServerUrl)
-                .Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl));
 
             MockServer
                 .Given(Request.Create().UsingGet())
@@ -385,10 +388,10 @@ namespace InfluxDB.Client.Test
             var reached = false;
 
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(new InfluxDBClientOptions.Builder()
-                .Url(mockServerSsl.Urls[0])
-                .RemoteCertificateValidationCallback((sender, certificate, chain, errors) => reached = true)
-                .Build());
+            _client = new InfluxDBClient(new InfluxDBClientOptions(mockServerSsl.Urls[0])
+            {
+                VerifySslCallback = (sender, certificate, chain, errors) => reached = true
+            });
 
             mockServerSsl.Given(Request.Create().WithPath("/ping").UsingGet())
                 .RespondWith(Response.Create().WithStatusCode(204)
@@ -422,7 +425,7 @@ namespace InfluxDB.Client.Test
         public void RedactedAuthorizationHeader()
         {
             _client.Dispose();
-            _client = InfluxDBClientFactory.Create(MockServerUrl, "my-token");
+            _client = new InfluxDBClient(MockServerUrl, "my-token");
 
             var writer = new StringWriter();
             Trace.Listeners.Add(new TextWriterTraceListener(writer));

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -298,7 +298,7 @@ namespace InfluxDB.Client.Test
             _client.Dispose();
             _client = new InfluxDBClient(new InfluxDBClientOptions(MockServerUrl)
             {
-                Username = "my-username", 
+                Username = "my-username",
                 Password = "my-password",
                 AllowHttpRedirects = true
             });

--- a/Client.Test/ItDeleteApiTest.cs
+++ b/Client.Test/ItDeleteApiTest.cs
@@ -136,10 +136,10 @@ namespace InfluxDB.Client.Test
                 Token = _token,
                 DefaultTags = new Dictionary<string, string>
                 {
-                    {"id", "132-987-655"},
-                    {"customer", "California Miner"},
-                    {"env-var", "${env.point-datacenter}"},
-                    {"sensor-version", "${point-sensor.version}"}
+                    { "id", "132-987-655" },
+                    { "customer", "California Miner" },
+                    { "env-var", "${env.point-datacenter}" },
+                    { "sensor-version", "${point-sensor.version}" }
                 }
             };
 

--- a/Client.Test/ItDeleteApiTest.cs
+++ b/Client.Test/ItDeleteApiTest.cs
@@ -41,9 +41,13 @@ namespace InfluxDB.Client.Test
             _token = authorization.Token;
 
             Client.Dispose();
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl).AuthenticateToken(_token)
-                .Org(_organization.Id).Bucket(_bucket.Id).Build();
-            Client = InfluxDBClientFactory.Create(options);
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                Org = _organization.Id,
+                Bucket = _bucket.Id
+            };
+            Client = new InfluxDBClient(options);
             _queryApi = Client.GetQueryApi();
         }
 
@@ -127,15 +131,19 @@ namespace InfluxDB.Client.Test
             Environment.SetEnvironmentVariable("point-datacenter", "LA");
             ConfigurationManager.AppSettings["point-sensor.version"] = "1.23a";
 
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
-                .AuthenticateToken(_token)
-                .AddDefaultTag("id", "132-987-655")
-                .AddDefaultTag("customer", "California Miner")
-                .AddDefaultTag("env-var", "${env.point-datacenter}")
-                .AddDefaultTag("sensor-version", "${point-sensor.version}")
-                .Build();
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                DefaultTags = new Dictionary<string, string>
+                {
+                    {"id", "132-987-655"},
+                    {"customer", "California Miner"},
+                    {"env-var", "${env.point-datacenter}"},
+                    {"sensor-version", "${point-sensor.version}"}
+                }
+            };
 
-            Client = InfluxDBClientFactory.Create(options);
+            Client = new InfluxDBClient(options);
 
             var point = PointData.Measurement("h2o_feet").Tag("location", "east").Field("water_level", 1);
             var point2 = PointData.Measurement("h2o_feet").Tag("location", "west").Field("water_level", 2);

--- a/Client.Test/ItInfluxDBClientTest.cs
+++ b/Client.Test/ItInfluxDBClientTest.cs
@@ -11,6 +11,7 @@ namespace InfluxDB.Client.Test
     public class ItInfluxDBClientTest : AbstractItClientTest
     {
         [Test]
+        [Obsolete("Obsolete")]
         public async Task Health()
         {
             var health = await Client.HealthAsync();
@@ -22,9 +23,10 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        [Obsolete("Obsolete")]
         public async Task HealthNotRunningInstance()
         {
-            var clientNotRunning = InfluxDBClientFactory.Create("http://localhost:8099");
+            var clientNotRunning = new InfluxDBClient("http://localhost:8099");
             var health = await clientNotRunning.HealthAsync();
 
             Assert.IsNotNull(health);
@@ -45,7 +47,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task PingNotRunningInstance()
         {
-            var clientNotRunning = InfluxDBClientFactory.Create("http://localhost:8099");
+            var clientNotRunning = new InfluxDBClient("http://localhost:8099");
 
             Assert.IsFalse(await clientNotRunning.PingAsync());
 
@@ -61,7 +63,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void VersionNotRunningInstance()
         {
-            var clientNotRunning = InfluxDBClientFactory.Create("http://localhost:8099");
+            var clientNotRunning = new InfluxDBClient("http://localhost:8099");
 
             var ex = Assert.ThrowsAsync<InfluxException>(async () => await clientNotRunning.VersionAsync());
 
@@ -97,7 +99,7 @@ namespace InfluxDB.Client.Test
             var url = $"http://{GetOrDefaultEnvironmentVariable("INFLUXDB_2_ONBOARDING_IP", "localhost")}:" +
                       $"{GetOrDefaultEnvironmentVariable("INFLUXDB_2_ONBOARDING_PORT", "9990")}";
 
-            using (var client = InfluxDBClientFactory.Create(url))
+            using (var client = new InfluxDBClient(url))
             {
                 Assert.IsTrue(await client.IsOnboardingAllowedAsync());
             }
@@ -120,7 +122,7 @@ namespace InfluxDB.Client.Test
             Assert.IsNotEmpty(onboarding.Auth.Id);
             Assert.IsNotEmpty(onboarding.Auth.Token);
 
-            using (var client = InfluxDBClientFactory.Create(url, onboarding.Auth.Token))
+            using (var client = new InfluxDBClient(url, onboarding.Auth.Token))
             {
                 var user = await client.GetUsersApi().MeAsync();
 
@@ -164,7 +166,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task ReadyNotRunningInstance()
         {
-            var clientNotRunning = InfluxDBClientFactory.Create("http://localhost:8099");
+            var clientNotRunning = new InfluxDBClient("http://localhost:8099");
             var ready = await clientNotRunning.ReadyAsync();
 
             Assert.IsNull(ready);
@@ -177,7 +179,7 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            Client = InfluxDBClientFactory.Create(InfluxDbUrl, "my-user", "my-password".ToCharArray());
+            Client = new InfluxDBClient(InfluxDbUrl, "my-user", "my-password");
 
             var measurement = $"mem_{DateTimeOffset.Now.ToUnixTimeSeconds()}";
             await Client

--- a/Client.Test/ItMonitoringAlertingTest.cs
+++ b/Client.Test/ItMonitoringAlertingTest.cs
@@ -21,7 +21,7 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            _client = InfluxDBClientFactory.Create(GetInfluxDb2Url(), "my-token");
+            _client = new InfluxDBClient(GetInfluxDb2Url(), "my-token");
         }
 
         [TearDown]

--- a/Client.Test/ItTasksApiTest.cs
+++ b/Client.Test/ItTasksApiTest.cs
@@ -21,7 +21,7 @@ namespace InfluxDB.Client.Test
             var authorization = await AddAuthorization(_organization);
 
             Client.Dispose();
-            Client = InfluxDBClientFactory.Create(InfluxDbUrl, authorization.Token);
+            Client = new InfluxDBClient(InfluxDbUrl, authorization.Token);
 
             _tasksApi = Client.GetTasksApi();
 
@@ -297,7 +297,7 @@ namespace InfluxDB.Client.Test
         public async Task FindTasksByUser()
         {
             Client.Dispose();
-            Client = InfluxDBClientFactory.Create(InfluxDbUrl, "my-user", "my-password".ToCharArray());
+            Client = new InfluxDBClient(InfluxDbUrl, "my-user", "my-password");
             _tasksApi = Client.GetTasksApi();
 
             var user = (await Client.GetUsersApi().FindUsersAsync(name: "my-user"))[0];

--- a/Client.Test/ItWriteApiAsyncTest.cs
+++ b/Client.Test/ItWriteApiAsyncTest.cs
@@ -44,9 +44,13 @@ namespace InfluxDB.Client.Test
             _token = authorization.Token;
 
             Client.Dispose();
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl).AuthenticateToken(_token)
-                .Org(_organization.Id).Bucket(_bucket.Id).Build();
-            Client = InfluxDBClientFactory.Create(options);
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                Org = _organization.Id,
+                Bucket = _bucket.Id
+            };
+            Client = new InfluxDBClient(options);
 
             _writeApi = Client.GetWriteApiAsync();
         }

--- a/Client.Test/ItWriteApiRaceTest.cs
+++ b/Client.Test/ItWriteApiRaceTest.cs
@@ -97,7 +97,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task BatchConsistency()
         {
-            var options = new WriteOptions {BatchSize = 1_555, FlushInterval = 10_000};
+            var options = new WriteOptions { BatchSize = 1_555, FlushInterval = 10_000 };
 
             var batches = new List<WriteSuccessEvent>();
             await StressfulWriteAndValidate(1, 5, options, (sender, eventArgs) =>
@@ -131,7 +131,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task MultipleBucketsWithFlush()
         {
-            var writeOptions = new WriteOptions {FlushInterval = 100};
+            var writeOptions = new WriteOptions { FlushInterval = 100 };
 
             await StressfulWriteAndValidate(writeOptions: writeOptions);
         }
@@ -143,7 +143,7 @@ namespace InfluxDB.Client.Test
 
             using var countdownEvent = new CountdownEvent(1);
             using var writeApi = Client
-                .GetWriteApi(writeOptions ?? new WriteOptions {FlushInterval = 20_000});
+                .GetWriteApi(writeOptions ?? new WriteOptions { FlushInterval = 20_000 });
             writeApi.EventHandler += eventHandler;
 
             var writers = new List<Writer>();

--- a/Client.Test/ItWriteManyMeasurements.cs
+++ b/Client.Test/ItWriteManyMeasurements.cs
@@ -41,9 +41,8 @@ namespace InfluxDB.Client.Test
         [Test]
         public async Task Write()
         {
-            var m_client = InfluxDBClientFactory.Create("http://localhost:9999", "my-token");
-            var api = m_client.GetWriteApi(WriteOptions.CreateNew().BatchSize(MaxBarsPerRequest).FlushInterval(10_000)
-                .Build());
+            var client = new InfluxDBClient("http://localhost:9999", "my-token");
+            var api = client.GetWriteApi(new WriteOptions {BatchSize = MaxBarsPerRequest,FlushInterval=10_000});
 
             var start = 0;
             for (;;)
@@ -69,7 +68,7 @@ namespace InfluxDB.Client.Test
 
             Trace.WriteLine("Flushing data...");
 
-            m_client.Dispose();
+            client.Dispose();
 
             Trace.WriteLine("Finished");
         }

--- a/Client.Test/ItWriteManyMeasurements.cs
+++ b/Client.Test/ItWriteManyMeasurements.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client.Test
         public async Task Write()
         {
             var client = new InfluxDBClient("http://localhost:9999", "my-token");
-            var api = client.GetWriteApi(new WriteOptions {BatchSize = MaxBarsPerRequest,FlushInterval=10_000});
+            var api = client.GetWriteApi(new WriteOptions { BatchSize = MaxBarsPerRequest, FlushInterval = 10_000 });
 
             var start = 0;
             for (;;)

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -83,7 +83,11 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var options = new InfluxDBClientOptions(InfluxDbUrl) {Token = _token};
+            var options = new InfluxDBClientOptions.Builder()
+                .LoadConfig()
+                .Url(InfluxDbUrl)
+                .AuthenticateToken(_token)
+                .Build();
 
             Client = new InfluxDBClient(options);
 
@@ -127,10 +131,10 @@ namespace InfluxDB.Client.Test
                 Token = _token,
                 DefaultTags = new Dictionary<string, string>
                 {
-                    {"id", "132-987-655"},
-                    {"customer", "California Miner"},
-                    {"env-var", "${env.measurement-datacenter}"},
-                    {"sensor-version", "${measurement-sensor.version}"}
+                    { "id", "132-987-655" },
+                    { "customer", "California Miner" },
+                    { "env-var", "${env.measurement-datacenter}" },
+                    { "sensor-version", "${measurement-sensor.version}" }
                 }
             };
 
@@ -177,10 +181,10 @@ namespace InfluxDB.Client.Test
                 Token = _token,
                 DefaultTags = new Dictionary<string, string>
                 {
-                    {"id", "132-987-655"},
-                    {"customer", "California Miner"},
-                    {"env-var", "${env.point-datacenter}"},
-                    {"sensor-version", "${point-sensor.version}"}
+                    { "id", "132-987-655" },
+                    { "customer", "California Miner" },
+                    { "env-var", "${env.point-datacenter}" },
+                    { "sensor-version", "${point-sensor.version}" }
                 }
             };
 
@@ -252,7 +256,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = new WriteOptions {BatchSize = 10, FlushInterval = 100_000};
+            var writeOptions = new WriteOptions { BatchSize = 10, FlushInterval = 100_000 };
 
             _writeApi = Client.GetWriteApi(writeOptions);
             var listener = new WriteApiTest.EventListener(_writeApi);
@@ -284,7 +288,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = new WriteOptions {BatchSize = 6, FlushInterval = 500_000};
+            var writeOptions = new WriteOptions { BatchSize = 6, FlushInterval = 500_000 };
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -326,7 +330,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = new WriteOptions {BatchSize = 1, FlushInterval = 500_000};
+            var writeOptions = new WriteOptions { BatchSize = 1, FlushInterval = 500_000 };
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -370,7 +374,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = new WriteOptions {BatchSize = 10, FlushInterval = 500};
+            var writeOptions = new WriteOptions { BatchSize = 10, FlushInterval = 500 };
 
             _writeApi = Client.GetWriteApi(writeOptions);
             var listener = new WriteApiTest.EventListener(_writeApi);
@@ -408,7 +412,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = new WriteOptions {BatchSize = 1, JitterInterval = 5_000};
+            var writeOptions = new WriteOptions { BatchSize = 1, JitterInterval = 5_000 };
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -476,7 +480,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            _writeApi = Client.GetWriteApi(new WriteOptions {BatchSize = 2});
+            _writeApi = Client.GetWriteApi(new WriteOptions { BatchSize = 2 });
 
             const string records = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n" +
                                    "h2o_feet,location=coyote_hill level\\ water_level=2.0 2x";
@@ -892,7 +896,7 @@ namespace InfluxDB.Client.Test
                     { Level = i, Time = DateTime.UnixEpoch.Add(TimeSpan.FromSeconds(i)), Location = "Europe" });
 
             var successEvents = new List<WriteSuccessEvent>();
-            _writeApi = Client.GetWriteApi(new WriteOptions {BatchSize = batchSize, FlushInterval = 10_000});
+            _writeApi = Client.GetWriteApi(new WriteOptions { BatchSize = batchSize, FlushInterval = 10_000 });
             _writeApi.EventHandler += (sender, args) => { successEvents.Add(args as WriteSuccessEvent); };
 
             var start = 0;

--- a/Client.Test/ItWriteQueryApiTest.cs
+++ b/Client.Test/ItWriteQueryApiTest.cs
@@ -45,9 +45,13 @@ namespace InfluxDB.Client.Test
             _token = authorization.Token;
 
             Client.Dispose();
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl).AuthenticateToken(_token)
-                .Org(_organization.Id).Bucket(_bucket.Id).Build();
-            Client = InfluxDBClientFactory.Create(options);
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                Org = _organization.Id,
+                Bucket = _bucket.Id
+            };
+            Client = new InfluxDBClient(options);
             _queryApi = Client.GetQueryApi();
         }
 
@@ -79,13 +83,9 @@ namespace InfluxDB.Client.Test
         {
             Client.Dispose();
 
-            var options = new InfluxDBClientOptions.Builder()
-                .LoadConfig()
-                .Url(InfluxDbUrl)
-                .AuthenticateToken(_token)
-                .Build();
+            var options = new InfluxDBClientOptions(InfluxDbUrl) {Token = _token};
 
-            Client = InfluxDBClientFactory.Create(options);
+            Client = new InfluxDBClient(options);
 
             var measurement1 = new H20Measurement
             {
@@ -122,15 +122,19 @@ namespace InfluxDB.Client.Test
             Environment.SetEnvironmentVariable("measurement-datacenter", "LA");
             ConfigurationManager.AppSettings["measurement-sensor.version"] = "1.23a";
 
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
-                .AuthenticateToken(_token)
-                .AddDefaultTag("id", "132-987-655")
-                .AddDefaultTag("customer", "California Miner")
-                .AddDefaultTag("env-var", "${env.measurement-datacenter}")
-                .AddDefaultTag("sensor-version", "${measurement-sensor.version}")
-                .Build();
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                DefaultTags = new Dictionary<string, string>
+                {
+                    {"id", "132-987-655"},
+                    {"customer", "California Miner"},
+                    {"env-var", "${env.measurement-datacenter}"},
+                    {"sensor-version", "${measurement-sensor.version}"}
+                }
+            };
 
-            Client = InfluxDBClientFactory.Create(options);
+            Client = new InfluxDBClient(options);
 
             var measurement1 = new H20Measurement
             {
@@ -168,15 +172,19 @@ namespace InfluxDB.Client.Test
             Environment.SetEnvironmentVariable("point-datacenter", "LA");
             ConfigurationManager.AppSettings["point-sensor.version"] = "1.23a";
 
-            var options = new InfluxDBClientOptions.Builder().Url(InfluxDbUrl)
-                .AuthenticateToken(_token)
-                .AddDefaultTag("id", "132-987-655")
-                .AddDefaultTag("customer", "California Miner")
-                .AddDefaultTag("env-var", "${env.point-datacenter}")
-                .AddDefaultTag("sensor-version", "${point-sensor.version}")
-                .Build();
+            var options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                DefaultTags = new Dictionary<string, string>
+                {
+                    {"id", "132-987-655"},
+                    {"customer", "California Miner"},
+                    {"env-var", "${env.point-datacenter}"},
+                    {"sensor-version", "${point-sensor.version}"}
+                }
+            };
 
-            Client = InfluxDBClientFactory.Create(options);
+            Client = new InfluxDBClient(options);
 
             var point = PointData.Measurement("h2o_feet").Tag("location", "west").Field("water_level", 1);
 
@@ -244,7 +252,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = WriteOptions.CreateNew().BatchSize(10).FlushInterval(100_000).Build();
+            var writeOptions = new WriteOptions {BatchSize = 10, FlushInterval = 100_000};
 
             _writeApi = Client.GetWriteApi(writeOptions);
             var listener = new WriteApiTest.EventListener(_writeApi);
@@ -276,7 +284,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = WriteOptions.CreateNew().BatchSize(6).FlushInterval(500_000).Build();
+            var writeOptions = new WriteOptions {BatchSize = 6, FlushInterval = 500_000};
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -318,7 +326,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = WriteOptions.CreateNew().BatchSize(1).FlushInterval(500_000).Build();
+            var writeOptions = new WriteOptions {BatchSize = 1, FlushInterval = 500_000};
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -362,7 +370,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = WriteOptions.CreateNew().BatchSize(10).FlushInterval(500).Build();
+            var writeOptions = new WriteOptions {BatchSize = 10, FlushInterval = 500};
 
             _writeApi = Client.GetWriteApi(writeOptions);
             var listener = new WriteApiTest.EventListener(_writeApi);
@@ -400,7 +408,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            var writeOptions = WriteOptions.CreateNew().BatchSize(1).JitterInterval(5_000).Build();
+            var writeOptions = new WriteOptions {BatchSize = 1, JitterInterval = 5_000};
 
             _writeApi = Client.GetWriteApi(writeOptions);
 
@@ -468,7 +476,7 @@ namespace InfluxDB.Client.Test
         {
             var bucketName = _bucket.Name;
 
-            _writeApi = Client.GetWriteApi(WriteOptions.CreateNew().BatchSize(2).Build());
+            _writeApi = Client.GetWriteApi(new WriteOptions {BatchSize = 2});
 
             const string records = "h2o_feet,location=coyote_creek level\\ water_level=1.0 1\n" +
                                    "h2o_feet,location=coyote_hill level\\ water_level=2.0 2x";
@@ -488,7 +496,7 @@ namespace InfluxDB.Client.Test
         {
             // Using WriteApi
             {
-                var client = InfluxDBClientFactory.Create(InfluxDbUrl, _token);
+                var client = new InfluxDBClient(InfluxDbUrl, _token);
 
                 using (var writeApi = client.GetWriteApi())
                 {
@@ -501,19 +509,15 @@ namespace InfluxDB.Client.Test
 
             // Using both
             {
-                using (var client = InfluxDBClientFactory.Create(InfluxDbUrl, _token))
-                {
-                    using (var writeApi = client.GetWriteApi())
-                    {
-                        writeApi.WriteRecord("temperature,location=north value=70.0 2", WritePrecision.Ns, _bucket.Name,
-                            _organization.Id);
-                    }
-                }
+                using var client = new InfluxDBClient(InfluxDbUrl, _token);
+                using var writeApi = client.GetWriteApi();
+                writeApi.WriteRecord("temperature,location=north value=70.0 2", WritePrecision.Ns, _bucket.Name,
+                    _organization.Id);
             }
 
             // Using without
             {
-                var client = InfluxDBClientFactory.Create(InfluxDbUrl, _token);
+                var client = new InfluxDBClient(InfluxDbUrl, _token);
                 var writeApi = client.GetWriteApi();
 
                 writeApi.WriteRecord("temperature,location=north value=80.0 3", WritePrecision.Ns, _bucket.Name,
@@ -888,7 +892,7 @@ namespace InfluxDB.Client.Test
                     { Level = i, Time = DateTime.UnixEpoch.Add(TimeSpan.FromSeconds(i)), Location = "Europe" });
 
             var successEvents = new List<WriteSuccessEvent>();
-            _writeApi = Client.GetWriteApi(WriteOptions.CreateNew().BatchSize(batchSize).FlushInterval(10_000).Build());
+            _writeApi = Client.GetWriteApi(new WriteOptions {BatchSize = batchSize, FlushInterval = 10_000});
             _writeApi.EventHandler += (sender, args) => { successEvents.Add(args as WriteSuccessEvent); };
 
             var start = 0;

--- a/Client.Test/QueryApiSyncTest.cs
+++ b/Client.Test/QueryApiSyncTest.cs
@@ -73,7 +73,7 @@ namespace InfluxDB.Client.Test
         {
             _client.Dispose();
 
-            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
+            var options = new InfluxDBClientOptions(MockServerUrl) { Token = "token" };
 
             _client = new InfluxDBClient(options);
             _queryApiSync = _client.GetQueryApiSync();

--- a/Client.Test/QueryApiSyncTest.cs
+++ b/Client.Test/QueryApiSyncTest.cs
@@ -9,7 +9,7 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class QueryApiSyncTest : AbstractMockServerTest
     {
-        private InfluxDBClient _influxDbClient;
+        private InfluxDBClient _client;
         private QueryApiSync _queryApiSync;
 
         private const string Data =
@@ -23,21 +23,20 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Org("my-org")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl)
+            {
+                Token = "token",
+                Org = "my-org"
+            };
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            _queryApiSync = _influxDbClient.GetQueryApiSync();
+            _client = new InfluxDBClient(options);
+            _queryApiSync = _client.GetQueryApiSync();
         }
 
         [TearDown]
         public void TearDown()
         {
-            _influxDbClient?.Dispose();
+            _client?.Dispose();
         }
 
         [Test]
@@ -72,16 +71,12 @@ namespace InfluxDB.Client.Test
         [Test]
         public void RequiredOrgQuerySync()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
 
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            _queryApiSync = _influxDbClient.GetQueryApiSync();
+            _client = new InfluxDBClient(options);
+            _queryApiSync = _client.GetQueryApiSync();
 
             var ae = Assert.Throws<ArgumentException>(() => _queryApiSync.QuerySync("from(..."));
 

--- a/Client.Test/QueryApiTest.cs
+++ b/Client.Test/QueryApiTest.cs
@@ -30,7 +30,7 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token", Org = "my-org"};
+            var options = new InfluxDBClientOptions(MockServerUrl) { Token = "token", Org = "my-org" };
 
             _client = new InfluxDBClient(options);
             _queryApi = _client.GetQueryApi();
@@ -105,7 +105,7 @@ namespace InfluxDB.Client.Test
         {
             _client.Dispose();
 
-            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
+            var options = new InfluxDBClientOptions(MockServerUrl) { Token = "token" };
 
             _client = new InfluxDBClient(options);
             _queryApi = _client.GetQueryApi();

--- a/Client.Test/QueryApiTest.cs
+++ b/Client.Test/QueryApiTest.cs
@@ -16,7 +16,7 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class QueryApiTest : AbstractMockServerTest
     {
-        private InfluxDBClient _influxDbClient;
+        private InfluxDBClient _client;
         private QueryApi _queryApi;
 
         private const string Data =
@@ -30,21 +30,16 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Org("my-org")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token", Org = "my-org"};
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            _queryApi = _influxDbClient.GetQueryApi();
+            _client = new InfluxDBClient(options);
+            _queryApi = _client.GetQueryApi();
         }
 
         [TearDown]
         public void TearDown()
         {
-            _influxDbClient?.Dispose();
+            _client?.Dispose();
         }
 
         [Test]
@@ -108,16 +103,12 @@ namespace InfluxDB.Client.Test
         [Test]
         public void RequiredOrgQueryAsync()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
 
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            _queryApi = _influxDbClient.GetQueryApi();
+            _client = new InfluxDBClient(options);
+            _queryApi = _client.GetQueryApi();
 
             var ae = Assert.ThrowsAsync<ArgumentException>(async () =>
                 await _queryApi.QueryAsync<SyncPoco>("from(..."));
@@ -134,7 +125,7 @@ namespace InfluxDB.Client.Test
             var writer = new StringWriter();
             Trace.Listeners.Add(new TextWriterTraceListener(writer));
 
-            _influxDbClient.SetLogLevel(LogLevel.Headers);
+            _client.SetLogLevel(LogLevel.Headers);
 
             MockServer
                 .Given(Request.Create().WithPath("/api/v2/query").UsingPost())

--- a/Client.Test/RetryAttemptTest.cs
+++ b/Client.Test/RetryAttemptTest.cs
@@ -49,7 +49,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void MaxRetries()
         {
-            var options = new WriteOptions {MaxRetries = 5};
+            var options = new WriteOptions { MaxRetries = 5 };
 
             var retry = new RetryAttempt(new HttpException("", 429), 1, _default);
             Assert.IsTrue(retry.IsRetry());

--- a/Client.Test/RetryAttemptTest.cs
+++ b/Client.Test/RetryAttemptTest.cs
@@ -11,7 +11,7 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class RetryAttemptTest
     {
-        private readonly WriteOptions _default = WriteOptions.CreateNew().Build();
+        private readonly WriteOptions _default = new WriteOptions();
 
         [Test]
         public void ErrorType()
@@ -49,7 +49,7 @@ namespace InfluxDB.Client.Test
         [Test]
         public void MaxRetries()
         {
-            var options = WriteOptions.CreateNew().MaxRetries(5).Build();
+            var options = new WriteOptions {MaxRetries = 5};
 
             var retry = new RetryAttempt(new HttpException("", 429), 1, _default);
             Assert.IsTrue(retry.IsRetry());
@@ -86,12 +86,13 @@ namespace InfluxDB.Client.Test
         [Test]
         public void ExponentialBase()
         {
-            var options = WriteOptions.CreateNew()
-                .RetryInterval(5_000)
-                .ExponentialBase(5)
-                .MaxRetries(4)
-                .MaxRetryDelay(int.MaxValue)
-                .Build();
+            var options = new WriteOptions
+            {
+                RetryInterval = 5_000,
+                ExponentialBase = 5,
+                MaxRetries = 4,
+                MaxRetryDelay = int.MaxValue
+            };
 
             var retry = new RetryAttempt(new HttpException("", 429), 1, options);
             var retryInterval = retry.GetRetryInterval();
@@ -137,12 +138,13 @@ namespace InfluxDB.Client.Test
         [Test]
         public void MaxRetryDelay()
         {
-            var options = WriteOptions.CreateNew()
-                .RetryInterval(2_000)
-                .ExponentialBase(2)
-                .MaxRetries(10)
-                .MaxRetryDelay(50_000)
-                .Build();
+            var options = new WriteOptions
+            {
+                RetryInterval = 2_000,
+                ExponentialBase = 2,
+                MaxRetries = 10,
+                MaxRetryDelay = 50_000
+            };
 
             var retry = new RetryAttempt(new HttpException("", 429), 1, options);
             Assert.GreaterOrEqual(retry.GetRetryInterval(), 2_000);

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -16,18 +16,18 @@ namespace InfluxDB.Client.Test
     [TestFixture]
     public class WriteApiAsyncTest : AbstractMockServerTest
     {
-        private InfluxDBClient _influxDbClient;
+        private InfluxDBClient _client;
 
         [SetUp]
         public new void SetUp()
         {
-            _influxDbClient = InfluxDBClientFactory.Create(MockServerUrl, "token");
+            _client = new InfluxDBClient(MockServerUrl, "token");
         }
 
         [TearDown]
         public new void ResetServer()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
         }
 
         [Test]
@@ -37,7 +37,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             await writeApi.WritePointsAsync(new List<PointData>
             {
                 PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
@@ -62,7 +62,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             await writeApi.WritePointsAsync(new List<PointData>
             {
                 PointData.Measurement("h2o").Tag("location", "coyote_creek").Field("water_level", 9.0D)
@@ -93,7 +93,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
 
             var points = new List<PointData>
             {
@@ -141,7 +141,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             var response = await writeApi.WriteRecordsAsyncWithIRestResponse(
                 new[] { "h2o,location=coyote_creek water_level=9 1" },
                 WritePrecision.Ms, "my-bucket", "my-org");
@@ -160,7 +160,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             var responses = await writeApi.WritePointsAsyncWithIRestResponse(
                 new[]
                 {
@@ -190,7 +190,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             var response = await writeApi.WriteMeasurementsAsyncWithIRestResponse(
                 new[]
                 {
@@ -211,16 +211,12 @@ namespace InfluxDB.Client.Test
         [Test]
         public void RequiredOrgBucketWriteApiAsync()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
 
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            _client = new InfluxDBClient(options);
+            var writeApi = _client.GetWriteApiAsync();
 
             var ae = Assert.ThrowsAsync<ArgumentException>(async () =>
                 await writeApi.WriteRecordAsync(
@@ -246,19 +242,18 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
                 .RespondWith(CreateResponse("{}"));
 
-            _influxDbClient.Dispose();
+            _client.Dispose();
 
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Bucket("my-bucket")
-                .Org("my-org")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl)
+            {
+                Token = "token",
+                Bucket = "my-bucket",
+                Org = "my-org"
+            };
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
+            _client = new InfluxDBClient(options);
 
-            var writeApi = _influxDbClient.GetWriteApiAsync();
+            var writeApi = _client.GetWriteApiAsync();
             await writeApi.WriteRecordsAsyncWithIRestResponse(new[] { "mem,location=a level=1.0 1" });
             await writeApi.WritePointsAsyncWithIRestResponse(new[]
                 { PointData.Measurement("h2o").Field("water_level", 9.0D) });

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -213,7 +213,7 @@ namespace InfluxDB.Client.Test
         {
             _client.Dispose();
 
-            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
+            var options = new InfluxDBClientOptions(MockServerUrl) { Token = "token" };
 
             _client = new InfluxDBClient(options);
             var writeApi = _client.GetWriteApiAsync();

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -22,7 +22,7 @@ namespace InfluxDB.Client.Test
         public new void SetUp()
         {
             _client = new InfluxDBClient(MockServerUrl, "token");
-            _writeApi = _client.GetWriteApi(new WriteOptions {RetryInterval = 1_000});
+            _writeApi = _client.GetWriteApi(new WriteOptions { RetryInterval = 1_000 });
         }
 
         [TearDown]
@@ -511,10 +511,10 @@ namespace InfluxDB.Client.Test
         {
             _client.Dispose();
 
-            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
+            var options = new InfluxDBClientOptions(MockServerUrl) { Token = "token" };
 
             _client = new InfluxDBClient(options);
-            _writeApi = _client.GetWriteApi(new WriteOptions {RetryInterval = 1_000});
+            _writeApi = _client.GetWriteApi(new WriteOptions { RetryInterval = 1_000 });
 
             var ae = Assert.Throws<ArgumentException>(() =>
                 _writeApi.WriteRecord("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1",
@@ -569,7 +569,7 @@ namespace InfluxDB.Client.Test
         public void WritesToDifferentBucketsJitter()
         {
             _writeApi.Dispose();
-            _writeApi = _client.GetWriteApi(new WriteOptions {JitterInterval = 1_000});
+            _writeApi = _client.GetWriteApi(new WriteOptions { JitterInterval = 1_000 });
 
             var listener = new EventListener(_writeApi);
 

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -21,19 +21,19 @@ namespace InfluxDB.Client.Test
         [SetUp]
         public new void SetUp()
         {
-            _influxDbClient = InfluxDBClientFactory.Create(MockServerUrl, "token");
-            _writeApi = _influxDbClient.GetWriteApi(WriteOptions.CreateNew().RetryInterval(1_000).Build());
+            _client = new InfluxDBClient(MockServerUrl, "token");
+            _writeApi = _client.GetWriteApi(new WriteOptions {RetryInterval = 1_000});
         }
 
         [TearDown]
         public new void ResetServer()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
             _writeApi.Dispose();
         }
 
         private WriteApi _writeApi;
-        private InfluxDBClient _influxDbClient;
+        private InfluxDBClient _client;
 
         private IResponseBuilder CreateResponse(string error, int status)
         {
@@ -101,23 +101,23 @@ namespace InfluxDB.Client.Test
         [Test]
         public void DisposeCallFromInfluxDbClientToWriteApi()
         {
-            var writeApi = _influxDbClient.GetWriteApi();
+            var writeApi = _client.GetWriteApi();
 
             Assert.False(writeApi.Disposed);
-            _influxDbClient.Dispose();
+            _client.Dispose();
             Assert.True(writeApi.Disposed);
         }
 
         [Test]
         public void DisposedClientRemovedFromApis()
         {
-            var writeApi = _influxDbClient.GetWriteApi();
+            var writeApi = _client.GetWriteApi();
 
             Assert.False(writeApi.Disposed);
             writeApi.Dispose();
             Assert.True(writeApi.Disposed);
 
-            _influxDbClient.Dispose();
+            _client.Dispose();
             // nothing bad happens
         }
 
@@ -306,12 +306,14 @@ namespace InfluxDB.Client.Test
             MockServer.Stop();
             _writeApi.Dispose();
 
-            var options = WriteOptions.CreateNew()
-                .BatchSize(1)
-                .MaxRetryDelay(2_000)
-                .MaxRetries(3)
-                .Build();
-            _writeApi = _influxDbClient.GetWriteApi(options);
+            var options = new WriteOptions
+            {
+                BatchSize = 1,
+                MaxRetryDelay = 2_000,
+                MaxRetries = 3
+            };
+
+            _writeApi = _client.GetWriteApi(options);
 
             var listener = new EventListener(_writeApi);
 
@@ -352,12 +354,14 @@ namespace InfluxDB.Client.Test
                 .WillSetStateTo("RetryWithRetryAfter Finished")
                 .RespondWith(CreateResponse("{}"));
 
-            var options = WriteOptions.CreateNew()
-                .BatchSize(1)
-                .RetryInterval(100)
-                .MaxRetries(1)
-                .Build();
-            _writeApi = _influxDbClient.GetWriteApi(options);
+            var options = new WriteOptions
+            {
+                BatchSize = 1,
+                RetryInterval = 100,
+                MaxRetries = 1
+            };
+
+            _writeApi = _client.GetWriteApi(options);
 
             var listener = new EventListener(_writeApi);
 
@@ -382,8 +386,8 @@ namespace InfluxDB.Client.Test
             _writeApi.Dispose();
             _writeApi.Dispose();
 
-            _influxDbClient.Dispose();
-            _influxDbClient.Dispose();
+            _client.Dispose();
+            _client.Dispose();
         }
 
         [Test]
@@ -421,7 +425,8 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
-        public void WriteOptionsDefaults()
+        [Obsolete("Obsolete")]
+        public void WriteOptionsDefaultsBuilder()
         {
             var options = WriteOptions.CreateNew().Build();
 
@@ -432,7 +437,19 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
-        public void WriteOptionsCustom()
+        public void WriteOptionsDefaults()
+        {
+            var options = new WriteOptions();
+
+            Assert.AreEqual(5_000, options.RetryInterval);
+            Assert.AreEqual(5, options.MaxRetries);
+            Assert.AreEqual(125_000, options.MaxRetryDelay);
+            Assert.AreEqual(2, options.ExponentialBase);
+        }
+
+        [Test]
+        [Obsolete("Obsolete")]
+        public void WriteOptionsCustomBuilder()
         {
             var options = WriteOptions.CreateNew()
                 .RetryInterval(1_250)
@@ -440,6 +457,23 @@ namespace InfluxDB.Client.Test
                 .MaxRetryDelay(1_800_000)
                 .ExponentialBase(2)
                 .Build();
+
+            Assert.AreEqual(1_250, options.RetryInterval);
+            Assert.AreEqual(25, options.MaxRetries);
+            Assert.AreEqual(1_800_000, options.MaxRetryDelay);
+            Assert.AreEqual(2, options.ExponentialBase);
+        }
+
+        [Test]
+        public void WriteOptionsCustom()
+        {
+            var options = new WriteOptions
+            {
+                RetryInterval = 1_250,
+                MaxRetries = 25,
+                MaxRetryDelay = 1_800_000,
+                ExponentialBase = 2
+            };
 
             Assert.AreEqual(1_250, options.RetryInterval);
             Assert.AreEqual(25, options.MaxRetries);
@@ -475,16 +509,12 @@ namespace InfluxDB.Client.Test
         [Test]
         public void RequiredOrgBucketWriteApi()
         {
-            _influxDbClient.Dispose();
+            _client.Dispose();
 
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(MockServerUrl)
-                .AuthenticateToken("token")
-                .Build();
+            var options = new InfluxDBClientOptions(MockServerUrl) {Token = "token"};
 
-            _influxDbClient = InfluxDBClientFactory.Create(options);
-            _writeApi = _influxDbClient.GetWriteApi(WriteOptions.CreateNew().RetryInterval(1_000).Build());
+            _client = new InfluxDBClient(options);
+            _writeApi = _client.GetWriteApi(new WriteOptions {RetryInterval = 1_000});
 
             var ae = Assert.Throws<ArgumentException>(() =>
                 _writeApi.WriteRecord("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1",
@@ -539,7 +569,7 @@ namespace InfluxDB.Client.Test
         public void WritesToDifferentBucketsJitter()
         {
             _writeApi.Dispose();
-            _writeApi = _influxDbClient.GetWriteApi(WriteOptions.CreateNew().JitterInterval(1_000).Build());
+            _writeApi = _client.GetWriteApi(new WriteOptions {JitterInterval = 1_000});
 
             var listener = new EventListener(_writeApi);
 

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -243,7 +243,7 @@ namespace InfluxDB.Client
                 .Build())
         {
         }
-        
+
         /// <summary>
         /// Create a instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
         /// <para>
@@ -258,7 +258,7 @@ namespace InfluxDB.Client
                 .Build())
         {
         }
-        
+
         /// <summary>
         /// Create a instance of the InfluxDB 2.x client.
         /// </summary>
@@ -269,11 +269,11 @@ namespace InfluxDB.Client
             this(new InfluxDBClientOptions(url)
             {
                 Username = username,
-                Password = password,
+                Password = password
             })
         {
         }
-        
+
         /// <summary>
         /// Create a instance of the InfluxDB 2.x client.
         /// </summary>
@@ -282,11 +282,11 @@ namespace InfluxDB.Client
         public InfluxDBClient(string url, char[] token) :
             this(new InfluxDBClientOptions(url)
             {
-                Token = token,
+                Token = token
             })
         {
         }
-        
+
         /// <summary>
         /// Create a instance of the InfluxDB 2.x client.
         /// </summary>
@@ -295,11 +295,11 @@ namespace InfluxDB.Client
         public InfluxDBClient(string url, string token) :
             this(new InfluxDBClientOptions(url)
             {
-                Token = token.ToCharArray(),
+                Token = token.ToCharArray()
             })
         {
         }
-        
+
         /// <summary>
         /// Create a instance of the InfluxDB 2.x client to connect into InfluxDB 1.8.
         /// </summary>

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -840,7 +840,7 @@ namespace InfluxDB.Client
         /// <returns>new instance of service</returns>
         public TS CreateService<TS>(Type serviceType) where TS : IApiAccessor
         {
-            var instance = (TS) Activator.CreateInstance(serviceType, (Configuration)_apiClient.Configuration);
+            var instance = (TS)Activator.CreateInstance(serviceType, (Configuration)_apiClient.Configuration);
             instance.ExceptionFactory = _exceptionFactory;
 
             return instance;

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -335,19 +335,19 @@ namespace InfluxDB.Client
             _exceptionFactory = (methodName, response) =>
                 !response.IsSuccessful ? HttpException.Create(response, response.Content) : null;
 
-            _setupService = new SetupService((Configuration) _apiClient.Configuration)
+            _setupService = new SetupService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _healthService = new HealthService((Configuration) _apiClient.Configuration)
+            _healthService = new HealthService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _readyService = new ReadyService((Configuration) _apiClient.Configuration)
+            _readyService = new ReadyService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _pingService = new PingService((Configuration) _apiClient.Configuration)
+            _pingService = new PingService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -396,7 +396,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Query API</returns>
         public QueryApi GetQueryApi(IDomainObjectMapper mapper = null)
         {
-            var service = new QueryService((Configuration) _apiClient.Configuration)
+            var service = new QueryService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -421,7 +421,7 @@ namespace InfluxDB.Client
         /// <returns>the new synchronous client instance for the Query API</returns>
         public QueryApiSync GetQueryApiSync(IDomainObjectMapper mapper = null)
         {
-            var service = new QueryService((Configuration) _apiClient.Configuration)
+            var service = new QueryService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -466,7 +466,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Write API Async without batching</returns>
         public WriteApiAsync GetWriteApiAsync(IDomainObjectMapper mapper = null)
         {
-            var service = new WriteService((Configuration) _apiClient.Configuration)
+            var service = new WriteService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -493,7 +493,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Write API</returns>
         public WriteApi GetWriteApi(WriteOptions writeOptions, IDomainObjectMapper mapper = null)
         {
-            var service = new WriteService((Configuration) _apiClient.Configuration)
+            var service = new WriteService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -519,11 +519,11 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Organization API</returns>
         public OrganizationsApi GetOrganizationsApi()
         {
-            var service = new OrganizationsService((Configuration) _apiClient.Configuration)
+            var service = new OrganizationsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            var secretService = new SecretsService((Configuration) _apiClient.Configuration)
+            var secretService = new SecretsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -546,7 +546,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for User API</returns>
         public UsersApi GetUsersApi()
         {
-            var service = new UsersService((Configuration) _apiClient.Configuration)
+            var service = new UsersService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -569,7 +569,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Bucket API</returns>
         public BucketsApi GetBucketsApi()
         {
-            var service = new BucketsService((Configuration) _apiClient.Configuration)
+            var service = new BucketsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -592,7 +592,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Source API</returns>
         public SourcesApi GetSourcesApi()
         {
-            var service = new SourcesService((Configuration) _apiClient.Configuration)
+            var service = new SourcesService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -615,7 +615,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Authorization API</returns>
         public AuthorizationsApi GetAuthorizationsApi()
         {
-            var service = new AuthorizationsService((Configuration) _apiClient.Configuration)
+            var service = new AuthorizationsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -638,7 +638,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Task API</returns>
         public TasksApi GetTasksApi()
         {
-            var service = new TasksService((Configuration) _apiClient.Configuration)
+            var service = new TasksService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -661,7 +661,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Scraper API</returns>
         public ScraperTargetsApi GetScraperTargetsApi()
         {
-            var service = new ScraperTargetsService((Configuration) _apiClient.Configuration)
+            var service = new ScraperTargetsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -684,7 +684,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Telegrafs API</returns>
         public TelegrafsApi GetTelegrafsApi()
         {
-            var service = new TelegrafsService((Configuration) _apiClient.Configuration)
+            var service = new TelegrafsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -707,7 +707,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Label API</returns>
         public LabelsApi GetLabelsApi()
         {
-            var service = new LabelsService((Configuration) _apiClient.Configuration)
+            var service = new LabelsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -730,7 +730,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for NotificationEndpoint API</returns>
         public NotificationEndpointsApi GetNotificationEndpointsApi()
         {
-            var service = new NotificationEndpointsService((Configuration) _apiClient.Configuration)
+            var service = new NotificationEndpointsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -753,7 +753,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for NotificationRules API</returns>
         public NotificationRulesApi GetNotificationRulesApi()
         {
-            var service = new NotificationRulesService((Configuration) _apiClient.Configuration)
+            var service = new NotificationRulesService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -776,7 +776,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Checks API</returns>
         public ChecksApi GetChecksApi()
         {
-            var service = new ChecksService((Configuration) _apiClient.Configuration)
+            var service = new ChecksService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -799,7 +799,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Delete API</returns>
         public DeleteApi GetDeleteApi()
         {
-            var service = new DeleteService((Configuration) _apiClient.Configuration)
+            var service = new DeleteService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -824,7 +824,7 @@ namespace InfluxDB.Client
         /// <returns>New instance of InvokableScriptsApi.</returns>
         public InvokableScriptsApi GetInvokableScriptsApi(IDomainObjectMapper mapper = null)
         {
-            var service = new InvokableScriptsService((Configuration) _apiClient.Configuration)
+            var service = new InvokableScriptsService((Configuration)_apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -840,7 +840,7 @@ namespace InfluxDB.Client
         /// <returns>new instance of service</returns>
         public TS CreateService<TS>(Type serviceType) where TS : IApiAccessor
         {
-            var instance = (TS) Activator.CreateInstance(serviceType, (Configuration) _apiClient.Configuration);
+            var instance = (TS) Activator.CreateInstance(serviceType, (Configuration)_apiClient.Configuration);
             instance.ExceptionFactory = _exceptionFactory;
 
             return instance;

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -259,10 +259,7 @@ namespace InfluxDB.Client
         /// <param name="connectionString">connection string with various configurations
         /// </param>
         public InfluxDBClient(string connectionString) :
-            this(InfluxDBClientOptions.Builder
-                .CreateNew()
-                .ConnectionString(connectionString)
-                .Build())
+            this(new InfluxDBClientOptions(connectionString, true))
         {
         }
 
@@ -440,7 +437,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Write API</returns>
         public WriteApi GetWriteApi(IDomainObjectMapper mapper = null)
         {
-            return GetWriteApi(WriteOptions.CreateNew().Build(), mapper);
+            return GetWriteApi(new WriteOptions(), mapper);
         }
 
         /// <summary>

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -256,10 +256,9 @@ namespace InfluxDB.Client
         /// </list>
         /// </para>
         /// </summary>
-        /// <param name="connectionString">connection string with various configurations
-        /// </param>
-        public InfluxDBClient(string connectionString) :
-            this(new InfluxDBClientOptions(connectionString, true))
+        /// <param name="url">connection string with various configurations</param>
+        public InfluxDBClient(string url) :
+            this(new InfluxDBClientOptions(url))
         {
         }
 

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -233,7 +233,96 @@ namespace InfluxDB.Client
 
         private readonly Subject<Unit> _disposeNotification = new Subject<Unit>();
 
-        protected internal InfluxDBClient(InfluxDBClientOptions options)
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client that is configured via <code>App.config</code>.
+        /// </summary>
+        public InfluxDBClient() :
+            this(InfluxDBClientOptions.Builder
+                .CreateNew()
+                .LoadConfig()
+                .Build())
+        {
+        }
+        
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
+        /// <para>
+        /// e.g.: "http://localhost:8086?timeout=5000&amp;logLevel=BASIC
+        /// </para>
+        /// </summary>
+        /// <param name="connectionString">connection string with various configurations</param>
+        public InfluxDBClient(string connectionString) :
+            this(InfluxDBClientOptions.Builder
+                .CreateNew()
+                .ConnectionString(connectionString)
+                .Build())
+        {
+        }
+        
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client.
+        /// </summary>
+        /// <param name="url">the url to connect to the InfluxDB 2.x</param>
+        /// <param name="username">the username to use in the basic auth</param>
+        /// <param name="password">the password to use in the basic auth</param>
+        public InfluxDBClient(string url, string username, char[] password) :
+            this(new InfluxDBClientOptions(url)
+            {
+                Username = username,
+                Password = password,
+            })
+        {
+        }
+        
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client.
+        /// </summary>
+        /// <param name="url">the url to connect to the InfluxDB 2.x</param>
+        /// <param name="token">the token to use for the authorization</param>
+        public InfluxDBClient(string url, char[] token) :
+            this(new InfluxDBClientOptions(url)
+            {
+                Token = token,
+            })
+        {
+        }
+        
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client.
+        /// </summary>
+        /// <param name="url">the url to connect to the InfluxDB 2.x</param>
+        /// <param name="token">the token to use for the authorization</param>
+        public InfluxDBClient(string url, string token) :
+            this(new InfluxDBClientOptions(url)
+            {
+                Token = token.ToCharArray(),
+            })
+        {
+        }
+        
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client to connect into InfluxDB 1.8.
+        /// </summary>
+        /// <param name="url">the url to connect to the InfluxDB 1.8</param>
+        /// <param name="username">authorization username</param>
+        /// <param name="password">authorization password</param>
+        /// <param name="database">database name</param>
+        /// <param name="retentionPolicy">retention policy</param>
+        public InfluxDBClient(string url, string username, char[] password, string database, string retentionPolicy) :
+            this(new InfluxDBClientOptions(url)
+            {
+                Org = "-",
+                Token = $"{username}:{new string(password)}".ToCharArray(),
+                Bucket = $"{database}/{retentionPolicy}"
+            })
+        {
+        }
+
+        /// <summary>
+        /// Create a instance of the InfluxDB 2.x client.
+        /// </summary>
+        /// <param name="options">the connection configuration</param>
+        public InfluxDBClient(InfluxDBClientOptions options)
         {
             Arguments.CheckNotNull(options, nameof(options));
 
@@ -246,19 +335,19 @@ namespace InfluxDB.Client
             _exceptionFactory = (methodName, response) =>
                 !response.IsSuccessful ? HttpException.Create(response, response.Content) : null;
 
-            _setupService = new SetupService((Configuration)_apiClient.Configuration)
+            _setupService = new SetupService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _healthService = new HealthService((Configuration)_apiClient.Configuration)
+            _healthService = new HealthService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _readyService = new ReadyService((Configuration)_apiClient.Configuration)
+            _readyService = new ReadyService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            _pingService = new PingService((Configuration)_apiClient.Configuration)
+            _pingService = new PingService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -307,7 +396,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Query API</returns>
         public QueryApi GetQueryApi(IDomainObjectMapper mapper = null)
         {
-            var service = new QueryService((Configuration)_apiClient.Configuration)
+            var service = new QueryService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -332,7 +421,7 @@ namespace InfluxDB.Client
         /// <returns>the new synchronous client instance for the Query API</returns>
         public QueryApiSync GetQueryApiSync(IDomainObjectMapper mapper = null)
         {
-            var service = new QueryService((Configuration)_apiClient.Configuration)
+            var service = new QueryService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -377,7 +466,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Write API Async without batching</returns>
         public WriteApiAsync GetWriteApiAsync(IDomainObjectMapper mapper = null)
         {
-            var service = new WriteService((Configuration)_apiClient.Configuration)
+            var service = new WriteService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -404,7 +493,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for the Write API</returns>
         public WriteApi GetWriteApi(WriteOptions writeOptions, IDomainObjectMapper mapper = null)
         {
-            var service = new WriteService((Configuration)_apiClient.Configuration)
+            var service = new WriteService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -430,11 +519,11 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Organization API</returns>
         public OrganizationsApi GetOrganizationsApi()
         {
-            var service = new OrganizationsService((Configuration)_apiClient.Configuration)
+            var service = new OrganizationsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
-            var secretService = new SecretsService((Configuration)_apiClient.Configuration)
+            var secretService = new SecretsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -457,7 +546,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for User API</returns>
         public UsersApi GetUsersApi()
         {
-            var service = new UsersService((Configuration)_apiClient.Configuration)
+            var service = new UsersService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -480,7 +569,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Bucket API</returns>
         public BucketsApi GetBucketsApi()
         {
-            var service = new BucketsService((Configuration)_apiClient.Configuration)
+            var service = new BucketsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -503,7 +592,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Source API</returns>
         public SourcesApi GetSourcesApi()
         {
-            var service = new SourcesService((Configuration)_apiClient.Configuration)
+            var service = new SourcesService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -526,7 +615,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Authorization API</returns>
         public AuthorizationsApi GetAuthorizationsApi()
         {
-            var service = new AuthorizationsService((Configuration)_apiClient.Configuration)
+            var service = new AuthorizationsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -549,7 +638,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Task API</returns>
         public TasksApi GetTasksApi()
         {
-            var service = new TasksService((Configuration)_apiClient.Configuration)
+            var service = new TasksService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -572,7 +661,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Scraper API</returns>
         public ScraperTargetsApi GetScraperTargetsApi()
         {
-            var service = new ScraperTargetsService((Configuration)_apiClient.Configuration)
+            var service = new ScraperTargetsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -595,7 +684,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Telegrafs API</returns>
         public TelegrafsApi GetTelegrafsApi()
         {
-            var service = new TelegrafsService((Configuration)_apiClient.Configuration)
+            var service = new TelegrafsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -618,7 +707,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Label API</returns>
         public LabelsApi GetLabelsApi()
         {
-            var service = new LabelsService((Configuration)_apiClient.Configuration)
+            var service = new LabelsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -641,7 +730,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for NotificationEndpoint API</returns>
         public NotificationEndpointsApi GetNotificationEndpointsApi()
         {
-            var service = new NotificationEndpointsService((Configuration)_apiClient.Configuration)
+            var service = new NotificationEndpointsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -664,7 +753,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for NotificationRules API</returns>
         public NotificationRulesApi GetNotificationRulesApi()
         {
-            var service = new NotificationRulesService((Configuration)_apiClient.Configuration)
+            var service = new NotificationRulesService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -687,7 +776,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Checks API</returns>
         public ChecksApi GetChecksApi()
         {
-            var service = new ChecksService((Configuration)_apiClient.Configuration)
+            var service = new ChecksService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -710,7 +799,7 @@ namespace InfluxDB.Client
         /// <returns>the new client instance for Delete API</returns>
         public DeleteApi GetDeleteApi()
         {
-            var service = new DeleteService((Configuration)_apiClient.Configuration)
+            var service = new DeleteService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -735,7 +824,7 @@ namespace InfluxDB.Client
         /// <returns>New instance of InvokableScriptsApi.</returns>
         public InvokableScriptsApi GetInvokableScriptsApi(IDomainObjectMapper mapper = null)
         {
-            var service = new InvokableScriptsService((Configuration)_apiClient.Configuration)
+            var service = new InvokableScriptsService((Configuration) _apiClient.Configuration)
             {
                 ExceptionFactory = _exceptionFactory
             };
@@ -751,7 +840,7 @@ namespace InfluxDB.Client
         /// <returns>new instance of service</returns>
         public TS CreateService<TS>(Type serviceType) where TS : IApiAccessor
         {
-            var instance = (TS)Activator.CreateInstance(serviceType, (Configuration)_apiClient.Configuration);
+            var instance = (TS) Activator.CreateInstance(serviceType, (Configuration) _apiClient.Configuration);
             instance.ExceptionFactory = _exceptionFactory;
 
             return instance;

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -243,9 +243,16 @@ namespace InfluxDB.Client
         /// <item>bucket - default destination bucket for writes</item>
         /// <item>token - the token to use for the authorization</item>
         /// <item>logLevel (default - NONE) - rest client verbosity level</item>
-        /// <item>timeout (default - 10000ms) - The timespan to wait before the HTTP request times out</item>
+        /// <item>timeout (default - 10000) - The timespan to wait before the HTTP request times out in milliseconds</item>
         /// <item>allowHttpRedirects (default - false) - Configure automatically following HTTP 3xx redirects</item>
         /// <item>verifySsl (default - true) - Ignore Certificate Validation Errors when false</item>
+        /// </list>
+        /// Options for logLevel:
+        /// <list type="bullet">
+        /// <item>Basic - Logs request and response lines.</item>
+        /// <item>Body - Logs request and response lines including headers and body (if present). Note that applying the `Body` LogLevel will disable chunking while streaming and will load the whole response into memory.</item>
+        /// <item>Headers - Logs request and response lines including headers.</item>
+        /// <item>None - Disable logging.</item>
         /// </list>
         /// </para>
         /// </summary>
@@ -269,7 +276,7 @@ namespace InfluxDB.Client
             this(new InfluxDBClientOptions(url)
             {
                 Username = username,
-                Password = password.ToCharArray()
+                Password = password
             })
         {
         }

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -234,23 +234,23 @@ namespace InfluxDB.Client
         private readonly Subject<Unit> _disposeNotification = new Subject<Unit>();
 
         /// <summary>
-        /// Create a instance of the InfluxDB 2.x client that is configured via <code>App.config</code>.
-        /// </summary>
-        public InfluxDBClient() :
-            this(InfluxDBClientOptions.Builder
-                .CreateNew()
-                .LoadConfig()
-                .Build())
-        {
-        }
-
-        /// <summary>
         /// Create a instance of the InfluxDB 2.x client. The url could be a connection string with various configurations.
         /// <para>
         /// e.g.: "http://localhost:8086?timeout=5000&amp;logLevel=BASIC
+        /// The following options are supported:
+        /// <list type="bullet">
+        /// <item>org - default destination organization for writes and queries</item>
+        /// <item>bucket - default destination bucket for writes</item>
+        /// <item>token - the token to use for the authorization</item>
+        /// <item>logLevel (default - NONE) - rest client verbosity level</item>
+        /// <item>timeout (default - 10000ms) - The timespan to wait before the HTTP request times out</item>
+        /// <item>allowHttpRedirects (default - false) - Configure automatically following HTTP 3xx redirects</item>
+        /// <item>verifySsl (default - true) - Ignore Certificate Validation Errors when false</item>
+        /// </list>
         /// </para>
         /// </summary>
-        /// <param name="connectionString">connection string with various configurations</param>
+        /// <param name="connectionString">connection string with various configurations
+        /// </param>
         public InfluxDBClient(string connectionString) :
             this(InfluxDBClientOptions.Builder
                 .CreateNew()
@@ -265,24 +265,11 @@ namespace InfluxDB.Client
         /// <param name="url">the url to connect to the InfluxDB 2.x</param>
         /// <param name="username">the username to use in the basic auth</param>
         /// <param name="password">the password to use in the basic auth</param>
-        public InfluxDBClient(string url, string username, char[] password) :
+        public InfluxDBClient(string url, string username, string password) :
             this(new InfluxDBClientOptions(url)
             {
                 Username = username,
-                Password = password
-            })
-        {
-        }
-
-        /// <summary>
-        /// Create a instance of the InfluxDB 2.x client.
-        /// </summary>
-        /// <param name="url">the url to connect to the InfluxDB 2.x</param>
-        /// <param name="token">the token to use for the authorization</param>
-        public InfluxDBClient(string url, char[] token) :
-            this(new InfluxDBClientOptions(url)
-            {
-                Token = token
+                Password = password.ToCharArray()
             })
         {
         }
@@ -295,7 +282,7 @@ namespace InfluxDB.Client
         public InfluxDBClient(string url, string token) :
             this(new InfluxDBClientOptions(url)
             {
-                Token = token.ToCharArray()
+                Token = token
             })
         {
         }
@@ -308,11 +295,11 @@ namespace InfluxDB.Client
         /// <param name="password">authorization password</param>
         /// <param name="database">database name</param>
         /// <param name="retentionPolicy">retention policy</param>
-        public InfluxDBClient(string url, string username, char[] password, string database, string retentionPolicy) :
+        public InfluxDBClient(string url, string username, string password, string database, string retentionPolicy) :
             this(new InfluxDBClientOptions(url)
             {
                 Org = "-",
-                Token = $"{username}:{new string(password)}".ToCharArray(),
+                Token = $"{username}:{password}",
                 Bucket = $"{database}/{retentionPolicy}"
             })
         {

--- a/Client/InfluxDBClientFactory.cs
+++ b/Client/InfluxDBClientFactory.cs
@@ -11,6 +11,10 @@ namespace InfluxDB.Client
         /// Create a instance of the InfluxDB 2.x client that is configured via <code>App.config</code>.
         /// </summary>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(InfluxDBClientOptions)"/>
+        /// together with <see cref="InfluxDBClientOptions.LoadConfig"/>
+        /// </remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create()
         {
             var options = InfluxDBClientOptions.Builder

--- a/Client/InfluxDBClientFactory.cs
+++ b/Client/InfluxDBClientFactory.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
@@ -28,6 +29,8 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="connectionString">connection string with various configurations</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create(string connectionString)
         {
             var options = InfluxDBClientOptions.Builder
@@ -45,6 +48,8 @@ namespace InfluxDB.Client
         /// <param name="username">the username to use in the basic auth</param>
         /// <param name="password">the password to use in the basic auth</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(string, string, string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create(string url, string username, char[] password)
         {
             var options = InfluxDBClientOptions.Builder
@@ -62,6 +67,8 @@ namespace InfluxDB.Client
         /// <param name="url">the url to connect to the InfluxDB 2.x</param>
         /// <param name="token">the token to use for the authorization</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(string, string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create(string url, char[] token)
         {
             var options = InfluxDBClientOptions.Builder
@@ -79,6 +86,8 @@ namespace InfluxDB.Client
         /// <param name="url">the url to connect to the InfluxDB 2.x</param>
         /// <param name="token">the token to use for the authorization</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(string, string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create(string url, string token)
         {
             var options = InfluxDBClientOptions.Builder
@@ -99,6 +108,8 @@ namespace InfluxDB.Client
         /// <param name="database">database name</param>
         /// <param name="retentionPolicy">retention policy</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(string, string, string, string, string)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient CreateV1(string url, string username, char[] password, string database,
             string retentionPolicy)
         {
@@ -120,6 +131,8 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="options">the connection configuration</param>
         /// <returns>client</returns>
+        /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClient(InfluxDBClientOptions)"/></remarks>
+        [Obsolete("This method is deprecated. Call 'InfluxDBClient' initializer instead.", false)]
         public static InfluxDBClient Create(InfluxDBClientOptions options)
         {
             Arguments.CheckNotNull(options, nameof(options));
@@ -162,11 +175,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(url, nameof(url));
             Arguments.CheckNotNull(onboarding, nameof(onboarding));
 
-
-            using (var client = new InfluxDBClient(InfluxDBClientOptions.Builder.CreateNew().Url(url).Build()))
-            {
-                return await client.OnboardingAsync(onboarding).ConfigureAwait(false);
-            }
+            using var client = new InfluxDBClient(new InfluxDBClientOptions(url));
+            return await client.OnboardingAsync(onboarding).ConfigureAwait(false);
         }
     }
 }

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -216,7 +216,7 @@ namespace InfluxDB.Client
             Arguments.CheckNotNull(tagName, nameof(tagName));
             PointSettings.AddDefaultTag(tagName, expression);
         }
-        
+
         /// <summary>
         /// Add default tags that will be use for writes by Point and POJO.
         /// </summary>

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -333,7 +333,7 @@ namespace InfluxDB.Client
 
             PointSettings = new PointSettings();
         }
-        
+
         private InfluxDBClientOptions(Builder builder)
         {
             Arguments.CheckNotNull(builder, nameof(builder));
@@ -371,7 +371,7 @@ namespace InfluxDB.Client
                 ClientCertificates = builder.CertificateCollection;
             }
         }
-        
+
         private static TimeSpan ToTimeout(string value)
         {
             var matcher = DurationRegex.Match(value);
@@ -450,7 +450,7 @@ namespace InfluxDB.Client
             internal X509CertificateCollection CertificateCollection;
 
             internal PointSettings PointSettings = new PointSettings();
-            
+
             public static Builder CreateNew()
             {
                 return new Builder();

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -250,19 +250,17 @@ namespace InfluxDB.Client
 
             Org = builder.OrgString;
             Bucket = builder.BucketString;
-
             Timeout = builder.Timeout;
-
+            AllowHttpRedirects = builder.AllowHttpRedirects;
+            PointSettings = builder.PointSettings;
+            VerifySsl = builder.VerifySslCertificates;
+            VerifySslCallback = builder.VerifySslCallback;
+            
             if (builder.WebProxy != null)
             {
                 WebProxy = builder.WebProxy;
             }
-            AllowHttpRedirects = builder.AllowHttpRedirects;
-
-            PointSettings = builder.PointSettings;
-
-            VerifySsl = builder.VerifySslCertificates;
-            VerifySslCallback = builder.VerifySslCallback;
+            
             if (builder.CertificateCollection != null)
             {
                 ClientCertificates = builder.CertificateCollection;

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -33,7 +33,7 @@ namespace InfluxDB.Client
         private bool _allowHttpRedirects;
         private bool _verifySsl;
         private X509CertificateCollection _clientCertificates;
-        
+
         /// <summary>
         /// Set the url to connect the InfluxDB.
         /// </summary>
@@ -46,7 +46,7 @@ namespace InfluxDB.Client
                 _url = value;
             }
         }
-        
+
         /// <summary>
         /// Set the timespan to wait before the HTTP request times out.
         /// </summary>
@@ -59,7 +59,7 @@ namespace InfluxDB.Client
                 _timeout = value;
             }
         }
-        
+
         /// <summary>
         /// Set the log level for the request and response information.
         /// </summary>
@@ -88,9 +88,8 @@ namespace InfluxDB.Client
 
                 AuthScheme = AuthenticationScheme.Token;
             }
-
         }
-        
+
         /// <summary>
         /// Setup authorization by <see cref="AuthenticationScheme.Session"/>.
         /// </summary>
@@ -101,32 +100,33 @@ namespace InfluxDB.Client
             {
                 Arguments.CheckNonEmptyString(value, "Username");
                 _username = value;
-                
+
                 if (!string.IsNullOrEmpty(Username) && Password != null)
                     AuthScheme = AuthenticationScheme.Session;
             }
         }
-        
+
         /// <summary>
         /// Setup authorization by <see cref="AuthenticationScheme.Session"/>.
         /// </summary>
-        public char[] Password { 
+        public char[] Password
+        {
             get => _password;
             set
             {
                 Arguments.CheckNotNull(value, "Password");
                 _password = value;
-                
+
                 if (!string.IsNullOrEmpty(Username) && Password != null)
                     AuthScheme = AuthenticationScheme.Session;
-            } 
+            }
         }
 
         /// <summary>
         /// Specify the default destination organization for writes and queries.
         /// </summary>
         public string Org { get; set; }
-        
+
         /// <summary>
         /// Specify the default destination bucket for writes.
         /// </summary>
@@ -144,7 +144,7 @@ namespace InfluxDB.Client
                 _webProxy = value;
             }
         }
-        
+
         /// <summary>
         /// Configure automatically following HTTP 3xx redirects.
         /// </summary>
@@ -189,9 +189,9 @@ namespace InfluxDB.Client
                 _clientCertificates = value;
             }
         }
-        
+
         public PointSettings PointSettings { get; }
-        
+
         /// <summary>
         /// Add default tag that will be use for writes by Point and POJO.
         ///
@@ -220,9 +220,11 @@ namespace InfluxDB.Client
             {
                 throw new InvalidOperationException("The url to connect the InfluxDB has to be defined.");
             }
+
             _timeout = TimeSpan.FromSeconds(10);
             PointSettings = new PointSettings();
         }
+
         private InfluxDBClientOptions(Builder builder)
         {
             Arguments.CheckNotNull(builder, nameof(builder));
@@ -230,7 +232,7 @@ namespace InfluxDB.Client
             Url = builder.UrlString;
             LogLevel = builder.LogLevelValue;
             AuthScheme = builder.AuthScheme;
-            
+
             switch (builder.AuthScheme)
             {
                 case AuthenticationScheme.Token:
@@ -519,7 +521,7 @@ namespace InfluxDB.Client
             /// <returns><see cref="Builder"/></returns>
             internal Builder LoadConfig(string sectionName = "influx2")
             {
-                var config = (Influx2)ConfigurationManager.GetSection(sectionName);
+                var config = (Influx2) ConfigurationManager.GetSection(sectionName);
                 if (config == null)
                 {
                     const string message = "The configuration doesn't contains a 'influx2' section. " +

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
 using System.Net.Security;
@@ -78,12 +79,12 @@ namespace InfluxDB.Client
         /// <summary>
         /// Setup authorization by <see cref="AuthenticationScheme.Token"/>.
         /// </summary>
-        public char[] Token
+        public object Token
         {
             get => _token;
             set
             {
-                _token = value;
+                _token = value as char[] ?? value.ToString().ToCharArray();
                 Arguments.CheckNotNull(_token, "Token");
 
                 AuthScheme = AuthenticationScheme.Token;
@@ -210,11 +211,23 @@ namespace InfluxDB.Client
         /// </summary>
         /// <param name="tagName">the tag name</param>
         /// <param name="expression">the tag value expression</param>
-        /// <returns><see cref="Builder"/></returns>
         public void AddDefaultTag(string tagName, string expression)
         {
             Arguments.CheckNotNull(tagName, nameof(tagName));
             PointSettings.AddDefaultTag(tagName, expression);
+        }
+        
+        /// <summary>
+        /// Add default tags that will be use for writes by Point and POJO.
+        /// </summary>
+        /// <param name="tags">tags dictionary</param>
+        public void AddDefaultTags(Dictionary<string, string> tags)
+        {
+            foreach (var tag in tags)
+            {
+                Arguments.CheckNotNull(tag.Key, "TagName");
+                PointSettings.AddDefaultTag(tag.Key, tag.Value);
+            }
         }
 
         public InfluxDBClientOptions(string url)

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -284,6 +284,10 @@ namespace InfluxDB.Client
             var uri = new Uri(url);
 
             Url = uri.GetLeftPart(UriPartial.Path);
+            if (string.IsNullOrEmpty(Url))
+            {
+                throw new ArgumentException("The url to connect the InfluxDB has to be defined.");
+            }
 
             var query = HttpUtility.ParseQueryString(uri.Query);
             Org = query.Get("org");
@@ -296,11 +300,6 @@ namespace InfluxDB.Client
             var timeout = query.Get("timeout");
 
             VerifySsl = Convert.ToBoolean(string.IsNullOrEmpty(verifySslValue) ? "true" : verifySslValue);
-
-            if (string.IsNullOrEmpty(Url))
-            {
-                throw new InvalidOperationException("The url to connect the InfluxDB has to be defined.");
-            }
 
             if (!string.IsNullOrWhiteSpace(token))
             {

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -252,9 +252,10 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
-        /// Create an instance of InfluxDBClientOptions.
-        /// <para>
-        /// InfluxDBClientOptions properties:
+        /// Create an instance of InfluxDBClientOptions. The url could be a connection string with various configurations.
+        ///<para>
+        /// e.g.: "http://localhost:8086?timeout=5000&amp;logLevel=BASIC
+        /// The following options are supported:
         /// <list type="bullet">
         /// <item>Timeout - timespan to wait before the HTTP request times out</item>
         /// <item>LogLevel - log level for the request and response information</item>
@@ -275,21 +276,12 @@ namespace InfluxDB.Client
         /// <param name="url">url to connect the InfluxDB</param>
         public InfluxDBClientOptions(string url)
         {
-            Url = url;
-            if (string.IsNullOrEmpty(Url))
+            if (string.IsNullOrEmpty(url))
             {
-                throw new InvalidOperationException("The url to connect the InfluxDB has to be defined.");
+                throw new ArgumentException("The url to connect the InfluxDB has to be defined.");
             }
 
-            _timeout = TimeSpan.FromSeconds(10);
-            PointSettings = new PointSettings();
-        }
-
-        public InfluxDBClientOptions(string connectionString, bool isConnectionString = true)
-        {
-            Arguments.CheckNonEmptyString(connectionString, nameof(connectionString));
-
-            var uri = new Uri(connectionString);
+            var uri = new Uri(url);
 
             Url = uri.GetLeftPart(UriPartial.Path);
 
@@ -756,8 +748,6 @@ namespace InfluxDB.Client
             /// </summary>
             /// <returns><see cref="InfluxDBClientOptions"/></returns>
             /// <exception cref="InvalidOperationException">If url is not defined.</exception>
-            /// <remarks>Deprecated - please use use object initializer <see cref="InfluxDBClientOptions(string url)"/></remarks>
-            [Obsolete("This method is deprecated. Call 'InfluxDBClientOptions' initializer instead.", false)]
             public InfluxDBClientOptions Build()
             {
                 if (string.IsNullOrEmpty(UrlString))

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -255,12 +255,12 @@ namespace InfluxDB.Client
             PointSettings = builder.PointSettings;
             VerifySsl = builder.VerifySslCertificates;
             VerifySslCallback = builder.VerifySslCallback;
-            
+
             if (builder.WebProxy != null)
             {
                 WebProxy = builder.WebProxy;
             }
-            
+
             if (builder.CertificateCollection != null)
             {
                 ClientCertificates = builder.CertificateCollection;

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -102,7 +102,9 @@ namespace InfluxDB.Client
                 _username = value;
 
                 if (!string.IsNullOrEmpty(Username) && Password != null)
+                {
                     AuthScheme = AuthenticationScheme.Session;
+                }
             }
         }
 
@@ -118,7 +120,9 @@ namespace InfluxDB.Client
                 _password = value;
 
                 if (!string.IsNullOrEmpty(Username) && Password != null)
+                {
                     AuthScheme = AuthenticationScheme.Session;
+                }
             }
         }
 
@@ -249,14 +253,20 @@ namespace InfluxDB.Client
 
             Timeout = builder.Timeout;
 
-            if (builder.WebProxy != null) WebProxy = builder.WebProxy;
+            if (builder.WebProxy != null)
+            {
+                WebProxy = builder.WebProxy;
+            }
             AllowHttpRedirects = builder.AllowHttpRedirects;
 
             PointSettings = builder.PointSettings;
 
             VerifySsl = builder.VerifySslCertificates;
             VerifySslCallback = builder.VerifySslCallback;
-            if (builder.CertificateCollection != null) ClientCertificates = builder.CertificateCollection;
+            if (builder.CertificateCollection != null)
+            {
+                ClientCertificates = builder.CertificateCollection;
+            }
         }
 
         /// <summary>
@@ -521,7 +531,7 @@ namespace InfluxDB.Client
             /// <returns><see cref="Builder"/></returns>
             internal Builder LoadConfig(string sectionName = "influx2")
             {
-                var config = (Influx2) ConfigurationManager.GetSection(sectionName);
+                var config = (Influx2)ConfigurationManager.GetSection(sectionName);
                 if (config == null)
                 {
                     const string message = "The configuration doesn't contains a 'influx2' section. " +

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -85,7 +85,7 @@ namespace InfluxDB.Client.Api.Client
 
             if (InfluxDBClientOptions.AuthenticationScheme.Token.Equals(_options.AuthScheme))
             {
-                request.AddHeader("Authorization", "Token " + new string((char[])_options.Token));
+                request.AddHeader("Authorization", $"Token {_options.Token}");
             }
             else if (InfluxDBClientOptions.AuthenticationScheme.Session.Equals(_options.AuthScheme))
             {
@@ -116,7 +116,7 @@ namespace InfluxDB.Client.Api.Client
                 {
                     var header = "Basic " + Convert.ToBase64String(
                         Encoding.Default.GetBytes(
-                            _options.Username + ":" + new string(_options.Password)));
+                            _options.Username + ":" + _options.Password));
 
                     var request = new RestRequest("/api/v2/signin", Method.Post)
                         .AddHeader("Authorization", header);

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -85,7 +85,7 @@ namespace InfluxDB.Client.Api.Client
 
             if (InfluxDBClientOptions.AuthenticationScheme.Token.Equals(_options.AuthScheme))
             {
-                request.AddHeader("Authorization", "Token " + new string(_options.Token));
+                request.AddHeader("Authorization", "Token " + new string((char[])_options.Token));
             }
             else if (InfluxDBClientOptions.AuthenticationScheme.Session.Equals(_options.AuthScheme))
             {

--- a/Client/README.md
+++ b/Client/README.md
@@ -656,13 +656,15 @@ In a [configuration file](#client-configuration-file) you are able to specify de
 ```c#
 var options = new InfluxDBClientOptions(Url)
 {
-    Token = token
+    Token = token,
+    DefaultTags = new Dictionary<string, string>
+    {
+        {"id", "132-987-655"},
+        {"customer", "California Miner"},
+    }
 };   
-options.AddDefaultTag("id", "132-987-655")
-options.AddDefaultTag("customer", "California Miner")
 options.AddDefaultTag("hostname", "${env.Hostname}")
-options.AddDefaultTag("sensor-version", "${SensorVersion}")
-options.AddDefaultTags(new Dictionary<string, string>{{ "id", "132-987-655" }, { "customer", "California Miner" }})
+options.AddDefaultTags(new Dictionary<string, string>{{ "sensor-version", "${SensorVersion}" }})
 ```
 
 Both of configurations will produce the Line protocol:
@@ -1154,19 +1156,8 @@ influxDBClient.EnableGzip();
 
 ### How to use WebProxy
 
-You can configure the client to tunnel requests through an HTTP proxy. The `WebProxy` could be 
-configured via `InfluxDBClientOptions.Builder` parameter `Proxy` or `InfluxDBClientOptions`
-parameter `WebProxy`:
-
-```c#
-var options = new InfluxDBClientOptions.Builder()
-    .Url("http://localhost:8086")
-    .AuthenticateToken("my-token")
-    .Proxy(new WebProxy("http://proxyserver:80/", true))
-    .Build();
-
-var client = InfluxDBClientFactory.Create(options);
-```
+You can configure the client to tunnel requests through an HTTP proxy. The `WebProxy` could be
+configured via `InfluxDBClientOptions` parameter `WebProxy`:
 
 ```c#
 var options = new InfluxDBClientOptions("http://localhost:8086")

--- a/Client/README.md
+++ b/Client/README.md
@@ -61,11 +61,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -99,11 +99,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -146,11 +146,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -195,11 +195,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -243,11 +243,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -275,11 +275,11 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
-            var queryApi = influxDBClient.GetQueryApi();
+            var queryApi = client.GetQueryApi();
 
             //
             // QueryData
@@ -383,12 +383,12 @@ namespace Examples
 
         public static void Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
             //
-            using (var writeApi = influxDBClient.GetWriteApi())
+            using (var writeApi = client.GetWriteApi())
             {
                 //
                 // Write by POCO
@@ -430,12 +430,12 @@ namespace Examples
 
         public static void Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
             //
-            using (var writeApi = influxDBClient.GetWriteApi())
+            using (var writeApi = client.GetWriteApi())
             {
                 //
                 // Write by Data Point
@@ -470,12 +470,12 @@ namespace Examples
 
         public static void Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
             //
-            using (var writeApi = influxDBClient.GetWriteApi())
+            using (var writeApi = client.GetWriteApi())
             {
                 //
                 // Write by Data Point
@@ -517,12 +517,12 @@ namespace Examples
 
         public static void Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
             //
-            using (var writeApi = influxDBClient.GetWriteApi())
+            using (var writeApi = client.GetWriteApi())
             {
                 //
                 //
@@ -560,13 +560,13 @@ namespace Examples
         
         public static async Task Main()
         {
-            using var influxDbClient = new InfluxDBClient("http://localhost:8086", 
-                            "my-user", "my-password".ToCharArray());
+            using var client = new InfluxDBClient("http://localhost:8086", 
+                            "my-user", "my-password");
 
             //
             // Write Data
             //
-            var writeApiAsync = influxDbClient.GetWriteApiAsync();
+            var writeApiAsync = client.GetWriteApiAsync();
 
             //
             //
@@ -662,6 +662,7 @@ options.AddDefaultTag("id", "132-987-655")
 options.AddDefaultTag("customer", "California Miner")
 options.AddDefaultTag("hostname", "${env.Hostname}")
 options.AddDefaultTag("sensor-version", "${SensorVersion}")
+options.AddDefaultTags(new Dictionary<string, string>{{ "id", "132-987-655" }, { "customer", "California Miner" }})
 ```
 
 Both of configurations will produce the Line protocol:
@@ -755,12 +756,12 @@ namespace Examples
 
         public static void Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Delete data
             //
-            await influxDB.GetDeleteApi().Delete(DateTime.UtcNow.AddMinutes(-1), DateTime.Now, "", "bucket", "org");
+            await client.GetDeleteApi().Delete(DateTime.UtcNow.AddMinutes(-1), DateTime.Now, "", "bucket", "org");
         }
     }
 }
@@ -1004,7 +1005,7 @@ namespace Examples
             const string organization = "my-org";
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };
@@ -1120,7 +1121,7 @@ The `Timeout` supports `ms`, `s` and `m` as unit. Default is milliseconds.
 and then:
 
 ```c#
-var influxDBClient = InfluxDBClientFactory.Create();
+var client = InfluxDBClientFactory.Create();
 ```
 
 ### Client connection string
@@ -1128,7 +1129,7 @@ var influxDBClient = InfluxDBClientFactory.Create();
 A client can be constructed using a connection string that can contain the InfluxDBClientOptions parameters encoded into the URL.  
  
 ```c#
-var influxDBClient = new InfluxDBClient("http://localhost:8086?timeout=5000&logLevel=BASIC");
+var client = new InfluxDBClient("http://localhost:8086?timeout=5000&logLevel=BASIC");
 ```
 The following options are supported:
 
@@ -1153,12 +1154,14 @@ influxDBClient.EnableGzip();
 
 ### How to use WebProxy
 
-The `WebProxy` could be configured via `InfluxDBClientOptions.Builder` or `InfluxDBClientOptions` parameter `WebProxy`:
+You can configure the client to tunnel requests through an HTTP proxy. The `WebProxy` could be 
+configured via `InfluxDBClientOptions.Builder` parameter `Proxy` or `InfluxDBClientOptions`
+parameter `WebProxy`:
 
 ```c#
 var options = new InfluxDBClientOptions.Builder()
     .Url("http://localhost:8086")
-    .AuthenticateToken("my-token".ToCharArray())
+    .AuthenticateToken("my-token")
     .Proxy(new WebProxy("http://proxyserver:80/", true))
     .Build();
 
@@ -1168,33 +1171,21 @@ var client = InfluxDBClientFactory.Create(options);
 ```c#
 var options = new InfluxDBClientOptions("http://localhost:8086")
 {
-    Token = "my-token".ToCharArray(),
+    Token = "my-token",
     WebProxy = new WebProxy("http://proxyserver:80/", true)
 };
 
 var client = new InfluxDBClient(options);
 ```
 
-### Proxy and redirects configuration
-
-You can configure the client to tunnel requests through an HTTP proxy. To configure the proxy use `Proxy` configuration option:
-
- ```csharp
-var options = new InfluxDBClientOptions.Builder()
-    .Url("http://localhost:8086")
-    .AuthenticateToken("my-token")
-    .Proxy(new WebProxy("http://proxyserver:80/", true))
-    .Build();
-
-using var client = InfluxDBClientFactory.Create(options);
-```
+### Redirects configuration
 
 Client automatically **doesn't** follows HTTP redirects. You can enable redirects by `AllowRedirects` configuration option:
 
 ```csharp
-var options = new InfluxDBClientOptions.Builder("http://localhost:8086")
+var options = new InfluxDBClientOptions("http://localhost:8086")
 {
-    Token = "my-token".ToCharArray(),
+    Token = "my-token",
     AllowRedirects = true
 };
 
@@ -1210,7 +1201,7 @@ The Requests and Responses can be logged by changing the LogLevel. LogLevel valu
 applying the `Body` LogLevel will disable chunking while streaming and will load the whole response into memory.  
 
 ```c#
-influxDBClient.SetLogLevel(LogLevel.Body)
+client.SetLogLevel(LogLevel.Body)
 ```
 
 #### Check the server status and version

--- a/Client/README.md
+++ b/Client/README.md
@@ -59,9 +59,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
@@ -78,8 +78,6 @@ namespace Examples
                     Console.WriteLine($"{record.GetTime()}: {record.GetValueByKey("_value")}");
                 });
             });
-
-            influxDBClient.Dispose();
         }        
     }
 }
@@ -99,9 +97,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
@@ -115,8 +113,6 @@ namespace Examples
             {
                 Console.WriteLine($"{temperature.Location}: {temperature.Value} at {temperature.Time}");
             });
-
-            influxDBClient.Dispose();
         }  
         
         [Measurement("temperature")]
@@ -148,9 +144,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
@@ -178,8 +174,6 @@ namespace Examples
                 //
                 Console.WriteLine("Query completed");
             }, "org_id");
-
-            influxDBClient.Dispose();
         }
     }
 }
@@ -199,9 +193,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
             
@@ -217,8 +211,6 @@ namespace Examples
                 //
                 Console.WriteLine($"{temperature.Location}: {temperature.Value} at {temperature.Time}");
             }, org: "org_id");
-
-            influxDBClient.Dispose();
         }  
         
         [Measurement("temperature")]
@@ -249,9 +241,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
@@ -263,8 +255,6 @@ namespace Examples
             var csv = await queryApi.QueryRawAsync(flux, org: "org_id");
             
             Console.WriteLine($"CSV response: {csv}");
-
-            influxDBClient.Dispose();
         }
     }
 }
@@ -283,9 +273,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             var flux = "from(bucket:\"temperature-sensors\") |> range(start: 0)";
 
@@ -301,8 +291,6 @@ namespace Examples
                 //
                 Console.WriteLine($"Response: {line}");
             }, org: "org_id");
-
-            influxDBClient.Dispose();
         }
     }
 }
@@ -320,9 +308,9 @@ namespace Examples
 {
     public static class SynchronousQuery
     {
-        public static void Main(string[] args)
+        public static void Main()
         {
-            using var client = InfluxDBClientFactory.Create("http://localhost:9999", "my-token");
+            using var client = new InfluxDBClient("http://localhost:9999", "my-token");
 
             const string query = "from(bucket:\"my-bucket\") |> range(start: 0)";
            
@@ -393,9 +381,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static void Main(string[] args)
+        public static void Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
@@ -409,8 +397,6 @@ namespace Examples
 
                 writeApi.WriteMeasurement(temperature, WritePrecision.Ns, "bucket_name", "org_id");
             }
-            
-            influxDBClient.Dispose();
         }
         
         [Measurement("temperature")]
@@ -442,9 +428,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static void Main(string[] args)
+        public static void Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
@@ -461,8 +447,6 @@ namespace Examples
                 
                 writeApi.WritePoint(point, "bucket_name", "org_id");
             }
-            
-            influxDBClient.Dispose();
         }
     }
 }
@@ -484,9 +468,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static void Main(string[] args)
+        public static void Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
@@ -511,8 +495,6 @@ namespace Examples
                 
                 writeApi.WritePoint(pointB, "bucket_name", "org_id");
             }
-            
-            influxDBClient.Dispose();
         }
     }
 }
@@ -533,9 +515,9 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static void Main(string[] args)
+        public static void Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
@@ -548,8 +530,6 @@ namespace Examples
                 //
                 writeApi.WriteRecord("temperature,location=north value=60.0", WritePrecision.Ns,"bucket_name", "org_id");
             }
-            
-            influxDBClient.Dispose();
         }
     }
 }
@@ -578,9 +558,9 @@ namespace Examples
             [Column(IsTimestamp = true)] public DateTime Time { get; set; }
         }
         
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDbClient = InfluxDBClientFactory.Create("http://localhost:8086", 
+            using var influxDbClient = new InfluxDBClient("http://localhost:8086", 
                             "my-user", "my-password".ToCharArray());
 
             //
@@ -627,8 +607,6 @@ namespace Examples
                     Console.WriteLine($"{record.GetTime()}: {record.GetValue()}");
                 });
             });
-            
-            influxDbClient.Dispose();
         }
     }
 }
@@ -676,14 +654,14 @@ In a [configuration file](#client-configuration-file) you are able to specify de
 ##### Via API
 
 ```c#
-var options = new InfluxDBClientOptions.Builder()
-    .Url(url)
-    .AuthenticateToken(token)
-    .AddDefaultTag("id", "132-987-655")
-    .AddDefaultTag("customer", "California Miner")
-    .AddDefaultTag("hostname", "${env.Hostname}")
-    .AddDefaultTag("sensor-version", "${SensorVersion}")
-    .Build()    
+var options = new InfluxDBClientOptions(Url)
+{
+    Token = token
+};   
+options.AddDefaultTag("id", "132-987-655")
+options.AddDefaultTag("customer", "California Miner")
+options.AddDefaultTag("hostname", "${env.Hostname}")
+options.AddDefaultTag("sensor-version", "${SensorVersion}")
 ```
 
 Both of configurations will produce the Line protocol:
@@ -775,16 +753,14 @@ namespace Examples
     {
         private static readonly string Token = "";
 
-        public static void Main(string[] args)
+        public static void Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Delete data
             //
             await influxDB.GetDeleteApi().Delete(DateTime.UtcNow.AddMinutes(-1), DateTime.Now, "", "bucket", "org");
-            
-            influxDBClient.Dispose();
         }
     }
 }
@@ -823,13 +799,13 @@ namespace Examples
 {
     public static class ManagementExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string url = "http://localhost:8086";
             const string token = "my-token";
             const string org = "my-org";
             
-            using var client = InfluxDBClientFactory.Create(url, token);
+            using var client = new InfluxDBClient(url, token);
 
             // Find ID of Organization with specified name (PermissionAPI requires ID of Organization).
             var orgId = (await client.GetOrganizationsApi().FindOrganizationsAsync(org: org)).First().Id;
@@ -1026,15 +1002,15 @@ namespace Examples
             const string token = "my-token";
             const string bucket = "my-bucket";
             const string organization = "my-org";
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
 
             var converter = new DomainEntityConverter();
-            var client = InfluxDBClientFactory.Create(options);
+            using var client = new InfluxDBClient(options);
 
             //
             // Prepare data to write
@@ -1095,8 +1071,6 @@ namespace Examples
             // Print result
             //
             sensors.ForEach(it => Console.WriteLine(it.ToString()));
-
-            client.Dispose();
         }
     }
 }
@@ -1154,8 +1128,7 @@ var influxDBClient = InfluxDBClientFactory.Create();
 A client can be constructed using a connection string that can contain the InfluxDBClientOptions parameters encoded into the URL.  
  
 ```c#
-var influxDBClient = InfluxDBClientFactory
-            .Create("http://localhost:8086?timeout=5000&logLevel=BASIC")
+var influxDBClient = new InfluxDBClient("http://localhost:8086?timeout=5000&logLevel=BASIC");
 ```
 The following options are supported:
 
@@ -1180,7 +1153,7 @@ influxDBClient.EnableGzip();
 
 ### How to use WebProxy
 
-The `WebProxy` could be configured via `InfluxDBClientOptions.Builder`:
+The `WebProxy` could be configured via `InfluxDBClientOptions.Builder` or `InfluxDBClientOptions` parameter `WebProxy`:
 
 ```c#
 var options = new InfluxDBClientOptions.Builder()
@@ -1190,6 +1163,16 @@ var options = new InfluxDBClientOptions.Builder()
     .Build();
 
 var client = InfluxDBClientFactory.Create(options);
+```
+
+```c#
+var options = new InfluxDBClientOptions("http://localhost:8086")
+{
+    Token = "my-token".ToCharArray(),
+    WebProxy = new WebProxy("http://proxyserver:80/", true)
+};
+
+var client = new InfluxDBClient(options);
 ```
 
 ### Proxy and redirects configuration
@@ -1209,12 +1192,13 @@ using var client = InfluxDBClientFactory.Create(options);
 Client automatically **doesn't** follows HTTP redirects. You can enable redirects by `AllowRedirects` configuration option:
 
 ```csharp
-var options = new InfluxDBClientOptions.Builder()
-    .Url("http://localhost:8086")
-    .AllowRedirects(true)
-    .Build();
+var options = new InfluxDBClientOptions.Builder("http://localhost:8086")
+{
+    Token = "my-token".ToCharArray(),
+    AllowRedirects = true
+};
 
-using var client = InfluxDBClientFactory.Create(options);
+using var client = new InfluxDBClient(options);
 ```
 
 > :warning: Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain.

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -341,7 +341,7 @@ namespace InfluxDB.Client
                 return Task.CompletedTask;
             }
 
-            return WriteMeasurementsAsync(new List<TM> { measurement }, precision, bucket, org, cancellationToken);
+            return WriteMeasurementsAsync(new List<TM> {measurement}, precision, bucket, org, cancellationToken);
         }
 
         /// <summary>

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -341,7 +341,7 @@ namespace InfluxDB.Client
                 return Task.CompletedTask;
             }
 
-            return WriteMeasurementsAsync(new List<TM> {measurement}, precision, bucket, org, cancellationToken);
+            return WriteMeasurementsAsync(new List<TM> { measurement }, precision, bucket, org, cancellationToken);
         }
 
         /// <summary>

--- a/Client/WriteOptions.cs
+++ b/Client/WriteOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Reactive.Concurrency;
 using InfluxDB.Client.Core;
 
@@ -325,6 +326,8 @@ namespace InfluxDB.Client
             ///  Build an instance of WriteOptions.
             /// </summary>
             /// <returns><see cref="WriteOptions"/></returns>
+            /// <remarks>Deprecated - please use use object initializer <see cref="WriteOptions()"/></remarks>
+            [Obsolete("This method is deprecated. Call 'WriteOptions' initializer instead.", false)]
             public WriteOptions Build()
             {
                 return new WriteOptions(this);

--- a/Client/WriteOptions.cs
+++ b/Client/WriteOptions.cs
@@ -154,6 +154,21 @@ namespace InfluxDB.Client
             }
         }
 
+        /// <summary>
+        /// Create an instance of WriteOptions.
+        /// <para>
+        /// WriteOptions properties and their default values:
+        /// <list type="bullet">
+        /// <item>BatchSize:        1000</item>
+        /// <item>FlushInterval:    1000(ms)</item>
+        /// <item>JitterInterval:   0</item>
+        /// <item>RetryInterval:    5000(ms)</item>
+        /// <item>MaxRetries:       5</item>
+        /// <item>MaxRetryDelay:    125_000</item>
+        /// <item>ExponentialBase:  2</item>
+        /// </list>
+        /// </para>
+        /// </summary>
         public WriteOptions()
         {
             _batchSize = DefaultBatchSize;

--- a/Client/WriteOptions.cs
+++ b/Client/WriteOptions.cs
@@ -27,23 +27,56 @@ namespace InfluxDB.Client
         private const int DefaultMaxRetryDelay = 125_000;
         private const int DefaultExponentialBase = 2;
 
+        private int _batchSize;
+        private int _flushInterval;
+        private int _jitterInterval;
+        private int _retryInterval;
+        private int _maxRetries;
+        private int _maxRetryDelay;
+        private int _exponentialBase;
+        private IScheduler _writeScheduler;
+
         /// <summary>
         /// The number of data point to collect in batch.
         /// </summary>
         /// <seealso cref="Builder.BatchSize(int)"/>
-        internal int BatchSize { get; }
+        public int BatchSize
+        {
+            get => _batchSize;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "batchSize");
+                _batchSize = value;
+            }
+        }
 
         /// <summary>
         /// The time to wait at most (milliseconds).
         /// </summary>
         /// <seealso cref="Builder.FlushInterval(int)"/>
-        internal int FlushInterval { get; }
+        public int FlushInterval
+        {
+            get => _flushInterval;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "flushInterval");
+                _flushInterval = value;
+            }
+        }
 
         /// <summary>
         /// The batch flush jitter interval value (milliseconds).
         /// </summary>
         /// <seealso cref="Builder.JitterInterval(int)"/>
-        internal int JitterInterval { get; }
+        public int JitterInterval
+        {
+            get => _jitterInterval;
+            set
+            {
+                Arguments.CheckNotNegativeNumber(value, "jitterInterval");
+                _jitterInterval = value;
+            }
+        }
 
         /// <summary>
         /// The time to wait before retry unsuccessful write (milliseconds).
@@ -55,31 +88,83 @@ namespace InfluxDB.Client
         /// </para>
         /// </summary>
         /// <seealso cref="Builder.RetryInterval(int)"/>
-        public int RetryInterval { get; }
+        public int RetryInterval
+        {
+            get => _retryInterval;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "retryInterval");
+                _retryInterval = value;
+            }
+        }
 
         /// <summary>
         /// The number of max retries when write fails.
         /// </summary>
         /// <seealso cref="Builder.MaxRetries(int)"/>
-        public int MaxRetries { get; }
+        public int MaxRetries
+        {
+            get => _maxRetries;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "MaxRetries");
+                _maxRetries = value;
+            }
+        }
 
         /// <summary>
         /// The maximum delay between each retry attempt in milliseconds.
         /// </summary>
         /// <seealso cref="Builder.MaxRetryDelay(int)"/>
-        public int MaxRetryDelay { get; }
+        public int MaxRetryDelay
+        {
+            get => _maxRetryDelay;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "MaxRetryDelay");
+                _maxRetryDelay = value;
+            }
+        }
 
         /// <summary>
         /// The base for the exponential retry delay.
         /// </summary>
         /// <seealso cref="Builder.ExponentialBase(int)"/>
-        public int ExponentialBase { get; }
+        public int ExponentialBase
+        {
+            get => _exponentialBase;
+            set
+            {
+                Arguments.CheckPositiveNumber(value, "ExponentialBase");
+                _exponentialBase = value;
+            }
+        }
 
         /// <summary>
         /// Set the scheduler which is used for write data points.
         /// </summary>
         /// <seealso cref="Builder.WriteScheduler(IScheduler)"/>
-        internal IScheduler WriteScheduler { get; }
+        public IScheduler WriteScheduler
+        {
+            get => _writeScheduler;
+            set
+            {
+                Arguments.CheckNotNull(value, "Write scheduler");
+                _writeScheduler = value;
+            }
+        }
+
+        public WriteOptions()
+        {
+            _batchSize = DefaultBatchSize;
+            _flushInterval = DefaultFlushInterval;
+            _jitterInterval = DefaultJitterInterval;
+            _retryInterval = DefaultRetryInterval;
+            _maxRetries = DefaultMaxRetries;
+            _maxRetryDelay = DefaultMaxRetryDelay;
+            _exponentialBase = DefaultExponentialBase;
+            _writeScheduler = ThreadPoolScheduler.Instance;
+        }
 
         private WriteOptions(Builder builder)
         {

--- a/Client/Writes/PointSettings.cs
+++ b/Client/Writes/PointSettings.cs
@@ -41,7 +41,7 @@ namespace InfluxDB.Client.Writes
                 foreach (var tag in value)
                 {
                     Arguments.CheckNotNull(tag.Key, "TagName");
-                   _defaultTags[tag.Key] = tag.Value;
+                    _defaultTags[tag.Key] = tag.Value;
                 }
             }
         }
@@ -58,7 +58,7 @@ namespace InfluxDB.Client.Writes
             _defaultTags[key] = expression;
             return this;
         }
-        
+
         /// <summary>
         /// Get default tags with evaluated expressions.
         /// </summary>

--- a/Client/Writes/PointSettings.cs
+++ b/Client/Writes/PointSettings.cs
@@ -29,6 +29,24 @@ namespace InfluxDB.Client.Writes
             RegexOptions.RightToLeft);
 
         /// <summary>
+        /// Default tags that will be use for writes by Point and POJO.
+        /// </summary>
+        public Dictionary<string, string> DefaultTags
+        {
+            get => (Dictionary<string, string>)GetDefaultTags();
+            set
+            {
+                Arguments.CheckNotNull(value, "DefaultTags");
+                _defaultTags.Clear();
+                foreach (var tag in value)
+                {
+                    Arguments.CheckNotNull(tag.Key, "TagName");
+                   _defaultTags[tag.Key] = tag.Value;
+                }
+            }
+        }
+
+        /// <summary>
         /// Add default tag. 
         /// </summary>
         /// <param name="key">the tag name</param>
@@ -40,7 +58,7 @@ namespace InfluxDB.Client.Writes
             _defaultTags[key] = expression;
             return this;
         }
-
+        
         /// <summary>
         /// Get default tags with evaluated expressions.
         /// </summary>

--- a/Examples/CustomDomainMapping.cs
+++ b/Examples/CustomDomainMapping.cs
@@ -97,7 +97,7 @@ namespace Examples
 
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };

--- a/Examples/CustomDomainMapping.cs
+++ b/Examples/CustomDomainMapping.cs
@@ -88,21 +88,22 @@ namespace Examples
             }
         }
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string host = "http://localhost:9999";
             const string token = "my-token";
             const string bucket = "my-bucket";
             const string organization = "my-org";
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
+
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
 
             var converter = new DomainEntityConverter();
-            var client = InfluxDBClientFactory.Create(options);
+            using var client = new InfluxDBClient(options);
 
             //
             // Prepare data to write
@@ -163,8 +164,6 @@ namespace Examples
             // Print result
             //
             sensors.ForEach(it => Console.WriteLine(it.ToString()));
-
-            client.Dispose();
         }
     }
 }

--- a/Examples/CustomDomainMappingAndLinq.cs
+++ b/Examples/CustomDomainMappingAndLinq.cs
@@ -169,7 +169,7 @@ namespace Examples
 
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };

--- a/Examples/CustomDomainMappingAndLinq.cs
+++ b/Examples/CustomDomainMappingAndLinq.cs
@@ -160,21 +160,22 @@ namespace Examples
             }
         }
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string host = "http://localhost:9999";
             const string token = "my-token";
             const string bucket = "my-bucket";
             const string organization = "my-org";
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
+
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
 
             var converter = new DomainEntityConverter();
-            var client = InfluxDBClientFactory.Create(options);
+            using var client = new InfluxDBClient(options);
 
             //
             // Prepare data to write
@@ -308,8 +309,6 @@ namespace Examples
 
             Console.WriteLine();
             Console.WriteLine(influxQuery._Query);
-
-            client.Dispose();
         }
     }
 }

--- a/Examples/ExampleBlazor/Data/ClientSettings.cs
+++ b/Examples/ExampleBlazor/Data/ClientSettings.cs
@@ -21,12 +21,12 @@ public class Client
 
     public InfluxDBClient GetClient(double timespanSeconds = 10)
     {
-        var options = new InfluxDBClientOptions.Builder()
-            .Url(Url)
-            .AuthenticateToken(Token)
-            .TimeOut(TimeSpan.FromSeconds(timespanSeconds))
-            .Build();
+        var options = new InfluxDBClientOptions(Url)
+        {
+            Token = Token!.ToCharArray(),
+            Timeout = TimeSpan.FromSeconds(timespanSeconds)
+        };
 
-        return InfluxDBClientFactory.Create(options);
+        return new InfluxDBClient(options);
     }
 }

--- a/Examples/ExampleBlazor/Data/ClientSettings.cs
+++ b/Examples/ExampleBlazor/Data/ClientSettings.cs
@@ -23,7 +23,7 @@ public class Client
     {
         var options = new InfluxDBClientOptions(Url)
         {
-            Token = Token!.ToCharArray(),
+            Token = Token,
             Timeout = TimeSpan.FromSeconds(timespanSeconds)
         };
 

--- a/Examples/ExampleBlazor/wwwroot/css/site.css
+++ b/Examples/ExampleBlazor/wwwroot/css/site.css
@@ -175,6 +175,8 @@ a:hover { color: #5EE4E4; }
     margin: 0.1rem;
 }
 
+.rzi { min-height: 39px; }
+
 .rz-gauge .rz-tick-text { font-size: 0.65rem !important; }
 
 .rz-button.rz-state-disabled, .rz-state-disabled.rz-paginator-element { opacity: 0.7 !important; }

--- a/Examples/ExampleBlazor/wwwroot/css/site.css
+++ b/Examples/ExampleBlazor/wwwroot/css/site.css
@@ -175,7 +175,7 @@ a:hover { color: #5EE4E4; }
     margin: 0.1rem;
 }
 
-.rzi { min-height: 39px; }
+/*.rzi { min-height: 39px; }*/
 
 .rz-gauge .rz-tick-text { font-size: 0.65rem !important; }
 

--- a/Examples/ExampleBlazor/wwwroot/css/site.css
+++ b/Examples/ExampleBlazor/wwwroot/css/site.css
@@ -175,8 +175,6 @@ a:hover { color: #5EE4E4; }
     margin: 0.1rem;
 }
 
-/*.rzi { min-height: 39px; }*/
-
 .rz-gauge .rz-tick-text { font-size: 0.65rem !important; }
 
 .rz-button.rz-state-disabled, .rz-state-disabled.rz-paginator-element { opacity: 0.7 !important; }

--- a/Examples/FluxClientExample.cs
+++ b/Examples/FluxClientExample.cs
@@ -4,13 +4,13 @@ using InfluxDB.Client.Flux;
 
 namespace Examples
 {
-    public static class FluxClientFactoryExample
+    public static class FluxClientExample
     {
         public static async Task Main()
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var client = FluxClientFactory.Create(options);
+            using var client = new FluxClient(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxClientFactoryExample.cs
+++ b/Examples/FluxClientFactoryExample.cs
@@ -10,7 +10,7 @@ namespace Examples
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var fluxClient = new FluxClient(options);
+            using var fluxClient = FluxClientFactory.Create(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxClientFactoryExample.cs
+++ b/Examples/FluxClientFactoryExample.cs
@@ -6,11 +6,11 @@ namespace Examples
 {
     public static class FluxClientFactoryExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var fluxClient = FluxClientFactory.Create(options);
+            using var fluxClient = new FluxClient(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxClientFactoryExample.cs
+++ b/Examples/FluxClientFactoryExample.cs
@@ -10,14 +10,14 @@ namespace Examples
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var fluxClient = FluxClientFactory.Create(options);
+            using var client = FluxClientFactory.Create(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"
                             + " |> range(start: -1d)"
                             + " |> sample(n: 5, pos: 1)";
 
-            await fluxClient.QueryAsync(fluxQuery, record =>
+            await client.QueryAsync(fluxQuery, record =>
                 {
                     // process the flux query records
                     Console.WriteLine(record.GetTime() + ": " + record.GetValue());

--- a/Examples/FluxClientPocoExample.cs
+++ b/Examples/FluxClientPocoExample.cs
@@ -10,7 +10,7 @@ namespace Examples
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var fluxClient = new FluxClient(options);
+            using var client = new FluxClient(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"
@@ -18,7 +18,7 @@ namespace Examples
                             + " |> sample(n: 5, pos: 1)";
 
             ////Example of additional result stream processing on client side
-            await fluxClient.QueryAsync<Cpu>(fluxQuery, cpu =>
+            await client.QueryAsync<Cpu>(fluxQuery, cpu =>
                 {
                     // process the flux query records
                     Console.WriteLine(cpu.ToString());

--- a/Examples/FluxClientPocoExample.cs
+++ b/Examples/FluxClientPocoExample.cs
@@ -6,11 +6,11 @@ namespace Examples
 {
     public static class FluxClientPocoExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             var options = new FluxConnectionOptions("http://127.0.0.1:8086");
 
-            using var fluxClient = FluxClientFactory.Create(options);
+            using var fluxClient = new FluxClient(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxClientSimpleExample.cs
+++ b/Examples/FluxClientSimpleExample.cs
@@ -6,12 +6,12 @@ namespace Examples
 {
     public static class FluxClientSimpleExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             Console.WriteLine("Start");
 
             var options = new FluxConnectionOptions("http://127.0.0.1:8086", TimeSpan.FromSeconds(20));
-            using var client = FluxClientFactory.Create(options);
+            using var client = new FluxClient(options);
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxExample.cs
+++ b/Examples/FluxExample.cs
@@ -6,9 +6,9 @@ namespace Examples
 {
     public static class FluxExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            using var fluxClient = FluxClientFactory.Create("http://localhost:8086/");
+            using var fluxClient = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxExample.cs
+++ b/Examples/FluxExample.cs
@@ -8,14 +8,14 @@ namespace Examples
     {
         public static async Task Main()
         {
-            using var fluxClient = new FluxClient("http://localhost:8086/");
+            using var client = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"
                             + " |> range(start: -1d)"
                             + " |> sample(n: 5, pos: 1)";
 
-            await fluxClient.QueryAsync(fluxQuery, record =>
+            await client.QueryAsync(fluxQuery, record =>
                 {
                     // process the flux query records
                     Console.WriteLine(record.GetTime() + ": " + record.GetValue());

--- a/Examples/FluxRawExample.cs
+++ b/Examples/FluxRawExample.cs
@@ -6,9 +6,9 @@ namespace Examples
 {
     public static class FluxRawExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            using var fluxClient = FluxClientFactory.Create("http://localhost:8086/");
+            using var fluxClient = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"

--- a/Examples/FluxRawExample.cs
+++ b/Examples/FluxRawExample.cs
@@ -8,14 +8,14 @@ namespace Examples
     {
         public static async Task Main()
         {
-            using var fluxClient = new FluxClient("http://localhost:8086/");
+            using var client = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                             + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"
                             + " |> range(start: -1d)"
                             + " |> sample(n: 5, pos: 1)";
 
-            await fluxClient.QueryRawAsync(fluxQuery, line =>
+            await client.QueryRawAsync(fluxQuery, line =>
                 {
                     // process the flux query result record
                     Console.WriteLine(line);

--- a/Examples/InfluxDB18Example.cs
+++ b/Examples/InfluxDB18Example.cs
@@ -14,7 +14,7 @@ namespace Examples
 
             using var client = new InfluxDBClient("http://localhost:8086",
                 "username",
-                "password".ToCharArray(),
+                "password",
                 database,
                 retentionPolicy);
 

--- a/Examples/InfluxDB18Example.cs
+++ b/Examples/InfluxDB18Example.cs
@@ -7,12 +7,12 @@ namespace Examples
 {
     public class InfluxDB18Example
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string database = "telegraf";
             const string retentionPolicy = "autogen";
 
-            var client = InfluxDBClientFactory.CreateV1("http://localhost:8086",
+            using var client = new InfluxDBClient("http://localhost:8086",
                 "username",
                 "password".ToCharArray(),
                 database,
@@ -39,8 +39,6 @@ namespace Examples
                 Console.WriteLine(
                     $"{record.GetTime()} {record.GetMeasurement()}: {record.GetField()} {record.GetValue()}");
             });
-
-            client.Dispose();
         }
     }
 }

--- a/Examples/InvokableScripts.cs
+++ b/Examples/InvokableScripts.cs
@@ -24,7 +24,7 @@ namespace Examples
 
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };

--- a/Examples/InvokableScripts.cs
+++ b/Examples/InvokableScripts.cs
@@ -15,21 +15,21 @@ namespace Examples
     /// </summary>
     public static class InvokableScripts
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string host = "https://us-west-2-1.aws.cloud2.influxdata.com";
             const string token = "my-token";
             const string bucket = "my-bucket";
             const string organization = "my-org";
 
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
 
-            using var client = InfluxDBClientFactory.Create(options);
+            using var client = new InfluxDBClient(options);
             client.SetLogLevel(LogLevel.Body);
 
             //

--- a/Examples/ManagementExample.cs
+++ b/Examples/ManagementExample.cs
@@ -9,13 +9,13 @@ namespace Examples
 {
     public static class ManagementExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string url = "http://localhost:8086";
             const string token = "my-token";
             const string org = "my-org";
 
-            using var client = InfluxDBClientFactory.Create(url, token);
+            using var client = new InfluxDBClient(url, token);
 
             // Find ID of Organization with specified name (PermissionAPI requires ID of Organization).
             var orgId = (await client.GetOrganizationsApi().FindOrganizationsAsync(org: org)).First().Id;

--- a/Examples/ParametrizedQuery.cs
+++ b/Examples/ParametrizedQuery.cs
@@ -22,7 +22,7 @@ namespace Examples
         {
             var options = new InfluxDBClientOptions(Url)
             {
-                Token = Token.ToCharArray(),
+                Token = Token,
                 Org = Org,
                 Bucket = Bucket
             };

--- a/Examples/ParametrizedQuery.cs
+++ b/Examples/ParametrizedQuery.cs
@@ -18,17 +18,16 @@ namespace Examples
         private const string Org = "my-org";
         private const string Bucket = "my-bucket";
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var options = InfluxDBClientOptions.Builder
-                .CreateNew()
-                .Url(Url)
-                .AuthenticateToken(Token)
-                .Bucket(Bucket)
-                .Org(Org)
-                .Build();
+            var options = new InfluxDBClientOptions(Url)
+            {
+                Token = Token.ToCharArray(),
+                Org = Org,
+                Bucket = Bucket
+            };
 
-            using var client = InfluxDBClientFactory.Create(options);
+            using var client = new InfluxDBClient(options);
 
             //
             // Prepare Data

--- a/Examples/PlatformExample.cs
+++ b/Examples/PlatformExample.cs
@@ -49,13 +49,13 @@ namespace Examples
                 // Add Permissions to read and write to the Bucket
                 //
                 var resource = new PermissionResource
-                    {Type = PermissionResource.TypeBuckets, OrgID = medicalGMBH.Id, Id = temperatureBucket.Id};
+                    { Type = PermissionResource.TypeBuckets, OrgID = medicalGMBH.Id, Id = temperatureBucket.Id };
 
                 var readBucket = new Permission(Permission.ActionEnum.Read, resource);
                 var writeBucket = new Permission(Permission.ActionEnum.Write, resource);
 
                 var authorization = await client.GetAuthorizationsApi()
-                    .CreateAuthorizationAsync(medicalGMBH, new List<Permission> {readBucket, writeBucket});
+                    .CreateAuthorizationAsync(medicalGMBH, new List<Permission> { readBucket, writeBucket });
 
                 Console.WriteLine($"The token to write to temperature-sensors bucket is: {authorization.Token}");
             }
@@ -67,7 +67,6 @@ namespace Examples
             using (var client = new InfluxDBClient("http://localhost:9999",
                        "my-user", "my-password"))
             {
-
                 var writeOptions = new WriteOptions
                 {
                     BatchSize = 5000,
@@ -93,7 +92,7 @@ namespace Examples
                     //
                     // Write by POCO
                     //
-                    var temperature = new Temperature {Location = "south", Value = 62D, Time = DateTime.UtcNow};
+                    var temperature = new Temperature { Location = "south", Value = 62D, Time = DateTime.UtcNow };
                     writeClient.WriteMeasurement(temperature, WritePrecision.Ns, "temperature-sensors", medicalGMBH.Id);
 
                     //

--- a/Examples/PlatformExample.cs
+++ b/Examples/PlatformExample.cs
@@ -30,7 +30,7 @@ namespace Examples
         public static async Task Main()
         {
             var influxDB = new InfluxDBClient("http://localhost:9999",
-                "my-user", "my-password".ToCharArray());
+                "my-user", "my-password");
 
             var organizationClient = influxDB.GetOrganizationsApi();
 

--- a/Examples/PlatformExample.cs
+++ b/Examples/PlatformExample.cs
@@ -27,9 +27,9 @@ namespace Examples
             }
         }
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDB = InfluxDBClientFactory.Create("http://localhost:9999",
+            var influxDB = new InfluxDBClient("http://localhost:9999",
                 "my-user", "my-password".ToCharArray());
 
             var organizationClient = influxDB.GetOrganizationsApi();
@@ -66,15 +66,15 @@ namespace Examples
             // Create new client with specified authorization token
             //
 
-            influxDB = InfluxDBClientFactory.Create("http://localhost:9999", authorization.Token);
+            influxDB = new InfluxDBClient("http://localhost:9999", authorization.Token);
 
-            var writeOptions = WriteOptions
-                .CreateNew()
-                .BatchSize(5000)
-                .FlushInterval(1000)
-                .JitterInterval(1000)
-                .RetryInterval(5000)
-                .Build();
+            var writeOptions = new WriteOptions
+            {
+                BatchSize = 5000,
+                FlushInterval = 1000,
+                JitterInterval = 1000,
+                RetryInterval = 5000
+            };
 
             //
             // Write data

--- a/Examples/PocoQueryWriteExample.cs
+++ b/Examples/PocoQueryWriteExample.cs
@@ -42,7 +42,7 @@ namespace Examples
 
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };

--- a/Examples/PocoQueryWriteExample.cs
+++ b/Examples/PocoQueryWriteExample.cs
@@ -30,7 +30,7 @@ namespace Examples
             }
         }
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             //
             // Initialize Client
@@ -39,13 +39,15 @@ namespace Examples
             const string token = "my-token";
             const string bucket = "my-bucket";
             const string organization = "my-org";
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
-            var client = InfluxDBClientFactory.Create(options);
+
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
+
+            using var client = new InfluxDBClient(options);
 
             //
             // Prepare data to write
@@ -92,8 +94,6 @@ namespace Examples
             // Print result
             //
             list.ForEach(it => Console.WriteLine(it.ToString()));
-
-            client.Dispose();
         }
     }
 }

--- a/Examples/QueryLinqCloud.cs
+++ b/Examples/QueryLinqCloud.cs
@@ -141,22 +141,22 @@ namespace Examples
             }
         }
 
-        public static void Main(string[] args)
+        public static void Main()
         {
             const string host = "https://us-west-2-1.aws.cloud2.influxdata.com";
             const string token = "...";
             const string bucket = "linq_bucket";
             const string organization = "jakub_bednar";
-            var options = new InfluxDBClientOptions.Builder()
-                .Url(host)
-                .AuthenticateToken(token.ToCharArray())
-                .Org(organization)
-                .Bucket(bucket)
-                .Build();
+
+            var options = new InfluxDBClientOptions(host)
+            {
+                Token = token.ToCharArray(),
+                Org = organization,
+                Bucket = bucket
+            };
 
             var converter = new DomainEntityConverter();
-            var client = InfluxDBClientFactory.Create(options)
-                .EnableGzip();
+            using var client = new InfluxDBClient(options).EnableGzip();
 
             //
             // Query Data to Domain object
@@ -199,8 +199,6 @@ namespace Examples
             Console.WriteLine();
             Console.WriteLine("> query:");
             Console.WriteLine(influxQuery._Query);
-
-            client.Dispose();
         }
     }
 }

--- a/Examples/QueryLinqCloud.cs
+++ b/Examples/QueryLinqCloud.cs
@@ -150,7 +150,7 @@ namespace Examples
 
             var options = new InfluxDBClientOptions(host)
             {
-                Token = token.ToCharArray(),
+                Token = token,
                 Org = organization,
                 Bucket = bucket
             };

--- a/Examples/RecordRowExample.cs
+++ b/Examples/RecordRowExample.cs
@@ -16,7 +16,7 @@ namespace Examples
             const string bucket = "my-bucket";
             const string org = "my-org";
 
-            using var client = InfluxDBClientFactory.Create(url, token.ToCharArray());
+            using var client = new InfluxDBClient(url: url, token: token);
 
             //
             // Prepare Data

--- a/Examples/RecordRowExample.cs
+++ b/Examples/RecordRowExample.cs
@@ -16,7 +16,7 @@ namespace Examples
             const string bucket = "my-bucket";
             const string org = "my-org";
 
-            using var client = new InfluxDBClient(url: url, token: token);
+            using var client = new InfluxDBClient(url, token);
 
             //
             // Prepare Data

--- a/Examples/RunExamples.cs
+++ b/Examples/RunExamples.cs
@@ -28,7 +28,7 @@ namespace Examples
                         await FluxRawExample.Main();
                         break;
                     case "FluxClientFactoryExample":
-                        await FluxClientFactoryExample.Main();
+                        await FluxClientExample.Main();
                         break;
                     case "FluxClientPocoExample":
                         await FluxClientPocoExample.Main();

--- a/Examples/RunExamples.cs
+++ b/Examples/RunExamples.cs
@@ -19,55 +19,55 @@ namespace Examples
                 switch (args[0])
                 {
                     case "FluxExample":
-                        await FluxExample.Main(args);
+                        await FluxExample.Main();
                         break;
                     case "FluxClientSimpleExample":
-                        await FluxClientSimpleExample.Main(args);
+                        await FluxClientSimpleExample.Main();
                         break;
                     case "FluxRawExample":
-                        await FluxRawExample.Main(args);
+                        await FluxRawExample.Main();
                         break;
                     case "FluxClientFactoryExample":
-                        await FluxClientFactoryExample.Main(args);
+                        await FluxClientFactoryExample.Main();
                         break;
                     case "FluxClientPocoExample":
-                        await FluxClientPocoExample.Main(args);
+                        await FluxClientPocoExample.Main();
                         break;
                     case "PlatformExample":
-                        await PlatformExample.Main(args);
+                        await PlatformExample.Main();
                         break;
                     case "WriteEventHandlerExample":
                         await WriteEventHandlerExample.Main();
                         break;
                     case "WriteApiAsyncExample":
-                        await WriteApiAsyncExample.Main(args);
+                        await WriteApiAsyncExample.Main();
                         break;
                     case "PocoQueryWriteExample":
-                        await PocoQueryWriteExample.Main(args);
+                        await PocoQueryWriteExample.Main();
                         break;
                     case "CustomDomainMappingAndLinq":
-                        await CustomDomainMappingAndLinq.Main(args);
+                        await CustomDomainMappingAndLinq.Main();
                         break;
                     case "InfluxDB18Example":
-                        await InfluxDB18Example.Main(args);
+                        await InfluxDB18Example.Main();
                         break;
                     case "SynchronousQuery":
-                        SynchronousQuery.Main(args);
+                        SynchronousQuery.Main();
                         break;
                     case "CustomDomainMapping":
-                        await CustomDomainMapping.Main(args);
+                        await CustomDomainMapping.Main();
                         break;
                     case "QueryLinqCloud":
-                        QueryLinqCloud.Main(args);
+                        QueryLinqCloud.Main();
                         break;
                     case "ManagementExample":
-                        await ManagementExample.Main(args);
+                        await ManagementExample.Main();
                         break;
                     case "InvokableScripts":
-                        await InvokableScripts.Main(args);
+                        await InvokableScripts.Main();
                         break;
                     case "ParametrizedQuery":
-                        await ParametrizedQuery.Main(args);
+                        await ParametrizedQuery.Main();
                         break;
                     case "RecordRowExample":
                         await RecordRowExample.Main();

--- a/Examples/SynchronousQuery.cs
+++ b/Examples/SynchronousQuery.cs
@@ -5,9 +5,9 @@ namespace Examples
 {
     public class SynchronousQuery
     {
-        public static void Main(string[] args)
+        public static void Main()
         {
-            using var client = InfluxDBClientFactory.Create("http://localhost:9999", "my-token");
+            using var client = new InfluxDBClient("http://localhost:9999", "my-token");
 
             const string query = "from(bucket:\"my-bucket\") |> range(start: 0)";
 

--- a/Examples/WriteApiAsyncExample.cs
+++ b/Examples/WriteApiAsyncExample.cs
@@ -21,13 +21,13 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDbClient = new InfluxDBClient("http://localhost:9999",
+            using var client = new InfluxDBClient("http://localhost:9999",
                 "my-user", "my-password");
 
             //
             // Write Data
             //
-            var writeApiAsync = influxDbClient.GetWriteApiAsync();
+            var writeApiAsync = client.GetWriteApiAsync();
 
             //
             //
@@ -57,7 +57,7 @@ namespace Examples
             //
             // Check written data
             //
-            var tables = await influxDbClient.GetQueryApi()
+            var tables = await client.GetQueryApi()
                 .QueryAsync("from(bucket:\"my-bucket\") |> range(start: 0)", "my-org");
 
             tables.ForEach(table =>

--- a/Examples/WriteApiAsyncExample.cs
+++ b/Examples/WriteApiAsyncExample.cs
@@ -19,9 +19,9 @@ namespace Examples
             [Column(IsTimestamp = true)] public DateTime Time { get; set; }
         }
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDbClient = InfluxDBClientFactory.Create("http://localhost:9999",
+            using var influxDbClient = new InfluxDBClient("http://localhost:9999",
                 "my-user", "my-password".ToCharArray());
 
             //
@@ -65,8 +65,6 @@ namespace Examples
                 var fluxRecords = table.Records;
                 fluxRecords.ForEach(record => { Console.WriteLine($"{record.GetTime()}: {record.GetValue()}"); });
             });
-
-            influxDbClient.Dispose();
         }
     }
 }

--- a/Examples/WriteApiAsyncExample.cs
+++ b/Examples/WriteApiAsyncExample.cs
@@ -22,7 +22,7 @@ namespace Examples
         public static async Task Main()
         {
             using var influxDbClient = new InfluxDBClient("http://localhost:9999",
-                "my-user", "my-password".ToCharArray());
+                "my-user", "my-password");
 
             //
             // Write Data

--- a/Examples/WriteEventHandlerExample.cs
+++ b/Examples/WriteEventHandlerExample.cs
@@ -126,7 +126,7 @@ namespace Examples
                 //
                 // Write by POCO
                 //
-                var influxPoint = new InfluxPoint {WriteType = "POCO", Value = 33.33, Time = DateTime.UtcNow};
+                var influxPoint = new InfluxPoint { WriteType = "POCO", Value = 33.33, Time = DateTime.UtcNow };
 
                 writeApi.WriteMeasurement(influxPoint, WritePrecision.Ns, "my-bucket", "my-org");
 
@@ -141,7 +141,7 @@ namespace Examples
                 var pointsToWrite = new List<InfluxPoint>();
                 for (var i = 1; i <= 5; i++)
                     pointsToWrite.Add(new InfluxPoint
-                        {WriteType = "POCO", Value = i, Time = DateTime.UtcNow.AddSeconds(-i)});
+                        { WriteType = "POCO", Value = i, Time = DateTime.UtcNow.AddSeconds(-i) });
 
                 writeApi.WriteMeasurements(pointsToWrite, WritePrecision.Ns, "my-bucket", "my-org");
             }

--- a/Examples/WriteEventHandlerExample.cs
+++ b/Examples/WriteEventHandlerExample.cs
@@ -34,15 +34,16 @@ namespace Examples
 
         private static Task BasicEventHandler()
         {
-            using var client = InfluxDBClientFactory.Create("http://localhost:9999",
+            using var client = new InfluxDBClient("http://localhost:9999",
                 "my-user", "my-password".ToCharArray());
 
-            var options = WriteOptions.CreateNew()
-                .BatchSize(1)
-                .FlushInterval(1000)
-                .RetryInterval(2000)
-                .MaxRetries(3)
-                .Build();
+            var options = new WriteOptions
+            {
+                BatchSize = 1,
+                FlushInterval = 1000,
+                RetryInterval = 2000,
+                MaxRetries = 3
+            };
 
             //
             // Write Data
@@ -125,7 +126,7 @@ namespace Examples
                 //
                 // Write by POCO
                 //
-                var influxPoint = new InfluxPoint { WriteType = "POCO", Value = 33.33, Time = DateTime.UtcNow };
+                var influxPoint = new InfluxPoint {WriteType = "POCO", Value = 33.33, Time = DateTime.UtcNow};
 
                 writeApi.WriteMeasurement(influxPoint, WritePrecision.Ns, "my-bucket", "my-org");
 
@@ -140,7 +141,7 @@ namespace Examples
                 var pointsToWrite = new List<InfluxPoint>();
                 for (var i = 1; i <= 5; i++)
                     pointsToWrite.Add(new InfluxPoint
-                        { WriteType = "POCO", Value = i, Time = DateTime.UtcNow.AddSeconds(-i) });
+                        {WriteType = "POCO", Value = i, Time = DateTime.UtcNow.AddSeconds(-i)});
 
                 writeApi.WriteMeasurements(pointsToWrite, WritePrecision.Ns, "my-bucket", "my-org");
             }
@@ -150,15 +151,17 @@ namespace Examples
 
         private static Task CustomEventListener()
         {
-            using var client = InfluxDBClientFactory.Create("http://localhost:9999/",
+            using var client = new InfluxDBClient("http://localhost:9999",
                 "my-user", "my-password".ToCharArray());
 
-            var options = WriteOptions.CreateNew()
-                .BatchSize(5)
-                .FlushInterval(1000)
-                .RetryInterval(2000)
-                .MaxRetries(3)
-                .Build();
+            var options = new WriteOptions
+            {
+                BatchSize = 5,
+                FlushInterval = 1000,
+                RetryInterval = 2000,
+                MaxRetries = 3
+            };
+
             //
             // Write Data
             //

--- a/Examples/WriteEventHandlerExample.cs
+++ b/Examples/WriteEventHandlerExample.cs
@@ -35,7 +35,7 @@ namespace Examples
         private static Task BasicEventHandler()
         {
             using var client = new InfluxDBClient("http://localhost:9999",
-                "my-user", "my-password".ToCharArray());
+                "my-user", "my-password");
 
             var options = new WriteOptions
             {
@@ -152,7 +152,7 @@ namespace Examples
         private static Task CustomEventListener()
         {
             using var client = new InfluxDBClient("http://localhost:9999",
-                "my-user", "my-password".ToCharArray());
+                "my-user", "my-password");
 
             var options = new WriteOptions
             {

--- a/README.md
+++ b/README.md
@@ -89,12 +89,12 @@ namespace Examples
 
         public static async Task Main()
         {
-            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
+            using var client = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
             //
-            using (var writeApi = influxDBClient.GetWriteApi())
+            using (var writeApi = client.GetWriteApi())
             {
                 //
                 // Write by Point
@@ -262,14 +262,14 @@ namespace Examples
     {
         public static void Run()
         {
-            using var fluxClient = new FluxClient("http://localhost:8086/");
+            using var client = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                                + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"
                                + " |> range(start: -1d)"
                                + " |> sample(n: 5, pos: 1)";
 
-            fluxClient.QueryAsync(fluxQuery, record =>
+            client.QueryAsync(fluxQuery, record =>
                             {
                                 // process the flux query records
                                 Console.WriteLine(record.GetTime() + ": " + record.GetValue());

--- a/README.md
+++ b/README.md
@@ -87,9 +87,9 @@ namespace Examples
     {
         private static readonly char[] Token = "".ToCharArray();
 
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
-            var influxDBClient = InfluxDBClientFactory.Create("http://localhost:8086", Token);
+            using var influxDBClient = new InfluxDBClient("http://localhost:8086", Token);
 
             //
             // Write Data
@@ -132,8 +132,6 @@ namespace Examples
                     Console.WriteLine($"{fluxRecord.GetTime()}: {fluxRecord.GetValue()}");
                 });
             });
-
-            influxDBClient.Dispose();
         }
         
         [Measurement("temperature")]
@@ -179,13 +177,13 @@ namespace Examples
 {
     public static class ManagementExample
     {
-        public static async Task Main(string[] args)
+        public static async Task Main()
         {
             const string url = "http://localhost:8086";
             const string token = "my-token";
             const string org = "my-org";
             
-            using var client = InfluxDBClientFactory.Create(url, token);
+            using var client = new InfluxDBClient(url, token);
 
             // Find ID of Organization with specified name (PermissionAPI requires ID of Organization).
             var orgId = (await client.GetOrganizationsApi().FindOrganizationsAsync(org: org)).First().Id;
@@ -264,7 +262,7 @@ namespace Examples
     {
         public static void Run()
         {
-            using var fluxClient = FluxClientFactory.Create("http://localhost:8086/");
+            using var fluxClient = new FluxClient("http://localhost:8086/");
 
             var fluxQuery = "from(bucket: \"telegraf\")\n"
                                + " |> filter(fn: (r) => (r[\"_measurement\"] == \"cpu\" AND r[\"_field\"] == \"usage_system\"))"


### PR DESCRIPTION
Closes #381

## Proposed Changes

Added possibility of initializing InfluxDBClient, InfluxDBClientOptions, WriteOptions and FluxClient without using factory/builder. Examples and documentation were edited to use initializer.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
