### PR TITLE
Add HttpClient parameters for the constructor of the InfluxDbClient s…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1068,3 +1068,4 @@ This release introduces a support for new InfluxDB OSS API definitions - [oss.ym
 ###  Features
 1. [Influx] (https://github.com/influxdata/influxdb-client-csharp/blob/master/Client#InfluxDBClientOptions): Add a property of httpClient that can by used for dependency injection
 2. [Internal] (https://github.com/influxdata/influxdb-client-csharp/tree/master/Client/Internal#ApiClient): Create an RestClient instance by the httpClient of InfluxDBClientOptions
+2. [Influx] (https://github.com/influxdata/influxdb-client-csharp/tree/master/Client#InfluxDBClientOptions): Add the method SetHttpClient to set value of HttpClient 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1064,3 +1064,7 @@ This release introduces a support for new InfluxDB OSS API definitions - [oss.ym
 ### Features
 1. [Client](https://github.com/influxdata/influxdb-client-csharp/tree/master/Client#influxdbclient): The reference C# client that allows query, write and InfluxDB 2.0 management
 1. [Client.Legacy](https://github.com/influxdata/influxdb-client-csharp/tree/master/Client.Legacy#influxdbclientflux): The reference C# client that allows you to perform Flux queries against InfluxDB 1.7+
+
+###  Features
+1. [Influx] (https://github.com/influxdata/influxdb-client-csharp/blob/master/Client#InfluxDBClientOptions): Add a property of httpClient that can by used for dependency injection
+2. [Internal] (https://github.com/influxdata/influxdb-client-csharp/tree/master/Client/Internal#ApiClient): Create an RestClient instance by the httpClient of InfluxDBClientOptions

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -444,5 +444,27 @@ namespace InfluxDB.Client.Test
 
             StringAssert.Contains("Header: Authorization=***", writer.ToString());
         }
+
+        [Test]
+        public void SetHttpClient()
+        {
+            var httpClient = new HttpClient();
+            var dbClient = new InfluxDBClient(
+                InfluxDBClientOptions.Builder
+                .CreateNew()
+                .Url("http://localhost:8086/")
+                .SetHttpClient(httpClient)
+                .Build()
+                );
+            var fieldOfApiClient = dbClient.GetType().GetField("_apiClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            var apiClient = fieldOfApiClient.GetValue(dbClient) as ApiClient;
+
+            var propertydOfHttpClient = apiClient.RestClient.GetType().GetProperty("HttpClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+            var client = propertydOfHttpClient.GetValue(apiClient.RestClient) as HttpClient;
+
+            Assert.True(client.GetHashCode() == httpClient.GetHashCode());
+        }
     }
 }

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -456,11 +456,13 @@ namespace InfluxDB.Client.Test
                 .SetHttpClient(httpClient)
                 .Build()
                 );
-            var fieldOfApiClient = dbClient.GetType().GetField("_apiClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var fieldOfApiClient = dbClient.GetType().GetField("_apiClient", 
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             var apiClient = fieldOfApiClient.GetValue(dbClient) as ApiClient;
 
-            var propertydOfHttpClient = apiClient.RestClient.GetType().GetProperty("HttpClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+            var propertydOfHttpClient = apiClient.RestClient.GetType()
+                .GetProperty("HttpClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
             var client = propertydOfHttpClient.GetValue(apiClient.RestClient) as HttpClient;
 

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -452,7 +452,7 @@ namespace InfluxDB.Client.Test
             var dbClient = new InfluxDBClient(
                 InfluxDBClientOptions.Builder
                 .CreateNew()
-                .Url("http://localhost:8086/")
+                .Url(MockServerUrl)
                 .SetHttpClient(httpClient)
                 .Build()
                 );

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -313,8 +313,7 @@ namespace InfluxDB.Client
         /// Create a instance of the InfluxDB 2.x client.
         /// </summary>
         /// <param name="options">the connection configuration</param>
-        /// <param name="client">the http client</param> 
-        public InfluxDBClient(InfluxDBClientOptions options, HttpClient client = null)
+        public InfluxDBClient(InfluxDBClientOptions options)
         {
             Arguments.CheckNotNull(options, nameof(options));
 
@@ -322,7 +321,7 @@ namespace InfluxDB.Client
             _loggingHandler = new LoggingHandler(options.LogLevel);
             _gzipHandler = new GzipHandler();
 
-            _apiClient = new ApiClient(options, _loggingHandler, _gzipHandler, client);
+            _apiClient = new ApiClient(options, _loggingHandler, _gzipHandler);
 
             _exceptionFactory = (methodName, response) =>
                 !response.IsSuccessful ? HttpException.Create(response, response.Content) : null;

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Diagnostics;
+using System.Net.Http;
 using System.Reactive;
 using System.Reactive.Subjects;
 using System.Text;
@@ -312,7 +313,8 @@ namespace InfluxDB.Client
         /// Create a instance of the InfluxDB 2.x client.
         /// </summary>
         /// <param name="options">the connection configuration</param>
-        public InfluxDBClient(InfluxDBClientOptions options)
+        /// <param name="client">the http client</param> 
+        public InfluxDBClient(InfluxDBClientOptions options, HttpClient client = null)
         {
             Arguments.CheckNotNull(options, nameof(options));
 
@@ -320,7 +322,7 @@ namespace InfluxDB.Client
             _loggingHandler = new LoggingHandler(options.LogLevel);
             _gzipHandler = new GzipHandler();
 
-            _apiClient = new ApiClient(options, _loggingHandler, _gzipHandler);
+            _apiClient = new ApiClient(options, _loggingHandler, _gzipHandler, client);
 
             _exceptionFactory = (methodName, response) =>
                 !response.IsSuccessful ? HttpException.Create(response, response.Content) : null;

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
@@ -34,6 +35,7 @@ namespace InfluxDB.Client
         private bool _allowHttpRedirects;
         private bool _verifySsl;
         private X509CertificateCollection _clientCertificates;
+        private HttpClient _httpClient;
 
         /// <summary>
         /// Set the url to connect the InfluxDB.
@@ -202,6 +204,15 @@ namespace InfluxDB.Client
                 Arguments.CheckNotNull(value, "ClientCertificates");
                 _clientCertificates = value;
             }
+        }
+
+        /// <summary>
+        /// An instance of HttpClient that can by used for dependency injection
+        /// </summary>
+        public HttpClient HttpClient
+        {
+            get => _httpClient;
+            set => _httpClient = value;
         }
 
         /// <summary>

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -439,6 +439,11 @@ namespace InfluxDB.Client
             {
                 ClientCertificates = builder.CertificateCollection;
             }
+
+            if (builder.HttpClient != null)
+            {
+                HttpClient = builder.HttpClient;
+            }
         }
 
         private static TimeSpan ToTimeout(string value)
@@ -517,6 +522,7 @@ namespace InfluxDB.Client
             internal bool VerifySslCertificates = true;
             internal RemoteCertificateValidationCallback VerifySslCallback;
             internal X509CertificateCollection CertificateCollection;
+            internal HttpClient HttpClient;
 
             internal PointSettings PointSettings = new PointSettings();
 
@@ -725,6 +731,20 @@ namespace InfluxDB.Client
                 Arguments.CheckNotNull(clientCertificates, nameof(clientCertificates));
 
                 CertificateCollection = clientCertificates;
+
+                return this;
+            }
+
+            /// <summary>
+            /// Set HttpClient
+            /// </summary>
+            /// <param name="httpClient"></param>
+            /// <returns></returns>
+            public Builder SetHttpClient(HttpClient httpClient)
+            {
+                Arguments.CheckNotNull(httpClient, nameof(httpClient));
+
+                HttpClient = httpClient;
 
                 return this;
             }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -27,7 +27,7 @@ namespace InfluxDB.Client.Api.Client
         private bool _initializedSessionTokens = false;
         private bool _signout;
 
-        public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler, HttpClient client = null)
+        public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler)
         {
             _options = options;
             _loggingHandler = loggingHandler;
@@ -59,7 +59,10 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = client == null ? new RestClient(RestClientOptions) : new RestClient(client, RestClientOptions);
+            RestClient = options.HttpClient == null ? 
+                new RestClient(RestClientOptions) : 
+                new RestClient(options.HttpClient, RestClientOptions);
+
             Configuration = new Configuration
             {
                 ApiClient = this,

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -26,7 +27,7 @@ namespace InfluxDB.Client.Api.Client
         private bool _initializedSessionTokens = false;
         private bool _signout;
 
-        public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler)
+        public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler, HttpClient client = null)
         {
             _options = options;
             _loggingHandler = loggingHandler;
@@ -58,7 +59,7 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = new RestClient(RestClientOptions);
+            RestClient = client == null ? new RestClient(RestClientOptions) : new RestClient(client, RestClientOptions);
             Configuration = new Configuration
             {
                 ApiClient = this,


### PR DESCRIPTION
## Proposed Changes

    The RestClient object will create many TCP connections during use. 
    At present, RestClient should have noticed this problem, and it provides a constructor to add HttpClient objects. 
    With this constructor, external users can manage the creation of HttpClient objects themselves (by injecting HttpClient objects and other methods). Unfortunately, the InfluxDbClient does not support it at present, so I hope this problem can be improved.

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

## Checklist

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `dotnet test` completes successfully
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)