### PR TITLE
feat: Use IEnumerable in WriteApi to eliminate unnecessary memory all…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Update dependencies:
 ### Features
 
 1. [#590](https://github.com/influxdata/influxdb-client-csharp/pull/590): Allows disable Trace verbose messages
+2. [#606](https://github.com/influxdata/influxdb-client-csharp/pull/606): Use IEnumerable in WriteApi to eliminate unnescessary memmory allocations
 
 ### Dependencies
 Update dependencies:

--- a/Client/WriteApi.cs
+++ b/Client/WriteApi.cs
@@ -42,7 +42,7 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        void WriteRecords(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        void WriteRecords(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null);
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace InfluxDB.Client
         /// <param name="points">specifies the Data points to write into bucket</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        void WritePoints(List<PointData> points, string bucket = null, string org = null);
+        void WritePoints(IEnumerable<PointData> points, string bucket = null, string org = null);
 
         /// <summary>
         /// Write Data points into specified bucket.
@@ -98,7 +98,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        void WriteMeasurements<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        void WriteMeasurements<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null);
 
         /// <summary>
@@ -388,10 +388,10 @@ namespace InfluxDB.Client
         /// <param name="precision">specifies the precision for the unix timestamps within the body line-protocol; default Nanoseconds</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        public void WriteRecords(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        public void WriteRecords(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
-            records.ForEach(record => WriteRecord(record, precision, bucket, org));
+            foreach (var record in records) WriteRecord(record, precision, bucket, org); 
         }
 
         /// <summary>
@@ -430,7 +430,7 @@ namespace InfluxDB.Client
         /// <param name="points">specifies the Data points to write into bucket</param>
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
-        public void WritePoints(List<PointData> points, string bucket = null, string org = null)
+        public void WritePoints(IEnumerable<PointData> points, string bucket = null, string org = null)
         {
             foreach (var point in points) WritePoint(point, bucket, org);
         }
@@ -443,7 +443,7 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         public void WritePoints(PointData[] points, string bucket = null, string org = null)
         {
-            WritePoints(points.ToList(), bucket, org);
+            WritePoints(points.AsEnumerable(), bucket, org);
         }
 
         /// <summary>
@@ -475,7 +475,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public void WriteMeasurements<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        public void WriteMeasurements<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
             foreach (var measurement in measurements) WriteMeasurement(measurement, precision, bucket, org);
@@ -492,7 +492,7 @@ namespace InfluxDB.Client
         public void WriteMeasurements<TM>(TM[] measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null)
         {
-            WriteMeasurements(measurements.ToList(), precision, bucket, org);
+            WriteMeasurements(measurements.AsEnumerable(), precision, bucket, org);
         }
 
         /// <summary>

--- a/Client/WriteApiAsync.cs
+++ b/Client/WriteApiAsync.cs
@@ -34,7 +34,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
-        Task WriteRecordsAsync(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        Task WriteRecordsAsync(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -78,7 +78,7 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
-        Task WritePointsAsync(List<PointData> points, string bucket = null, string org = null,
+        Task WritePointsAsync(IEnumerable<PointData> points, string bucket = null, string org = null,
             CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -124,7 +124,7 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        Task WriteMeasurementsAsync<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        Task WriteMeasurementsAsync<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -200,11 +200,11 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
-        public Task WriteRecordsAsync(List<string> records, WritePrecision precision = WritePrecision.Ns,
+        public Task WriteRecordsAsync(IEnumerable<string> records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default)
         {
             var options = new BatchWriteOptions(bucket ?? _options.Bucket, org ?? _options.Org, precision);
-            var list = records.Select(record => new BatchWriteRecord(options, record)).ToList();
+            var list = records.Select(record => new BatchWriteRecord(options, record));
 
             return WriteData(options.OrganizationId, options.Bucket, precision, list, cancellationToken);
         }
@@ -220,7 +220,7 @@ namespace InfluxDB.Client
         public Task WriteRecordsAsync(string[] records, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default)
         {
-            return WriteRecordsAsync(records.ToList(), precision, bucket, org, cancellationToken);
+            return WriteRecordsAsync(records.AsEnumerable(), precision, bucket, org, cancellationToken);
         }
 
         /// <summary>
@@ -269,15 +269,14 @@ namespace InfluxDB.Client
         /// <param name="bucket">specifies the destination bucket for writes. If the bucket is not specified then is used config from <see cref="InfluxDBClientOptions.Bucket" />.</param>
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
-        public async Task WritePointsAsync(List<PointData> points, string bucket = null, string org = null,
+        public async Task WritePointsAsync(IEnumerable<PointData> points, string bucket = null, string org = null,
             CancellationToken cancellationToken = default)
         {
             foreach (var grouped in points.GroupBy(it => it.Precision))
             {
                 var options = new BatchWriteOptions(bucket ?? _options.Bucket, org ?? _options.Org, grouped.Key);
                 var groupedPoints = grouped
-                    .Select(it => new BatchWritePoint(options, _options, it))
-                    .ToList();
+                    .Select(it => new BatchWritePoint(options, _options, it));
 
                 await WriteData(options.OrganizationId, options.Bucket, grouped.Key, groupedPoints, cancellationToken)
                     .ConfigureAwait(false);
@@ -294,7 +293,7 @@ namespace InfluxDB.Client
         public Task WritePointsAsync(PointData[] points, string bucket = null, string org = null,
             CancellationToken cancellationToken = default)
         {
-            return WritePointsAsync(points.ToList(), bucket, org, cancellationToken);
+            return WritePointsAsync(points.AsEnumerable(), bucket, org, cancellationToken);
         }
 
         /// <summary>
@@ -353,7 +352,7 @@ namespace InfluxDB.Client
         /// <param name="org">specifies the destination organization for writes. If the org is not specified then is used config from <see cref="InfluxDBClientOptions.Org" />.</param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests</param>
         /// <typeparam name="TM">measurement type</typeparam>
-        public Task WriteMeasurementsAsync<TM>(List<TM> measurements, WritePrecision precision = WritePrecision.Ns,
+        public Task WriteMeasurementsAsync<TM>(IEnumerable<TM> measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default)
         {
             var list = new List<BatchWriteData>();
@@ -380,7 +379,7 @@ namespace InfluxDB.Client
         public Task WriteMeasurementsAsync<TM>(TM[] measurements, WritePrecision precision = WritePrecision.Ns,
             string bucket = null, string org = null, CancellationToken cancellationToken = default)
         {
-            return WriteMeasurementsAsync(measurements.ToList(), precision, bucket, org, cancellationToken);
+            return WriteMeasurementsAsync(measurements.AsEnumerable(), precision, bucket, org, cancellationToken);
         }
 
         /// <summary>
@@ -403,7 +402,6 @@ namespace InfluxDB.Client
 
             return WriteDataAsyncWithIRestResponse(batch, bucket, org, precision, cancellationToken);
         }
-
 
         private Task WriteData(string org, string bucket, WritePrecision precision, IEnumerable<BatchWriteData> data,
             CancellationToken cancellationToken)


### PR DESCRIPTION
Proposed Changes
Change WriteApi to use IEnumerable for collection arguments instead of List.
Change WriteRecords(List<string> records) to WriteRecords(IEnumerable<string> records)

Calling ToList on a collection will incur a memory allocation as the data is copied to the new list. Making the argument IEnumerable means ToList doesn't need to be called and so no extra memory allocation.
Internally this will eliminate the unnecessary memory allocation in WriteRecords(string[] record) call to ToList, and client code also won't have to make the allocation if their data isn't already in a List## Checklist

Checklist
 CHANGELOG.md updated
 Rebased/mergeable
 A test has been added if appropriate
 dotnet test completes successfully
 Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
 Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)