### PR TITLE
feat: allow to use `DateTimeKind.Local` and `DateTimeKind.Local` as a timestamp for data point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.10.0 [unreleased]
 
+### Bug Fixes
+1. [#442](https://github.com/influxdata/influxdb-client-csharp/pull/442): Allow to use `DateTimeKind.Local` and `DateTimeKind.Local` as a timestamp for Data point
+
 ### Dependencies
 Update dependencies:
 

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -290,15 +290,37 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
-        public void DateTimeUtc()
+        public void DateTimeUnspecified()
         {
-            var dateTime = new DateTime(2015, 10, 15, 8, 20, 15);
+            var dateTime = new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Unspecified);
 
             var point = PointData.Measurement("h2o")
                 .Tag("location", "europe")
-                .Field("level", 2);
+                .Field("level", 2)
+                .Timestamp(dateTime, WritePrecision.Ms);
 
-            Assert.Throws<ArgumentException>(() => point.Timestamp(dateTime, WritePrecision.Ms));
+            Assert.AreEqual("h2o,location=europe level=2i 1444897215000", point.ToLineProtocol());
+        }
+
+        [Test]
+        public void DateTimeLocal()
+        {
+            var dateTime = new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Local);
+
+            var point = PointData.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("level", 2)
+                .Timestamp(dateTime, WritePrecision.Ms);
+
+            var lineProtocolLocal = point.ToLineProtocol();
+
+            point = PointData.Measurement("h2o")
+                .Tag("location", "europe")
+                .Field("level", 2)
+                .Timestamp(TimeZoneInfo.ConvertTimeToUtc(dateTime), WritePrecision.Ms);
+            var lineProtocolUtc = point.ToLineProtocol();
+
+            Assert.AreEqual(lineProtocolUtc, lineProtocolLocal);
         }
 
         [Test]

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -605,14 +605,15 @@ namespace InfluxDB.Client.Test
     public class SimpleModel
     {
         private int _value;
-        
+
         [Column(IsTimestamp = true)] public DateTime Time { get; set; }
 
         [Column("device", IsTag = true)] public string Device { get; set; }
 
-        [Column("value")] public int Value
+        [Column("value")]
+        public int Value
         {
-            get => _value == -1 ? throw new ArgumentException("Something is wrong"): _value;
+            get => _value == -1 ? throw new ArgumentException("Something is wrong") : _value;
             set => _value = value;
         }
     }

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -494,14 +494,14 @@ namespace InfluxDB.Client.Test
             {
                 Time = new DateTime(2020, 11, 15, 8, 20, 15),
                 Device = "id-1",
-                Value = 15
+                Value = -1
             };
             _writeApi.WriteMeasurement(measurement, WritePrecision.S, "b1", "org1");
 
             var error = listener.Get<WriteRuntimeExceptionEvent>();
 
             Assert.IsNotNull(error);
-            StringAssert.StartsWith("Timestamps must be specified as UTC", error.Exception.Message);
+            StringAssert.StartsWith("Something is wrong", error.Exception.InnerException?.Message);
 
             Assert.AreEqual(0, MockServer.LogEntries.Count());
         }
@@ -604,10 +604,16 @@ namespace InfluxDB.Client.Test
     [Measurement("m")]
     public class SimpleModel
     {
+        private int _value;
+        
         [Column(IsTimestamp = true)] public DateTime Time { get; set; }
 
         [Column("device", IsTag = true)] public string Device { get; set; }
 
-        [Column("value")] public int Value { get; set; }
+        [Column("value")] public int Value
+        {
+            get => _value == -1 ? throw new ArgumentException("Something is wrong"): _value;
+            set => _value = value;
+        }
     }
 }

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -259,11 +259,6 @@ namespace InfluxDB.Client.Writes
                 var _ => timestamp
             };
 
-            if (utcTimestamp.Kind != DateTimeKind.Utc)
-            {
-                throw new ArgumentException("Timestamps must be specified as UTC", nameof(timestamp));
-            }
-
             var timeSpan = utcTimestamp.Subtract(EpochStart);
 
             return Timestamp(timeSpan, timeUnit);

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -252,12 +252,19 @@ namespace InfluxDB.Client.Writes
         /// <returns></returns>
         public PointData Timestamp(DateTime timestamp, WritePrecision timeUnit)
         {
-            if (timestamp != null && timestamp.Kind != DateTimeKind.Utc)
+            var utcTimestamp = timestamp.Kind switch
+            {
+                DateTimeKind.Local => timestamp.ToUniversalTime(),
+                DateTimeKind.Unspecified => DateTime.SpecifyKind(timestamp, DateTimeKind.Utc),
+                var _ => timestamp
+            };
+
+            if (utcTimestamp.Kind != DateTimeKind.Utc)
             {
                 throw new ArgumentException("Timestamps must be specified as UTC", nameof(timestamp));
             }
 
-            var timeSpan = timestamp.Subtract(EpochStart);
+            var timeSpan = utcTimestamp.Subtract(EpochStart);
 
             return Timestamp(timeSpan, timeUnit);
         }


### PR DESCRIPTION
Closes #441

## Proposed Changes

This PR allows to use `new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Local);` or `new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Unspecified)` as a timestamp for `PointData`:

```c#
var dateTime = new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Unspecified);

var point = PointData.Measurement("h2o")
    .Tag("location", "europe")
    .Field("level", 2)
    .Timestamp(new DateTime(2015, 10, 15, 8, 20, 15, DateTimeKind.Unspecified), WritePrecision.Ms);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
