### PR TITLE
fix: Aggregation function in LINQ expressions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,12 @@ jobs:
       - image: *default-dotnet-image
     steps:
       - checkout
+      - run: |
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Core.Test/Client.Core.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Test/Client.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Legacy.Test/Client.Legacy.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Client.Linq.Test/Client.Linq.Test.csproj
+          sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks>/c\<TargetFramework>'net7.0'<\/TargetFramework>' Examples/Examples.csproj
       - run:
           name: Check compilation warnings
           command: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.12.0 [unreleased]
 
+### Bug Fixes
+- [#510](https://github.com/influxdata/influxdb-client-csharp/pull/510): Passing aggregation function to AggregateWindow for LINQ queries
+
 ### Dependencies
 Update dependencies:
 

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1038,7 +1038,7 @@ namespace Client.Linq.Test
             Assert.AreEqual("p5", fnAssignment?.Id.Name);
             Assert.AreEqual("mean", (fnAssignment.Init as Identifier)?.Name);
         }
-        
+
         [Test]
         public void AggregateWindowCustomFunction()
         {

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1038,6 +1038,22 @@ namespace Client.Linq.Test
             Assert.AreEqual("p5", fnAssignment?.Id.Name);
             Assert.AreEqual("mean", (fnAssignment.Init as Identifier)?.Name);
         }
+        
+        [Test]
+        public void AggregateWindowCustomFunction()
+        {
+            var query = from s in InfluxDBQueryable<Sensor>.Queryable("my-bucket", "my-org", _queryApi)
+                where s.Timestamp.AggregateWindow(TimeSpan.FromSeconds(20), TimeSpan.FromSeconds(40), "min")
+                where s.Value == 5
+                select s;
+
+            var visitor = BuildQueryVisitor(query);
+            var ast = visitor.BuildFluxAST();
+
+            var fnAssignment = ((OptionStatement)ast.Body[4]).Assignment as VariableAssignment;
+            Assert.AreEqual("p5", fnAssignment?.Id.Name);
+            Assert.AreEqual("min", (fnAssignment.Init as Identifier)?.Name);
+        }
 
         [Test]
         public void AggregateWindowFluxQuery()

--- a/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
+++ b/Client.Linq/Internal/QueryExpressionTreeVisitor.cs
@@ -180,7 +180,7 @@ namespace InfluxDB.Client.Linq.Internal
                 //
                 var fn = ((ConstantExpression)expression.Arguments[3]).Value as string;
                 Arguments.CheckNonEmptyString(fn, "fn");
-                var fnVariable = _context.Variables.AddNamedVariable(new Identifier("Identifier", "mean"));
+                var fnVariable = _context.Variables.AddNamedVariable(new Identifier("Identifier", fn));
 
                 _context.QueryAggregator.AddAggregateWindow(everyVariable, periodVariable, fnVariable);
 


### PR DESCRIPTION
Closes #461

## Proposed Changes

Fixed passing aggregation function to `AggregateWindow`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
