### PR TITLE
feat: specify http completion for async queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.15.0 [unreleased]
 
+### Bug Fixes
+1. [#632](https://github.com/influxdata/influxdb-client-csharp/pull/632): Use HttpCompletionOption.ResponseHeadersRead for streaming
+
 ### Dependencies
 Update dependencies:
 

--- a/Client/InfluxDB.Client.Api/Client/ApiClient.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiClient.cs
@@ -15,6 +15,7 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Text;
 using System.Threading;
@@ -115,9 +116,13 @@ namespace InfluxDB.Client.Api.Client
             string path, Method method, List<KeyValuePair<string, string>> queryParams, object postBody,
             Dictionary<string, string> headerParams, Dictionary<string, string> formParams,
             Dictionary<string, FileParameter> fileParams, Dictionary<string, string> pathParams,
-            string contentType)
+            string contentType, 
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
-            var request = new RestRequest(path, method);
+            var request = new RestRequest(path, method)
+            {
+                CompletionOption = httpCompletionOption
+            };
 
             // add path parameter, if any
             foreach (var param in pathParams)

--- a/Client/InfluxDB.Client.Api/Client/ApiClient.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiClient.cs
@@ -116,7 +116,7 @@ namespace InfluxDB.Client.Api.Client
             string path, Method method, List<KeyValuePair<string, string>> queryParams, object postBody,
             Dictionary<string, string> headerParams, Dictionary<string, string> formParams,
             Dictionary<string, FileParameter> fileParams, Dictionary<string, string> pathParams,
-            string contentType, 
+            string contentType,
             HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             var request = new RestRequest(path, method)

--- a/Client/InfluxDB.Client.Api/Service/QueryService.cs
+++ b/Client/InfluxDB.Client.Api/Service/QueryService.cs
@@ -12,6 +12,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Net.Http;
 using System.Threading;
 using RestSharp;
 using InfluxDB.Client.Api.Client;
@@ -1544,9 +1545,11 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="org">Specifies the name of the organization executing the query. Takes either the ID or Name. If both &#x60;orgID&#x60; and &#x60;org&#x60; are specified, &#x60;org&#x60; takes precedence. (optional)</param>
         /// <param name="orgID">Specifies the ID of the organization executing the query. If both &#x60;orgID&#x60; and &#x60;org&#x60; are specified, &#x60;org&#x60; takes precedence. (optional)</param>
         /// <param name="query">Flux query or specification to execute (optional)</param>
+        /// <param name="httpCompletionOption">Specify http completion to enable fully stream queries for async.</param>
         /// <returns>ApiResponse of string</returns>
         public RestRequest PostQueryWithRestRequest(string zapTraceSpan = null, string acceptEncoding = null,
-            string contentType = null, string org = null, string orgID = null, Query query = null)
+            string contentType = null, string org = null, string orgID = null, Query query = null, 
+            HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             var localVarPath = "/api/v2/query";
             var localVarPathParams = new Dictionary<string, string>();
@@ -1621,7 +1624,7 @@ namespace InfluxDB.Client.Api.Service
             return Configuration.ApiClient.PrepareRequest(localVarPath,
                 Method.Post, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams,
                 localVarFileParams,
-                localVarPathParams, localVarHttpContentType);
+                localVarPathParams, localVarHttpContentType, httpCompletionOption);
         }
 
         /// <summary>

--- a/Client/InfluxDB.Client.Api/Service/QueryService.cs
+++ b/Client/InfluxDB.Client.Api/Service/QueryService.cs
@@ -1548,7 +1548,7 @@ namespace InfluxDB.Client.Api.Service
         /// <param name="httpCompletionOption">Specify http completion to enable fully stream queries for async.</param>
         /// <returns>ApiResponse of string</returns>
         public RestRequest PostQueryWithRestRequest(string zapTraceSpan = null, string acceptEncoding = null,
-            string contentType = null, string org = null, string orgID = null, Query query = null, 
+            string contentType = null, string org = null, string orgID = null, Query query = null,
             HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             var localVarPath = "/api/v2/query";

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -139,7 +139,8 @@ namespace InfluxDB.Client
             RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query)
+                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, 
+                        HttpCompletionOption.ResponseHeadersRead)
                     .AddAdvancedResponseHandler(advancedResponseWriter);
             }
 
@@ -191,7 +192,7 @@ namespace InfluxDB.Client
             RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query)
+                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, HttpCompletionOption.ResponseHeadersRead)
                     .AddAdvancedResponseHandler(advancedResponseWriter);
             }
 

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -75,6 +75,10 @@ namespace InfluxDB.Client
 
     /// <summary>
     /// The synchronous version of QueryApi.
+    ///
+    /// The client uses <see cref="System.Net.Http.HttpClient"/> to send the request and parse responses to InfluxDB 2.0.
+    /// The `HttpClient` is supposed to use maximus size of the body to int.MaxValue. 
+    /// If you want to query large data, use <see cref="QueryApi.QueryAsync"/> method.
     /// </summary>
     public class QueryApiSync : AbstractQueryClient, IQueryApiSync
     {
@@ -139,7 +143,7 @@ namespace InfluxDB.Client
             RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, 
+                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
                         HttpCompletionOption.ResponseHeadersRead)
                     .AddAdvancedResponseHandler(advancedResponseWriter);
             }
@@ -192,7 +196,8 @@ namespace InfluxDB.Client
             RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
             {
                 return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, HttpCompletionOption.ResponseHeadersRead)
+                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
+                        HttpCompletionOption.ResponseHeadersRead)
                     .AddAdvancedResponseHandler(advancedResponseWriter);
             }
 


### PR DESCRIPTION
Closes #566

## Proposed Changes

Use `HttpCompletionOption.ResponseHeadersRead` for async queries for possibility to use large queries then 2GiB. For more info see related issue.

For more info see: https://www.stevejgordon.co.uk/using-httpcompletionoption-responseheadersread-to-improve-httpclient-performance-dotnet

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
