### PR TITLE
feat: add support to filter by `Instant`, `ZonedDateTime`, `OffsetDateTime`, ... in LINQ

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,33 @@
 version: 2.1
 
 commands:
-  influxdb-onboarding:
-    steps:
-      - run:
-          name: "Post onBoarding request to InfluxDB 2"
-          command: ./Scripts/influxdb-onboarding.sh
   prepare:
     description: "Prepare environment to tests"
     steps:
       - checkout
       - influxdb-onboarding
+  
+  influxdb-onboarding:
+    steps:
+      - run:
+          name: "Post onBoarding request to InfluxDB 2"
+          command: ./Scripts/influxdb-onboarding.sh
+  
   client-test:
     parameters:
       code-coverage-report:
         type: boolean
         default: false
+      dotnet-runtime-versions:
+        type: string
+        default: ""
     steps:
       - run:
           name: "Running tests"
-          command: ./Scripts/ci-test.sh << parameters.code-coverage-report >>
+          command: ./Scripts/ci-test.sh --dotnet-runtime aspnetcore --dotnet-runtime-versions <<parameters.dotnet-runtime-versions>> <<#parameters.code-coverage-report>>--code-coverage-report<</parameters.code-coverage-report>>
       - run:
-          name: "Converting test results to Junit format"
-          when: on_fail
+          name: "Converting test results to JUnit format"
+          when: always
           command: ./trx2junit/trx2junit ./**/TestResults/*.trx
   
   storing-test-results:
@@ -61,10 +66,7 @@ jobs:
     parameters:
       dotnet-image:
         type: string
-        default: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:7.0"
-      dotnet-target-version:
-        type: string
-        default: "netstandard2.1"
+        default: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:8.0"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -73,8 +75,6 @@ jobs:
         default: false
     docker:
       - image: << parameters.dotnet-image >>
-        environment:
-          NET_TARGET_VERSION: << parameters.dotnet-target-version >>
       - image: &influx-image << parameters.influxdb-image >>
         environment:
           INFLUXD_HTTP_BIND_ADDRESS: :9999
@@ -91,6 +91,7 @@ jobs:
     steps:
       - prepare
       - client-test:
+          dotnet-runtime-versions: "3.1,5.0,6.0,7.0" # Additional runtime versions to install
           code-coverage-report: << parameters.code-coverage-report >>
       - storing-test-results
       - storing-artifacts
@@ -166,7 +167,7 @@ jobs:
       - restore_cache:
           name: Restoring reSharper Cache
           keys:
-              - &cache-key reSharper-cache-2022_1_0
+            - &cache-key reSharper-cache-2022_1_0
       - run:
           name: Check code formatting
           command: |
@@ -176,7 +177,7 @@ jobs:
             name: Saving reSharper Cache
             key: *cache-key
             paths:
-                - ./reSharperCLI
+              - ./reSharperCLI
   
   deploy-preview:
     parameters:
@@ -208,37 +209,24 @@ workflows:
       - check-compilation-warnings
       - check-code-formatting
       - tests-dotnet:
-          name: dotnet-3.1-nightly
-          influxdb-image: "quay.io/influxdb/influxdb:nightly"
-          dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.1"
-      - tests-dotnet:
-          name: dotnet-3.1
-          dotnet-image: "mcr.microsoft.com/dotnet/core/sdk:3.1"
-      - tests-dotnet:
-          name: dotnet-5.0
+          name: dotnet-docker
           code-coverage-report: true
-          dotnet-image: "mcr.microsoft.com/dotnet/sdk:5.0"
       - tests-dotnet:
-          name: dotnet-6.0
-          dotnet-image: "mcr.microsoft.com/dotnet/sdk:6.0"
-      - tests-dotnet:
-          name: dotnet-7.0
+          name: dotnet-docker-nightly
+          influxdb-image: "quay.io/influxdb/influxdb:nightly"
       - tests-windows:
           name: dotnet-windows
       - deploy-preview:
           requires:
             - check-compilation-warnings
             - check-code-formatting
-            - dotnet-3.1-nightly
-            - dotnet-3.1
-            - dotnet-5.0
-            - dotnet-6.0
-            - dotnet-7.0
+            - dotnet-docker
+            - dotnet-docker-nightly
             - dotnet-windows
           filters:
             branches:
               only: master
-
+  
   nightly:
     when:
       equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -13,6 +13,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NUnit" Version="3.13.3" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -21,17 +25,6 @@
 
     <ItemGroup>
         <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <NetCore5PlusFrameworks>|net5.0|net6.0|net7.0|</NetCore5PlusFrameworks>
-    </PropertyGroup>
-
-    <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Client.Core.Test/Client.Core.Test.csproj
+++ b/Client.Core.Test/Client.Core.Test.csproj
@@ -2,12 +2,12 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
         <AssemblyName>InfluxDB.Client.Core.Test</AssemblyName>
         <RootNamespace>InfluxDB.Client.Core.Test</RootNamespace>
-        
+
         <AssemblyOriginatorKeyFile>../Keys/Key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
@@ -20,7 +20,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
+        <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
 
         <Description>InfluxDB Client Core - exceptions, validations, REST client.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
@@ -32,11 +32,11 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="CsvHelper" Version="30.0.1" />
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-      <PackageReference Include="NodaTime" Version="3.1.10" />
-      <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="110.1.0" />
+        <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="NodaTime" Version="3.1.10" />
+        <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
+        <PackageReference Include="RestSharp" Version="110.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Flux/Domain/FluxRecord.cs
+++ b/Client.Core/Flux/Domain/FluxRecord.cs
@@ -62,7 +62,7 @@ namespace InfluxDB.Client.Core.Flux.Domain
         {
             var time = GetTime();
 
-            return time?.InUtc().ToDateTimeUtc() ?? default(DateTime);
+            return time?.ToDateTimeUtc() ?? default(DateTime);
         }
 
         /// <returns>the value of the record</returns>

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -11,6 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
     </ItemGroup>
@@ -18,17 +22,6 @@
     <ItemGroup>
         <ProjectReference Include="..\Client.Legacy\Client.Legacy.csproj" />
         <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <NetCore5PlusFrameworks>|net5.0|net6.0|net7.0|</NetCore5PlusFrameworks>
-    </PropertyGroup>
-
-    <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Client.Legacy.Test/Client.Legacy.Test.csproj
+++ b/Client.Legacy.Test/Client.Legacy.Test.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
-        
+
         <AssemblyOriginatorKeyFile>../Keys/Key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
@@ -16,8 +16,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Legacy\Client.Legacy.csproj" />
-      <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
+        <ProjectReference Include="..\Client.Legacy\Client.Legacy.csproj" />
+        <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -1,9 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <LangVersion>12.0</LangVersion>
 
-      <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
+        <Description>The client that allow perform Flux Query against the InfluxDB 1.7+.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Flux</AssemblyName>
         <VersionPrefix>4.15.0</VersionPrefix>

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -11,6 +11,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -20,17 +24,6 @@
     <ItemGroup>
         <ProjectReference Include="..\Client.Linq\Client.Linq.csproj" />
         <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <NetCore5PlusFrameworks>|net5.0|net6.0|net7.0|</NetCore5PlusFrameworks>
-    </PropertyGroup>
-
-    <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Client.Linq.Test/Client.Linq.Test.csproj
+++ b/Client.Linq.Test/Client.Linq.Test.csproj
@@ -2,10 +2,10 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
-        
+
         <AssemblyOriginatorKeyFile>../Keys/Key.snk</AssemblyOriginatorKeyFile>
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
@@ -18,8 +18,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Linq\Client.Linq.csproj" />
-      <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
+        <ProjectReference Include="..\Client.Linq\Client.Linq.csproj" />
+        <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
     <PropertyGroup>
@@ -32,5 +32,5 @@
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
     </ItemGroup>
-    
+
 </Project>

--- a/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
+++ b/Client.Linq.Test/InfluxDBQueryVisitorTest.cs
@@ -1026,13 +1026,13 @@ namespace Client.Linq.Test
 
             var everyAssignment = ((OptionStatement)ast.Body[2]).Assignment as VariableAssignment;
             Assert.AreEqual("p3", everyAssignment?.Id.Name);
-            Assert.AreEqual(20000000, (everyAssignment.Init as DurationLiteral)?.Values[0].Magnitude);
-            Assert.AreEqual("us", (everyAssignment.Init as DurationLiteral)?.Values[0].Unit);
+            Assert.AreEqual(20_000_000_000, (everyAssignment.Init as DurationLiteral)?.Values[0].Magnitude);
+            Assert.AreEqual("ns", (everyAssignment.Init as DurationLiteral)?.Values[0].Unit);
 
             var periodAssignment = ((OptionStatement)ast.Body[3]).Assignment as VariableAssignment;
             Assert.AreEqual("p4", periodAssignment?.Id.Name);
-            Assert.AreEqual(40000000, (periodAssignment.Init as DurationLiteral)?.Values[0].Magnitude);
-            Assert.AreEqual("us", (periodAssignment.Init as DurationLiteral)?.Values[0].Unit);
+            Assert.AreEqual(40_000_000_000, (periodAssignment.Init as DurationLiteral)?.Values[0].Magnitude);
+            Assert.AreEqual("ns", (periodAssignment.Init as DurationLiteral)?.Values[0].Unit);
 
             var fnAssignment = ((OptionStatement)ast.Body[4]).Assignment as VariableAssignment;
             Assert.AreEqual("p5", fnAssignment?.Id.Name);

--- a/Client.Linq.Test/VariableAggregatorTest.cs
+++ b/Client.Linq.Test/VariableAggregatorTest.cs
@@ -2,7 +2,10 @@ using System;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core.Test;
 using InfluxDB.Client.Linq.Internal;
+using NodaTime;
+using NodaTime.Text;
 using NUnit.Framework;
+using Duration = NodaTime.Duration;
 
 namespace Client.Linq.Test
 {
@@ -10,22 +13,45 @@ namespace Client.Linq.Test
     public class VariableAggregatorTest : AbstractTest
     {
         [Test]
-        public void TimeStamp()
+        public void DurationLiteral()
         {
-            var data = new[]
+            var data = new (object, long)[]
             {
                 (
+                    TimeSpan.FromTicks(1),
+                    100
+                ),
+                (
                     TimeSpan.FromMilliseconds(1),
-                    1000
+                    1_000_000
                 ),
                 (
                     TimeSpan.FromMilliseconds(-1),
-                    -1000
+                    -1_000_000
                 ),
                 (
                     TimeSpan.FromDays(2 * 365),
-                    63072000000000
-                )
+                    63_072_000_000_000_000
+                ),
+                (
+                    Duration.FromNanoseconds(3),
+                    3
+                ),
+                (
+                    Duration.FromHours(42) - Duration.FromMilliseconds(50),
+                    151_199_950_000_000
+                ),
+                (
+                    Period.FromNanoseconds(-5),
+                    -5
+                ),
+                (
+                    new PeriodBuilder
+                    {
+                        Weeks = 1, Hours = 2, Seconds = 30, Milliseconds = 3, Nanoseconds = 4
+                    }.Build(),
+                    612_030_003_000_004
+                ),
             };
 
             foreach (var (timeSpan, expected) in data)
@@ -38,6 +64,67 @@ namespace Client.Linq.Test
                         DurationLiteral)?.Values[0];
                 Assert.NotNull(duration);
                 Assert.AreEqual(expected, duration.Magnitude);
+                Assert.AreEqual("ns", duration.Unit);
+            }
+        }
+
+        [Test]
+        public void DateTimeLiteral()
+        {
+            var data = new (object, string)[]
+            {
+                (
+                    new DateTime(2024, 01, 02, 03, 04, 05, 06, DateTimeKind.Utc),
+                    "2024-01-02T03:04:05.006Z"
+                ),
+                (
+                    new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Local).AddTicks(678_912_3),
+                    new DateTime(2024, 01, 02, 03, 04, 05, DateTimeKind.Local).AddTicks(678_912_3)
+                        .ToUniversalTime().ToString("O")
+                ),
+                (
+                    new DateTimeOffset(2024, 01, 02, 03, 04, 05, 06, TimeSpan.FromHours(-5d)),
+                    "2024-01-02T08:04:05.006Z"
+                ),
+                (
+                    Instant.FromUtc(2024, 01, 02, 03, 04, 05).PlusNanoseconds(6),
+                    "2024-01-02T03:04:05.000000006Z"
+                ),
+                (
+                    new ZonedDateTime(
+                        Instant.FromUtc(2024, 01, 02, 03, 04, 05).PlusNanoseconds(6_007_008),
+                        DateTimeZone.ForOffset(Offset.FromHoursAndMinutes(-9, 30))),
+                    "2024-01-02T03:04:05.006007008Z"
+                ),
+                (
+                    OffsetDateTime.FromDateTimeOffset(new DateTimeOffset(2024, 01, 02, 05, 04, 05, TimeSpan.FromHours(2d)))
+                        .PlusNanoseconds(678_912_345),
+                    "2024-01-02T03:04:05.678912345Z"
+                ),
+                (
+                    new OffsetDate(new LocalDate(2024, 01, 02), Offset.FromHours(8)),
+                    "2024-01-01T16:00:00Z"
+                ),
+                (
+                    new LocalDateTime(2024, 01, 02, 03, 04, 05, 06),
+                    "2024-01-02T03:04:05.006Z"
+                ),
+                (
+                    new LocalDate(2024, 01, 02),
+                    "2024-01-02T00:00:00Z"
+                )
+            };
+
+            foreach (var (dateTime, expected) in data)
+            {
+                var aggregator = new VariableAggregator();
+                aggregator.AddNamedVariable(dateTime);
+
+                var instant =
+                    (((aggregator.GetStatements()[0] as OptionStatement)?.Assignment as VariableAssignment)?.Init as
+                        DateTimeLiteral)?.ValueInstant;
+                Assert.NotNull(instant);
+                Assert.AreEqual(expected, InstantPattern.ExtendedIso.Format(instant.Value));
             }
         }
     }

--- a/Client.Linq/Client.Linq.csproj
+++ b/Client.Linq/Client.Linq.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
 
         <Description>The library supports querying InfluxDB 2.x by LINQ expressions.</Description>

--- a/Client.Linq/Client.Linq.csproj
+++ b/Client.Linq/Client.Linq.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-      <LangVersion>8</LangVersion>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <LangVersion>12.0</LangVersion>
 
-      <Description>The library supports querying InfluxDB 2.x by LINQ expressions.</Description>
+        <Description>The library supports querying InfluxDB 2.x by LINQ expressions.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client.Linq</AssemblyName>
         <VersionPrefix>4.15.0</VersionPrefix>
@@ -35,7 +35,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Remotion.Linq" Version="2.2.0" />
+        <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Linq/Internal/VariableAggregator.cs
+++ b/Client.Linq/Internal/VariableAggregator.cs
@@ -76,7 +76,11 @@ namespace InfluxDB.Client.Linq.Internal
                         .Select(o => CreateExpression(new NamedVariable { Value = o, IsTag = variable.IsTag }))
                         .ToList()),
                 TimeSpan timeSpan => new DurationLiteral("DurationLiteral",
-                    [new Api.Domain.Duration("Duration", (long)(1000.0 * timeSpan.TotalMilliseconds), "us")]),
+                    [new Api.Domain.Duration("Duration", timeSpan.Ticks * 100L, "ns")]),
+                NodaTime.Duration d => new DurationLiteral("DurationLiteral",
+                    [new Api.Domain.Duration("Duration", d.ToInt64Nanoseconds(), "ns")]),
+                Period p => new DurationLiteral("DurationLiteral",
+                    [new Api.Domain.Duration("Duration", p.ToDuration().ToInt64Nanoseconds(), "ns")]),
                 Expression e => e,
                 _ => CreateStringLiteral(variable)
             };

--- a/Client.Linq/Internal/VariableAggregator.cs
+++ b/Client.Linq/Internal/VariableAggregator.cs
@@ -55,21 +55,18 @@ namespace InfluxDB.Client.Linq.Internal
 
             return variable.Value switch
             {
-                int i => new IntegerLiteral("IntegerLiteral", Convert.ToString(i)),
-                long l => new IntegerLiteral("IntegerLiteral", Convert.ToString(l)),
                 bool b => new BooleanLiteral("BooleanLiteral", b),
-                double d => new FloatLiteral("FloatLiteral", Convert.ToDecimal(d)),
-                float f => new FloatLiteral("FloatLiteral", Convert.ToDecimal(f)),
+                sbyte or short or int or long => new IntegerLiteral("IntegerLiteral", Convert.ToString(variable.Value)),
+                byte or ushort or uint or ulong => new UnsignedIntegerLiteral("UnsignedIntegerLiteral", Convert.ToString(variable.Value)),
+                float or double or decimal => new FloatLiteral("FloatLiteral", Convert.ToDecimal(variable.Value)),
                 DateTime d => new DateTimeLiteral("DateTimeLiteral", d),
                 DateTimeOffset o => new DateTimeLiteral("DateTimeLiteral", o.UtcDateTime),
                 IEnumerable e => new ArrayExpression("ArrayExpression",
                     e.Cast<object>()
                         .Select(o => CreateExpression(new NamedVariable { Value = o, IsTag = variable.IsTag }))
                         .ToList()),
-                TimeSpan timeSpan => new DurationLiteral("DurationLiteral", new List<Duration>
-                {
-                    new Duration("Duration", (long)(1000.0 * timeSpan.TotalMilliseconds), "us")
-                }),
+                TimeSpan timeSpan => new DurationLiteral("DurationLiteral",
+                    [new Duration("Duration", (long)(1000.0 * timeSpan.TotalMilliseconds), "us")]),
                 Expression e => e,
                 _ => CreateStringLiteral(variable)
             };

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
         <RootNamespace>InfluxDB.Client.Test</RootNamespace>
@@ -19,8 +19,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client\Client.csproj" />
-      <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
+        <ProjectReference Include="..\Client\Client.csproj" />
+        <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
+        <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0;net8.0</TargetFrameworks>
         <LangVersion>12.0</LangVersion>
 
         <IsPackable>false</IsPackable>
@@ -12,6 +12,10 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
@@ -21,17 +25,6 @@
     <ItemGroup>
         <ProjectReference Include="..\Client\Client.csproj" />
         <ProjectReference Include="..\Client.Core.Test\Client.Core.Test.csproj" />
-    </ItemGroup>
-
-    <PropertyGroup>
-        <NetCore5PlusFrameworks>|net5.0|net6.0|net7.0|</NetCore5PlusFrameworks>
-    </PropertyGroup>
-
-    <ItemGroup Condition="$(NetCore5PlusFrameworks.Contains('|$(TargetFramework)|'))">
-        <PackageReference Include="coverlet.collector" Version="6.0.0">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
     </ItemGroup>
 
 </Project>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -1,10 +1,10 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-      <LangVersion>8</LangVersion>
+        <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+        <LangVersion>12.0</LangVersion>
 
-      <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.x.</Description>
+        <Description>The reference client that allows query, write and management (bucket, organization, users) for the InfluxDB 2.x.</Description>
         <Authors>influxdb-client-csharp Contributors</Authors>
         <AssemblyName>InfluxDB.Client</AssemblyName>
         <VersionPrefix>4.15.0</VersionPrefix>

--- a/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
@@ -57,7 +57,7 @@ namespace InfluxDB.Client.Api.Domain
         public DateTime? Value
         {
             get => ValueInstant?.ToDateTimeUtc();
-            set => ValueInstant = value.HasValue ? Instant.FromDateTimeUtc(value.Value.ToUniversalTime()) : (Instant?)null;
+            set => ValueInstant = value.HasValue ? Instant.FromDateTimeUtc(value.Value.ToUniversalTime()) : null;
         }
 
         /// <summary>

--- a/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
+++ b/Client/InfluxDB.Client.Api/Domain/DateTimeLiteral.cs
@@ -9,31 +9,24 @@
  */
 
 using System;
