### PR TITLE
feat: Use IEnumerable in WriteApi to eliminate unnecessary memory allocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Update dependencies:
 ### Features
 
 1. [#590](https://github.com/influxdata/influxdb-client-csharp/pull/590): Allows disable Trace verbose messages
+2. [#606](https://github.com/influxdata/influxdb-client-csharp/pull/606): Use IEnumerable in WriteApi to eliminate unnescessary memmory allocations
 
 ### Dependencies
 Update dependencies:

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        void WriteRecords(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        void WriteRecords(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace InfluxDB.Client
         /// <param name="points">specifies the Data points to write into bucket</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        void WritePoints(List<PointData> points, string bucket = null, string org = null);
+        void WritePoints(IEnumerable<PointData> points, string bucket = null, string org = null);
 
         /// <summary>
         /// Write Data points into specified bucket.
@@ -98,7 +98,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        void WriteMeasurements<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        void WriteMeasurements<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null);
 
         /// <summary>
@@ -388,10 +388,10 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        public void WriteRecords(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        public void WriteRecords(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
-            records.ForEach(record => WriteRecord(record, precision, bucket, org));
+            foreach (var record in records) WriteRecord(record, precision, bucket, org); 
         }
 
         /// <summary>
@@ -430,7 +430,7 @@ namespace InfluxDB.Client
         /// <param name="points">specifies the Data points to write into bucket</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        public void WritePoints(List<PointData> points, string bucket = null, string org = null)
+        public void WritePoints(IEnumerable<PointData> points, string bucket = null, string org = null)
         {
             foreach (var point in points) WritePoint(point, bucket, org);
         }
@@ -443,7 +443,7 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         public void WritePoints(PointData[] points, string bucket = null, string org = null)
         {
-            WritePoints(points.ToList(), bucket, org);
+            WritePoints(points, bucket, org);
         }
 
         /// <summary>
@@ -475,7 +475,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public void WriteMeasurements<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        public void WriteMeasurements<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
             foreach (var measurement in measurements) WriteMeasurement(measurement, precision, bucket, org);
@@ -492,7 +492,7 @@ namespace InfluxDB.Client
         public void WriteMeasurements<TM>(TM[] measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
-            WriteMeasurements(measurements.ToList(), precision, bucket, org);
+            WriteMeasurements(measurements, precision, bucket, org);
         }
 
         /// <summary>


### PR DESCRIPTION
## Proposed Changes
Change WriteApi to use IEnumerable for collection arguments instead of List.
Change `WriteRecords(List<string> records)` to `WriteRecords(IEnumerable<string> records)`

Calling ToList on a collection will incur a memory allocation as the data is copied to the new list. Making the argument IEnumerable means ToList doesn't need to be called and so no extra memory allocation. 
Internally this will eliminate the unnecessary memory allocation in `WriteRecords(string[] record)` call to ToList, and client code also won't have to make the allocation if their data isn't already in a List## Checklist

## Checklist
<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [ ] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)