### PR TITLE
feat(deps): Add a HttpClient as a part of InfluxDBClientOptions.

### DIFF
--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -444,5 +444,35 @@ namespace InfluxDB.Client.Test
 
             StringAssert.Contains("Header: Authorization=***", writer.ToString());
         }
+
+        [Test]
+        public void SetHttpClient()
+        {
+            var httpClient1 = new HttpClient();
+
+            var options = InfluxDBClientOptions.Builder
+                .CreateNew()
+                .Url("http://localhost:8086/")
+                .AuthenticateToken(("EMnOtfL2y09sf8_2MCuoogkjlxzPSlpAlIKC-5v5RWSGCPS4v6TU4GqE6kNQlrb6zyVC9sTkK9aC8xEjymDc5Q==").ToArray())
+                .SetHttpClient(httpClient1)
+                .Build();
+
+            var dbClient = new InfluxDBClient(options);
+
+            var apiClient = dbClient.GetType().GetField("_apiClient",
+               BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetValue(dbClient) as ApiClient;
+
+            var httpClient2 = apiClient.RestClient.GetType()
+                .GetProperty("HttpClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .GetValue(apiClient.RestClient) as HttpClient;
+
+            Assert.True(httpClient1.GetHashCode() == httpClient2.GetHashCode());
+
+            using (var writeApi = dbClient.GetWriteApi())
+            {
+                writeApi.WriteRecord("h2o_feet,location=coyote_creek water_level=1.0 1", WritePrecision.Ns, "test",
+                    "seck");
+            }
+        }
     }
 }

--- a/Client.Test/InfluxDbClientTest.cs
+++ b/Client.Test/InfluxDbClientTest.cs
@@ -453,14 +453,16 @@ namespace InfluxDB.Client.Test
             var options = InfluxDBClientOptions.Builder
                 .CreateNew()
                 .Url("http://localhost:8086/")
-                .AuthenticateToken(("EMnOtfL2y09sf8_2MCuoogkjlxzPSlpAlIKC-5v5RWSGCPS4v6TU4GqE6kNQlrb6zyVC9sTkK9aC8xEjymDc5Q==").ToArray())
+                .AuthenticateToken(
+                    "EMnOtfL2y09sf8_2MCuoogkjlxzPSlpAlIKC-5v5RWSGCPS4v6TU4GqE6kNQlrb6zyVC9sTkK9aC8xEjymDc5Q=="
+                        .ToArray())
                 .SetHttpClient(httpClient1)
                 .Build();
 
             var dbClient = new InfluxDBClient(options);
 
             var apiClient = dbClient.GetType().GetField("_apiClient",
-               BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetValue(dbClient) as ApiClient;
+                BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).GetValue(dbClient) as ApiClient;
 
             var httpClient2 = apiClient.RestClient.GetType()
                 .GetProperty("HttpClient", BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
@@ -34,6 +35,7 @@ namespace InfluxDB.Client
         private bool _allowHttpRedirects;
         private bool _verifySsl;
         private X509CertificateCollection _clientCertificates;
+        private HttpClient _httpClient;
 
         /// <summary>
         /// Set the url to connect the InfluxDB.
@@ -216,6 +218,15 @@ namespace InfluxDB.Client
         {
             get => PointSettings.DefaultTags;
             set => PointSettings.DefaultTags = value;
+        }
+
+        /// <summary>
+        /// Add a HttpClient as a part of InfluxDBClientOptions
+        /// </summary>
+        public HttpClient HttpClient
+        {
+            get => _httpClient;
+            set => _httpClient = value;
         }
 
         /// <summary>
@@ -428,6 +439,11 @@ namespace InfluxDB.Client
             {
                 ClientCertificates = builder.CertificateCollection;
             }
+
+            if (builder.HttpClient != null)
+            {
+                HttpClient = builder.HttpClient;
+            }
         }
 
         private static TimeSpan ToTimeout(string value)
@@ -506,6 +522,7 @@ namespace InfluxDB.Client
             internal bool VerifySslCertificates = true;
             internal RemoteCertificateValidationCallback VerifySslCallback;
             internal X509CertificateCollection CertificateCollection;
+            internal HttpClient HttpClient;
 
             internal PointSettings PointSettings = new PointSettings();
 
@@ -827,6 +844,20 @@ namespace InfluxDB.Client
                 }
 
                 return new InfluxDBClientOptions(this);
+            }
+
+            /// <summary>
+            /// Configure HttpClient
+            /// </summary>
+            /// <param name="httpClient"></param>
+            /// <returns></returns>
+            public Builder SetHttpClient(HttpClient httpClient)
+            {
+                Arguments.CheckNotNull(httpClient, nameof(httpClient));
+
+                HttpClient = httpClient;
+
+                return this;
             }
         }
     }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -58,7 +58,10 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = new RestClient(RestClientOptions);
+            RestClient = options.HttpClient == null ?
+                new RestClient(RestClientOptions) :
+                new RestClient(options.HttpClient, RestClientOptions);
+
             Configuration = new Configuration
             {
                 ApiClient = this,

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -58,9 +58,9 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = options.HttpClient == null ?
-                new RestClient(RestClientOptions) :
-                new RestClient(options.HttpClient, RestClientOptions);
+            RestClient = options.HttpClient == null
+                ? new RestClient(RestClientOptions)
+                : new RestClient(options.HttpClient, RestClientOptions);
 
             Configuration = new Configuration
             {


### PR DESCRIPTION
If you create an HttpClient object each time, the server creates many TCP connections. Therefore, the HttpClient object needs to be reused to reduce the creation of TCP connections.