### PR TITLE
feat: add HttpClient as a part of InfluxDBClientOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
+## 4.13.0 [unreleased]
+
 ### Features
 1. [#528](https://github.com/influxdata/influxdb-client-csharp/pull/528): Add HttpClient as a part of InfluxDBClientOptions
-
-## 4.13.0 [unreleased]
 
 ### Dependencies
 Update dependencies:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Features
+1. [#528](https://github.com/influxdata/influxdb-client-csharp/pull/528): Add HttpClient as a part of InfluxDBClientOptions
+
 ## 4.10.0 [unreleased]
 
 ## 4.9.0 [2020-12-06]

--- a/Client.Test/ApiClientTest.cs
+++ b/Client.Test/ApiClientTest.cs
@@ -1,12 +1,9 @@
-using System;
-using System.Net;
-using System.Net.Http;
 using InfluxDB.Client.Api.Client;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Internal;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.DependencyInjection.Extensions;
 using NUnit.Framework;
+using System;
+using System.Net;
 
 namespace InfluxDB.Client.Test
 {
@@ -63,36 +60,6 @@ namespace InfluxDB.Client.Test
             _apiClient = new ApiClient(options, new LoggingHandler(LogLevel.Body), new GzipHandler());
 
             Assert.AreEqual(webProxy, _apiClient.RestClientOptions.Proxy);
-        }
-
-        [Test]
-        public void InjectHttpClient()
-        {
-            var webProxy = new WebProxy("my-proxy", 8088);
-
-            var options = new InfluxDBClientOptions("http://localhost:8086")
-            {
-                Token = "my-token",
-                WebProxy = webProxy
-            };
-            var services = new ServiceCollection();
-
-            services.AddHttpClient();
-
-            services.AddTransient(p =>
-            {
-                var client = p.GetService<HttpClient>();
-
-                options.HttpClient = client;
-
-                return new ApiClient(options, new LoggingHandler(LogLevel.Body), new GzipHandler());
-            });
-
-            var builder = services.BuildServiceProvider();
-
-            var apiClient = builder.GetRequiredService<ApiClient>();
-
-            Assert.NotNull(apiClient);
         }
     }
 }

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -564,9 +564,9 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
             {
                 var httpClientFactory = p.GetService<IHttpClientFactory>();
 
-                 options.HttpClient = httpClientFactory.CreateClient();
+                options.HttpClient = httpClientFactory.CreateClient();
 
-                 return new InfluxDBClient(options);
+                return new InfluxDBClient(options);
             });
             var builder = services.BuildServiceProvider();
             

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -569,13 +569,14 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
                 return new InfluxDBClient(options);
             });
             var builder = services.BuildServiceProvider();
-            
+
             _client = builder.GetRequiredService<InfluxDBClient>();
 
             var restClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient").RestClient;
 
-            Assert.AreEqual(options.HttpClient, 
-                GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField"));
+            var httpClient = GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField");
+
+            Assert.AreEqual(options.HttpClient, httpClient);
         }
 
         private static T GetDeclaredField<T>(IReflect type, object instance, string fieldName)

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -574,7 +574,8 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
 
             var restClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient").RestClient;
 
-            var httpClient = GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField");
+            var httpClient = 
+                GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField");
 
             Assert.AreEqual(options.HttpClient, httpClient);
         }

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -2,11 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Security.Cryptography.X509Certificates;
 using InfluxDB.Client.Api.Client;
 using InfluxDB.Client.Core;
 using InfluxDB.Client.Core.Exceptions;
+using Microsoft.Extensions.DependencyInjection;
 using NUnit.Framework;
 
 namespace InfluxDB.Client.Test
@@ -544,6 +547,33 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
             Assert.AreEqual(certificateCollection, apiClient.RestClientOptions.ClientCertificates);
