### PR TITLE
feat: Added support for custom request headers - as defined in RFC 2616 - passed by the InfluxDBClient to its (internal) RestClient.

### DIFF
--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -58,7 +59,7 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = new RestClient(RestClientOptions);
+            RestClient = new RestClient(RestClientOptions, options.ConfigureDefaultHeadersAction);
             Configuration = new Configuration
             {
                 ApiClient = this,


### PR DESCRIPTION
## Proposed Changes

Added support for custom request headers - as defined in RFC 2616 - passed by the InfluxDBClient to its (internal) RestClient. This is useful for example if you need to force specific security-related headers if your InfluxDB instance is behind an API management component.

## Checklist

- [X] A test has been added if appropriate
- [ ] `dotnet test` completes successfully (don't have the test infrastructure with a local InfluxDB on 8086/9999)
- [X] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)


To give more insight about this change, the reason is that we had to pass our InfluxDB trafic through an Azure APIM. This requires additional headers (for subscription) that were impossible to inject with the original version.