-using System.Linq;
-using System.IO;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Runtime.Serialization;
+using System.Text;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using OpenAPIDateConverter = InfluxDB.Client.Api.Client.OpenAPIDateConverter;
+using NodaTime;
 
 namespace InfluxDB.Client.Api.Domain
 {
     /// <summary>
-    /// Represents an instant in time with nanosecond precision using the syntax of golang&#39;s RFC3339 Nanosecond variant
+    /// Represents an instant in time with nanosecond precision using the syntax of golang&#39;s RFC3339 Nanosecond variant.
     /// </summary>
     [DataContract]
     public partial class DateTimeLiteral : Expression, IEquatable<DateTimeLiteral>
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="DateTimeLiteral" /> class.
+        /// Initializes a new instance of the <see cref="DateTimeLiteral" /> class with <see cref="DateTime"/>&#39;s ticks precision.
         /// </summary>
         /// <param name="type">Type of AST node.</param>
-        /// <param name="value">value.</param>
+        /// <param name="value"><see cref="DateTime"/> value.</param>
         public DateTimeLiteral(string type = default, DateTime? value = default) : base()
         {
             Type = type;
@@ -41,17 +34,37 @@ namespace InfluxDB.Client.Api.Domain
         }
 
         /// <summary>
-        /// Type of AST node
+        /// Initializes a new instance of the <see cref="DateTimeLiteral" /> class with nanosecond precision.
         /// </summary>
-        /// <value>Type of AST node</value>
+        /// <param name="type">Type of AST node.</param>
+        /// <param name="value"><see cref="Instant"/> value.</param>
+        public DateTimeLiteral(string type = default, Instant? value = default) : base()
+        {
+            Type = type;
+            ValueInstant = value;
+        }
+
+        /// <summary>
+        /// Type of AST node.
+        /// </summary>
+        /// <value>Type of AST node.</value>
         [DataMember(Name = "type", EmitDefaultValue = false)]
         public string Type { get; set; }
 
         /// <summary>
-        /// Gets or Sets Value
+        /// Gets or sets the value as a <see cref="DateTime"/>.
+        /// </summary>
+        public DateTime? Value
+        {
+            get => ValueInstant?.ToDateTimeUtc();
+            set => ValueInstant = value.HasValue ? Instant.FromDateTimeUtc(value.Value.ToUniversalTime()) : (Instant?)null;
+        }
+
+        /// <summary>
+        /// Gets or sets the value as an <see cref="Instant"/>.
         /// </summary>
         [DataMember(Name = "value", EmitDefaultValue = false)]
-        public DateTime? Value { get; set; }
+        public Instant? ValueInstant { get; set; }
 
         /// <summary>
         /// Returns the string presentation of the object
@@ -105,8 +118,8 @@ namespace InfluxDB.Client.Api.Domain
                        Type != null && Type.Equals(input.Type)
                    ) && base.Equals(input) &&
                    (
-                       Value == input.Value ||
-                       Value != null && Value.Equals(input.Value)
+                       ValueInstant == input.ValueInstant ||
+                       ValueInstant != null && ValueInstant.Equals(input.ValueInstant)
                    );
         }
 
