### PR TITLE
feat: expose `FluxCsvParser` as `AnnotatedCsvParser`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#376](https://github.com/influxdata/influxdb-client-csharp/pull/376): Add `FluxRecord.Row` which stores response data in a list
+1. [#404](https://github.com/influxdata/influxdb-client-csharp/pull/404): Expose `FluxCsvParser` as `AnnotatedCsvParser`
 
 ### Dependencies
 Update dependencies:

--- a/Client.Core/Flux/Serialization/AnnotatedCsvParser.cs
+++ b/Client.Core/Flux/Serialization/AnnotatedCsvParser.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading;
+using InfluxDB.Client.Core.Flux.Domain;
+using InfluxDB.Client.Core.Flux.Internal;
+
+namespace InfluxDB.Client.Core.Flux.Serialization
+{
+    public interface IAnnotatedCsvParser
+    {
+        /// <summary>
+        /// Parsing query results in annotated CSV format into list of <see cref="FluxTable"/>.
+        /// </summary>
+        /// <param name="annotatedCsv">Query results in annotated CSV format</param>
+        /// <param name="cancellationToken">To cancel the parsing</param>
+        /// <returns>Parsed Annotated CSV into list of <see cref="FluxTable"/></returns>
+        List<FluxTable> Parse(string annotatedCsv, CancellationToken cancellationToken = default);
+    }
+
+    /// <summary>
+    /// Parser for processing <see href="https://docs.influxdata.com/influxdb/cloud/reference/syntax/annotated-csv/">Annotated CSV</see>.
+    /// </summary>
+    public class AnnotatedCsvParser : IAnnotatedCsvParser
+    {
+        private readonly FluxCsvParser _parser;
+
+        /// <summary>
+        /// Public constructor.
+        /// </summary>
+        public AnnotatedCsvParser()
+        {
+            _parser = new FluxCsvParser();
+        }
+
+        /// <summary>
+        /// Parsing query results in annotated CSV format into list of <see cref="FluxTable"/>.
+        /// </summary>
+        /// <param name="annotatedCsv">Query results in annotated CSV format</param>
+        /// <param name="cancellationToken">To cancel the parsing</param>
+        /// <returns>Parsed Annotated CSV into list of <see cref="FluxTable"/></returns>
+        public List<FluxTable> Parse(string annotatedCsv, CancellationToken cancellationToken = default)
+        {
+            var consumer = new FluxCsvParser.FluxResponseConsumerTable();
+            _parser.ParseFluxResponse(annotatedCsv, cancellationToken, consumer);
+
+            return consumer.Tables;
+        }
+    }
+}

--- a/Client.Legacy.Test/FluxCsvParserTest.cs
+++ b/Client.Legacy.Test/FluxCsvParserTest.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using InfluxDB.Client.Core.Flux.Domain;
 using InfluxDB.Client.Core.Flux.Exceptions;
 using InfluxDB.Client.Core.Flux.Internal;
+using InfluxDB.Client.Core.Flux.Serialization;
 using NodaTime;
 using NodaTime.Text;
 using NUnit.Framework;
@@ -791,6 +792,22 @@ namespace Client.Legacy.Test
             Assert.AreEqual(7, tables[0].Records[0].Values.Count);
             Assert.AreEqual(8, tables[0].Records[0].Row.Count);
             Assert.AreEqual(25.3, tables[0].Records[0].Row[7]);
+        }
+
+        [Test]
+        public void AnnotatedCsvParser()
+        {
+            const string data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string\n"
+                                + "#group,false,false,true,true,true,true,true,true,false,false,false\n"
+                                + "#default,_result,,,,,,,,,,\n"
+                                + ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n"
+                                + ",,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test\n"
+                                + ",,1,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,B,west,484,22,test\n"
+                                + ",,2,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,usage_system,cpu,A,west,1444,38,test\n"
+                                + ",,3,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,user_usage,cpu,A,west,2401,49,test";
+
+            var tables = new AnnotatedCsvParser().Parse(data);
+            Assert.AreEqual(4, tables.Count);
         }
 
         private List<FluxTable> ParseFluxResponse(string data)

--- a/Client.Legacy.Test/FluxCsvParserTest.cs
+++ b/Client.Legacy.Test/FluxCsvParserTest.cs
@@ -797,14 +797,15 @@ namespace Client.Legacy.Test
         [Test]
         public void AnnotatedCsvParser()
         {
-            const string data = "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string\n"
-                                + "#group,false,false,true,true,true,true,true,true,false,false,false\n"
-                                + "#default,_result,,,,,,,,,,\n"
-                                + ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n"
-                                + ",,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test\n"
-                                + ",,1,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,B,west,484,22,test\n"
-                                + ",,2,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,usage_system,cpu,A,west,1444,38,test\n"
-                                + ",,3,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,user_usage,cpu,A,west,2401,49,test";
+            const string data =
+                "#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,string,string,string,string,long,long,string\n"
+                + "#group,false,false,true,true,true,true,true,true,false,false,false\n"
+                + "#default,_result,,,,,,,,,,\n"
+                + ",result,table,_start,_stop,_field,_measurement,host,region,_value2,value1,value_str\n"
+                + ",,0,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,A,west,121,11,test\n"
+                + ",,1,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,free,mem,B,west,484,22,test\n"
+                + ",,2,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,usage_system,cpu,A,west,1444,38,test\n"
+                + ",,3,1677-09-21T00:12:43.145224192Z,2018-07-16T11:21:02.547596934Z,user_usage,cpu,A,west,2401,49,test";
 
             var tables = new AnnotatedCsvParser().Parse(data);
             Assert.AreEqual(4, tables.Count);


### PR DESCRIPTION
Closes #389

## Proposed Changes

Expose `FluxCsvParser` as `AnnotatedCsvParser` for uses in third party integration.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
