### PR TITLE
chore: update RestSharp to `110.1.0`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,12 @@ jobs:
       - image: *default-dotnet-image
     steps:
       - checkout
+      - run: |
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Test/Client.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Linq.Test/Client.Linq.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Examples/Examples.csproj
       - run:
           name: Check compilation warnings
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Update dependencies:
   - [#497](https://github.com/influxdata/influxdb-client-csharp/pull/497): `NodaTime` to `3.1.9`
   - [#485](https://github.com/influxdata/influxdb-client-csharp/pull/485): `Newtonsoft.Json` to `13.0.3`
   - [#506](https://github.com/influxdata/influxdb-client-csharp/pull/506): `Microsoft.Extensions.ObjectPool` to `7.0.5`
+  - [#509](https://github.com/influxdata/influxdb-client-csharp/pull/509): `RestSharp` to `110.2.0`
 
 #### Examples:
   - [#511](https://github.com/influxdata/influxdb-client-csharp/pull/511): `Radzen.Blazor` to `4.10.1`

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.1.9" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.1" />
-      <PackageReference Include="RestSharp" Version="110.2.0" />
+      <PackageReference Include="RestSharp" Version="110.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -36,7 +36,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.1.9" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.0.1" />
-      <PackageReference Include="RestSharp" Version="108.0.3" />
+      <PackageReference Include="RestSharp" Version="110.2.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -188,7 +188,8 @@ namespace InfluxDB.Client.Core.Internal
         }
 
         protected async IAsyncEnumerable<T> QueryEnumerable<T>(
-            Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> queryFn, Func<FluxRecord, T> convert,
+            Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> queryFn,
+            Func<FluxRecord, T> convert,
             [EnumeratorCancellation] CancellationToken cancellationToken)
         {
             Arguments.CheckNotNull(queryFn, nameof(queryFn));
@@ -383,7 +384,8 @@ namespace InfluxDB.Client.Core.Internal
 
         private RestResponse FromHttpResponseMessage(HttpResponseMessage response, RestRequest request)
         {
-            return new RestResponse(request) {
+            return new RestResponse(request)
+            {
                 ErrorException = response.IsSuccessStatusCode
                     ? null
                     : new HttpRequestException($"Request failed with status code {response.StatusCode}")

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -28,7 +28,7 @@ namespace InfluxDB.Client.Core.Internal
         }
 
         internal static RestRequest AddAdvancedResponseHandler(this RestRequest restRequest,
-            Func<HttpResponseMessage, RestResponse> advancedResponseWriter)
+            Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
         {
             var field = restRequest.GetType()
                 .GetField("_advancedResponseHandler", BindingFlags.Instance | BindingFlags.NonPublic);

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -423,7 +423,7 @@ namespace InfluxDB.Client.Flux
             return new RestRequest("ping");
         }
 
-        private Func<Func<HttpResponseMessage, RestResponse>, RestRequest> QueryRequest(string query)
+        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> QueryRequest(string query)
         {
             return advancedResponseWriter => new RestRequest("api/v2/query", Method.Post)
                 .AddAdvancedResponseHandler(advancedResponseWriter)

--- a/Client.Test/WriteApiAsyncTest.cs
+++ b/Client.Test/WriteApiAsyncTest.cs
@@ -263,7 +263,8 @@ namespace InfluxDB.Client.Test
         {
             var bytes = (byte[])restResponse.Request?.Parameters
                             .GetParameters(ParameterType.RequestBody)
-                            .TryFind("text/plain")?.Value ??
+                            .First()
+                            .Value ??
                         throw new AssertionException("The body is required.");
             return Encoding.Default.GetString(bytes);
         }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -25,6 +25,8 @@ namespace InfluxDB.Client.Api.Client
 
         private bool _initializedSessionTokens = false;
         private bool _signout;
+        private IAuthenticator _authenticator;
+        private CookieContainer _cookieContainerCookieContainer;
 
         public ApiClient(InfluxDBClientOptions options, LoggingHandler loggingHandler, GzipHandler gzipHandler)
         {
@@ -91,6 +93,9 @@ namespace InfluxDB.Client.Api.Client
             {
                 InitToken();
             }
+            
+            request.CookieContainer = _cookieContainerCookieContainer;
+            request.Authenticator = _authenticator;
 
             _loggingHandler.BeforeIntercept(request);
             _gzipHandler.BeforeIntercept(request);
@@ -141,7 +146,12 @@ namespace InfluxDB.Client.Api.Client
                             .FirstOrDefault(it =>
                                 string.Equals("Set-Cookie", it.Name, StringComparison.OrdinalIgnoreCase));
 
-                        RestClient.Authenticator = new CookieRedirectAuthenticator(headerParameter);
+                        _authenticator = new CookieRedirectAuthenticator(headerParameter);
+                    }
+                    else
+                    {
+                        _cookieContainerCookieContainer = new CookieContainer();
+                        _cookieContainerCookieContainer.Add(authResponse.Cookies);
                     }
                 }
             }
@@ -159,10 +169,11 @@ namespace InfluxDB.Client.Api.Client
             _signout = true;
 
             _initializedSessionTokens = false;
+            _cookieContainerCookieContainer = null;
 
             var request = new RestRequest("/api/v2/signout", Method.Post);
             RestClient.ExecuteAsync(request).ConfigureAwait(false).GetAwaiter().GetResult();
-            RestClient.Authenticator = null;
+            _authenticator = null;
         }
     }
 

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -93,7 +93,7 @@ namespace InfluxDB.Client.Api.Client
             {
                 InitToken();
             }
-            
+
             request.CookieContainer = _cookieContainerCookieContainer;
             request.Authenticator = _authenticator;
 

--- a/Client/InvokableScriptsApi.cs
+++ b/Client/InvokableScriptsApi.cs
@@ -300,7 +300,7 @@ namespace InfluxDB.Client
                 cancellationToken);
         }
 
-        private Func<Func<HttpResponseMessage, RestResponse>, RestRequest> CreateRequest(string scriptId,
+        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(string scriptId,
             Dictionary<string, object> bindParams = default)
         {
             Arguments.CheckNonEmptyString(scriptId, nameof(scriptId));

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -783,7 +783,7 @@ namespace InfluxDB.Client
                 cancellationToken);
         }
 
-        private Func<Func<HttpResponseMessage, RestResponse>, RestRequest> CreateRequest(Query query, string org = null)
+        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(Query query, string org = null)
         {
             Arguments.CheckNotNull(query, nameof(query));
 

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -783,7 +783,8 @@ namespace InfluxDB.Client
                 cancellationToken);
         }
 
-        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(Query query, string org = null)
+        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(Query query,
+            string org = null)
         {
             Arguments.CheckNotNull(query, nameof(query));
 

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -136,7 +136,7 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(poco => { measurements.Add(poco); }, Mapper);
 
-            RestRequest QueryFn(Func<HttpResponseMessage, RestResponse> advancedResponseWriter)
+            RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
                     .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query)
@@ -188,7 +188,7 @@ namespace InfluxDB.Client
             var optionsOrg = org ?? _options.Org;
             Arguments.CheckNonEmptyString(optionsOrg, OrgArgumentValidation);
 
-            RestRequest QueryFn(Func<HttpResponseMessage, RestResponse> advancedResponseWriter)
+            RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
                     .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query)


### PR DESCRIPTION
Closes #494
Closes #501
Closes #504

## Proposed Changes

Updated RestSharp to `110.1.0`.

We cannot use  110.2.0 due the https://github.com/restsharp/RestSharp/issues/2072.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
