### PR TITLE
Revert "fix: use g17 format for doubles (#434)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.11.0 [unreleased]
 
+### Bug Fixes
+  - Revert [#408] conversion of double to string can result in a loss of precision
+
 ## 4.10.0 [2023-01-26]
 
 ### Bug Fixes

--- a/Client.Test/MeasurementMapperTest.cs
+++ b/Client.Test/MeasurementMapperTest.cs
@@ -57,8 +57,7 @@ namespace InfluxDB.Client.Test
 
             var lineProtocol = _mapper.ToPoint(poco, WritePrecision.S).ToLineProtocol();
 
-            Assert.AreEqual(
-                "poco,tag=tag\\ val value=15.444000000000001,ValueWithEmptyName=25,ValueWithoutDefaultName=20i 864000",
+            Assert.AreEqual("poco,tag=tag\\ val value=15.444,ValueWithEmptyName=25,ValueWithoutDefaultName=20i 864000",
                 lineProtocol);
         }
 
@@ -112,8 +111,7 @@ namespace InfluxDB.Client.Test
 
             var lineProtocol = _mapper.ToPoint(poco, WritePrecision.S).ToLineProtocol();
 
-            Assert.AreEqual(
-                "poco,tag=tag\\ val value=15.444000000000001,ValueWithEmptyName=25,ValueWithoutDefaultName=20i 864000",
+            Assert.AreEqual("poco,tag=tag\\ val value=15.444,ValueWithEmptyName=25,ValueWithoutDefaultName=20i 864000",
                 lineProtocol);
         }
 

--- a/Client.Test/PointDataTest.cs
+++ b/Client.Test/PointDataTest.cs
@@ -149,24 +149,7 @@ namespace InfluxDB.Client.Test
 
             var expected =
                 "h2o,location=europe boolean=false,byte=9i,decimal=25.6,double=250.69,float=35,integer=7i,long=1i," +
-                "point=13.300000000000001,sbyte=12i,short=8i,string=\"string value\",uint=11u,ulong=10u,ushort=13u";
-
-            Assert.AreEqual(expected, point.ToLineProtocol());
-        }
-
-        [Test]
-        public void DoubleFormat()
-        {
-            var point = PointData.Measurement("sensor")
-                .Field("double", 250.69D)
-                .Field("double15", 15.333333333333333D)
-                .Field("double16", 16.3333333333333333D)
-                .Field("double17", 17.33333333333333333D)
-                .Field("example", 459.29587181322927);
-
-            var expected =
-                "sensor double=250.69,double15=15.333333333333332,double16=16.333333333333332," +
-                "double17=17.333333333333332,example=459.29587181322927";
+                "point=13.3,sbyte=12i,short=8i,string=\"string value\",uint=11u,ulong=10u,ushort=13u";
 
             Assert.AreEqual(expected, point.ToLineProtocol());
         }

--- a/Client/Writes/PointData.cs
+++ b/Client/Writes/PointData.cs
@@ -472,14 +472,9 @@ namespace InfluxDB.Client.Writes
                 EscapeKey(sb, key);
                 sb.Append('=');
 
-                if (value is float)
+                if (value is double || value is float)
                 {
                     sb.Append(((IConvertible)value).ToString(CultureInfo.InvariantCulture));
-                }
-                else if (value is double)
-                {
-                    var valueStr = ((double)value).ToString("G17", CultureInfo.InvariantCulture);
-                    sb.Append((IConvertible)valueStr);
                 }
                 else if (value is uint || value is ulong || value is ushort)
                 {


### PR DESCRIPTION
This reverts commit c4b64ae35966c688042f80eb1992ff63f63168c6.