+        }
+
+        [Test]
+        public void InjectHttpClient()
+        {
+            var options = new InfluxDBClientOptions("http://localhost:8086")
+            {
+                Token = "my-token"
+            };
+            var services = new ServiceCollection();
+
+            services.AddHttpClient();
+
+            services.AddTransient(p =>
+            {
+                 options.HttpClient = p.GetService<HttpClient>();
+
+                 return new InfluxDBClient(options);
+            });
+            var builder = services.BuildServiceProvider();
+            
+            _client = builder.GetRequiredService<InfluxDBClient>();
+
+            var restClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient").RestClient;
+
+            Assert.AreEqual(options.HttpClient,
+                GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField"));
         }
 
         private static T GetDeclaredField<T>(IReflect type, object instance, string fieldName)

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -562,7 +562,9 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
 
             services.AddTransient(p =>
             {
-                 options.HttpClient = p.GetService<HttpClient>();
+                var httpClientFactory = p.GetService<IHttpClientFactory>();
+
+                 options.HttpClient = httpClientFactory.CreateClient();
 
                  return new InfluxDBClient(options);
             });
@@ -572,7 +574,7 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
 
             var restClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient").RestClient;
 
-            Assert.AreEqual(options.HttpClient,
+            Assert.AreEqual(options.HttpClient, 
                 GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField"));
         }
 

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -556,28 +556,25 @@ AJvDAFTSr5A9GSjJ3OyIeKoI8Q6xuaQBitpZR90P/Ah/Ymg490rpXavk";
             {
                 Token = "my-token"
             };
+
             var services = new ServiceCollection();
 
             services.AddHttpClient();
-
             services.AddTransient(p =>
             {
                 var httpClientFactory = p.GetService<IHttpClientFactory>();
-
                 options.HttpClient = httpClientFactory.CreateClient();
-
                 return new InfluxDBClient(options);
             });
+
             var builder = services.BuildServiceProvider();
 
             _client = builder.GetRequiredService<InfluxDBClient>();
 
             var restClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient").RestClient;
 
-            var httpClient = 
-                GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField");
-
-            Assert.AreEqual(options.HttpClient, httpClient);
+            Assert.AreEqual(options.HttpClient,
+                GetDeclaredField<HttpClient>(restClient.GetType(), restClient, "<HttpClient>k__BackingField"));
         }
 
         private static T GetDeclaredField<T>(IReflect type, object instance, string fieldName)

--- a/Client/InfluxDBClientOptions.cs
+++ b/Client/InfluxDBClientOptions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.Net;
+using System.Net.Http;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
@@ -34,6 +35,7 @@ namespace InfluxDB.Client
         private bool _allowHttpRedirects;
         private bool _verifySsl;
         private X509CertificateCollection _clientCertificates;
+        private HttpClient _httpClient;
 
         /// <summary>
         /// Set the url to connect the InfluxDB.
@@ -252,6 +254,15 @@ namespace InfluxDB.Client
         }
 
         /// <summary>
+        /// Add a HttpClient as a part of InfluxDBClientOptions
+        /// </summary>
+        public HttpClient HttpClient
+        {
+            get => _httpClient;
+            set => _httpClient = value;
+        }
+
+        /// <summary>
         /// Create an instance of InfluxDBClientOptions. The url could be a connection string with various configurations.
         ///<para>
         /// e.g.: "http://localhost:8086?timeout=5000&amp;logLevel=BASIC
@@ -428,6 +439,11 @@ namespace InfluxDB.Client
             {
                 ClientCertificates = builder.CertificateCollection;
             }
+
+            if (builder.HttpClient != null)
+            {
+                HttpClient = builder.HttpClient;
+            }
         }
 
         private static TimeSpan ToTimeout(string value)
@@ -506,6 +522,7 @@ namespace InfluxDB.Client
             internal bool VerifySslCertificates = true;
             internal RemoteCertificateValidationCallback VerifySslCallback;
             internal X509CertificateCollection CertificateCollection;
+            internal HttpClient HttpClient;
 
             internal PointSettings PointSettings = new PointSettings();
 
@@ -827,6 +844,20 @@ namespace InfluxDB.Client
                 }
 
                 return new InfluxDBClientOptions(this);
+            }
+
+            /// <summary>
+            /// Configure HttpClient
+            /// </summary>
+            /// <param name="httpClient"></param>
+            /// <returns></returns>
+            public Builder SetHttpClient(HttpClient httpClient)
+            {
+                Arguments.CheckNotNull(httpClient, nameof(httpClient));
+
+                HttpClient = httpClient;
+
+                return this;
             }
         }
     }

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -58,7 +58,10 @@ namespace InfluxDB.Client.Api.Client
                 RestClientOptions.ClientCertificates.AddRange(options.ClientCertificates);
             }
 
-            RestClient = new RestClient(RestClientOptions);
+            RestClient = options.HttpClient == null
+                ? new RestClient(RestClientOptions)
+                : new RestClient(options.HttpClient, RestClientOptions);
+
             Configuration = new Configuration
             {
                 ApiClient = this,


### PR DESCRIPTION
Add httpclient as  a part of InfluxbOption to allow injection of custom HttpMessageHandler(https://github.com/influxdata/influxdb-client-csharp/issues/516).

_Briefly describe your proposed changes: 
  The caller can create a RestClient themselves through this constructor 'public RestClient(HttpClient httpClient, RestClientOptions options, bool disposeHttpClient = false)'. And this HttpClientMessageHandler instances will be managed by the dependency injection container.
  It is also recommended in Microsoft documentation to send HTTP requests by injecting an HTTP client instead of creating an HTTP client instance every time(https://learn.microsoft.com/en-us/aspnet/core/fundamentals/http-requests?view=aspnetcore-7.0).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
