### PR TITLE
chore: change target framework monikers from `netcoreapp` to `net`

### DIFF
--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp5.0;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <NetCore5PlusFrameworks>|netcoreapp5.0|netcoreapp6.0|</NetCore5PlusFrameworks>
+        <NetCore5PlusFrameworks>|net5.0|net6.0|</NetCore5PlusFrameworks>
     </PropertyGroup>
 
     <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp5.0;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -21,7 +21,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <NetCore5PlusFrameworks>|netcoreapp5.0|netcoreapp6.0|</NetCore5PlusFrameworks>
+        <NetCore5PlusFrameworks>|net5.0|net6.0|</NetCore5PlusFrameworks>
     </PropertyGroup>
 
     <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp5.0;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -23,7 +23,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <NetCore5PlusFrameworks>|netcoreapp5.0|netcoreapp6.0|</NetCore5PlusFrameworks>
+        <NetCore5PlusFrameworks>|net5.0|net6.0|</NetCore5PlusFrameworks>
     </PropertyGroup>
 
     <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp5.0;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -24,7 +24,7 @@
     </ItemGroup>
 
     <PropertyGroup>
-        <NetCore5PlusFrameworks>|netcoreapp5.0|netcoreapp6.0|</NetCore5PlusFrameworks>
+        <NetCore5PlusFrameworks>|net5.0|net6.0|</NetCore5PlusFrameworks>
     </PropertyGroup>
 
     <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>netcoreapp3.1;netcoreapp5.0;netcoreapp6.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
         <LangVersion>8</LangVersion>
         <VersionPrefix>4.9.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>


### PR DESCRIPTION
Closes #427

## Proposed Changes

This PR changed the `TargetFrameworks` to `netX.Y`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