@@ -125,9 +138,9 @@ namespace InfluxDB.Client.Api.Domain
                     hashCode = hashCode * 59 + Type.GetHashCode();
                 }
 
-                if (Value != null)
+                if (ValueInstant != null)
                 {
-                    hashCode = hashCode * 59 + Value.GetHashCode();
+                    hashCode = hashCode * 59 + ValueInstant.GetHashCode();
                 }
 
                 return hashCode;

--- a/Examples/ExampleBlazor/ExampleBlazor.csproj
+++ b/Examples/ExampleBlazor/ExampleBlazor.csproj
@@ -2,6 +2,7 @@
 
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>12.0</LangVersion>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
@@ -13,7 +14,7 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Folder Include="..\wwwroot\assets\Readme" />
+        <Folder Include="..\wwwroot\assets\Readme" />
     </ItemGroup>
 
 </Project>

--- a/Examples/Examples.csproj
+++ b/Examples/Examples.csproj
@@ -3,7 +3,7 @@
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0</TargetFrameworks>
-        <LangVersion>8</LangVersion>
+        <LangVersion>12.0</LangVersion>
         <VersionPrefix>4.15.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
         <IsPackable>false</IsPackable>
@@ -14,9 +14,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Client.Legacy\Client.Legacy.csproj" />
-      <ProjectReference Include="..\Client.Linq\Client.Linq.csproj" />
-      <ProjectReference Include="..\Client\Client.csproj" />
+        <ProjectReference Include="..\Client.Legacy\Client.Legacy.csproj" />
+        <ProjectReference Include="..\Client.Linq\Client.Linq.csproj" />
+        <ProjectReference Include="..\Client\Client.csproj" />
         <Content Remove="ExampleBlazor\**" />
         <Compile Remove="ExampleBlazor\**" />
         <EmbeddedResource Remove="ExampleBlazor\**" />

--- a/Scripts/ci-deploy-snapshot.sh
+++ b/Scripts/ci-deploy-snapshot.sh
@@ -3,7 +3,7 @@
 set -e
 
 #
-# Nuget repository
+# NuGet repository
 #
 DEFAULT_BONITOO_NUGET_URL="https://apitea.com/nexus/service/local/nuget/bonitoo-nuget/"
 BONITOO_NUGET_URL="${BONITOO_NUGET_URL:-$DEFAULT_BONITOO_NUGET_URL}"

--- a/Scripts/ci-test.sh
+++ b/Scripts/ci-test.sh
@@ -29,7 +29,7 @@ sed -i '/<TargetFrameworks>netcoreapp3.1;net5.0;net6.0;net7.0<\/TargetFrameworks
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Core/Client.Core.csproj
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client/Client.csproj
 sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Legacy/Client.Legacy.csproj
-sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Linq/Client.Linq.csproj
+sed -i '/<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0<\/TargetFrameworks>/c\<TargetFramework>'"${NET_TARGET_VERSION}"'<\/TargetFramework>' Client.Linq/Client.Linq.csproj
 
 TRX2JUNIT_VERSION=""
 TEST_PARAMS=()


### PR DESCRIPTION
## Proposed Changes

### Features
- Add nanosecond precision support to the `DateTimeLiteral` AST type (thanks to NodaTime's `Instant`).
- Add support in LINQ queries for:
  - NodaTime's `Instant`, `ZonedDateTime`, `OffsetDateTime`, `OffsetDate`, `LocalDateTime` and `LocalDate`,
  - .NET 6+ `DateOnly` (adding `net6.0` to [InfluxDB.Client.Linq](https://www.nuget.org/packages/InfluxDB.Client.Linq)'s `TargetFrameworks`),
  - NodaTime's `Duration` and `Period`,
  - `Tick` precision for `TimeSpan` (only microsecond precision was supported),
  - Unsigned integers, `sbyte`, `short` and `decimal`.

### Refactor
- Use pattern matching when creating AST `Expression` (in `VariableAggregator.CreateExpression()`).
- Remove a useless function call for `DateTime` conversion (in `FluxRecord.GetTimeInDateTime()`).

### Tests
- Add tests to cover new supported types and adjust existing ones for `TimeSpan` precision.


## Checklist

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)