### PR TITLE
fix: package XML documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Check compilation warnings
           command: |
             dotnet clean --configuration Release
-            dotnet build --configuration Release -warnAsError -warnAsMessage:CS0618,CS1591,NETSDK1138
+            dotnet build --configuration Release -warnAsError -warnAsMessage:CS0419,CS0618,CS1591,CS1573,CS1574,NETSDK1138
       
   check-code-formatting:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -158,7 +158,7 @@ jobs:
           name: Check compilation warnings
           command: |
             dotnet clean --configuration Release
-            dotnet build --configuration Release -warnAsError -warnAsMessage:CS0618,NETSDK1138
+            dotnet build --configuration Release -warnAsError -warnAsMessage:CS0618,CS1591,NETSDK1138
       
   check-code-formatting:
     docker:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.16.0 [unreleased]
 
+#### Build:
+  - [#633](https://github.com/influxdata/influxdb-client-csharp/pull/633): Add package XML documentation.
+
 ## 4.15.0 [2024-05-17]
 
 ### Bug Fixes
@@ -11,7 +14,6 @@ Update dependencies:
 #### Build:
   - [#619](https://github.com/influxdata/influxdb-client-csharp/pull/619): `CsvHelper` to `31.0.2`
   - [#629](https://github.com/influxdata/influxdb-client-csharp/pull/629): `Microsoft.Extensions.ObjectPool` to `8.0.3`
-  - [#633](https://github.com/influxdata/influxdb-client-csharp/pull/633): Add package XML documentation.
 
 #### Test:
   - [#608](https://github.com/influxdata/influxdb-client-csharp/pull/608): `NUnit` to `3.14.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Update dependencies:
 #### Build:
   - [#619](https://github.com/influxdata/influxdb-client-csharp/pull/619): `CsvHelper` to `31.0.2`
   - [#629](https://github.com/influxdata/influxdb-client-csharp/pull/629): `Microsoft.Extensions.ObjectPool` to `8.0.3`
+  - [#633](https://github.com/influxdata/influxdb-client-csharp/pull/633): Add package XML documentation.
 
 #### Test:
   - [#608](https://github.com/influxdata/influxdb-client-csharp/pull/608): `NUnit` to `3.14.0`

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -43,12 +43,4 @@
       <PackageReference Include="RestSharp" Version="110.1.0" />
     </ItemGroup>
 
-    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
-        <ItemGroup>
-            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
-        </ItemGroup>
-        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
-        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
-    </Target>
-
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -27,6 +27,10 @@
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath="" />
     </ItemGroup>
@@ -38,5 +42,13 @@
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
       <PackageReference Include="RestSharp" Version="110.1.0" />
     </ItemGroup>
+
+    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
+        <ItemGroup>
+            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
+        </ItemGroup>
+        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
+        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
+    </Target>
 
 </Project>

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -37,12 +37,4 @@
         <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
     </ItemGroup>
 
-    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
-        <ItemGroup>
-            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
-        </ItemGroup>
-        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
-        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
-    </Target>
-
 </Project>

--- a/Client.Legacy/Client.Legacy.csproj
+++ b/Client.Legacy/Client.Legacy.csproj
@@ -27,10 +27,22 @@
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath="" />
         <None Include=".\README.md" Pack="true" PackagePath="\"/>
         <ProjectReference Include="..\Client.Core\Client.Core.csproj" />
     </ItemGroup>
+
+    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
+        <ItemGroup>
+            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
+        </ItemGroup>
+        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
+        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
+    </Target>
 
 </Project>

--- a/Client.Linq/Client.Linq.csproj
+++ b/Client.Linq/Client.Linq.csproj
@@ -28,6 +28,10 @@
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath="" />
         <None Include=".\README.md" Pack="true" PackagePath="\"/>
@@ -37,5 +41,13 @@
     <ItemGroup>
       <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     </ItemGroup>
+
+    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
+        <ItemGroup>
+            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
+        </ItemGroup>
+        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
+        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
+    </Target>
 
 </Project>

--- a/Client.Linq/Client.Linq.csproj
+++ b/Client.Linq/Client.Linq.csproj
@@ -42,12 +42,4 @@
       <PackageReference Include="Remotion.Linq" Version="2.2.0" />
     </ItemGroup>
 
-    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
-        <ItemGroup>
-            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
-        </ItemGroup>
-        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
-        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
-    </Target>
-
 </Project>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -28,6 +28,10 @@
         <SignAssembly>true</SignAssembly>
     </PropertyGroup>
 
+    <PropertyGroup>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    </PropertyGroup>
+
     <ItemGroup>
         <None Include="..\Assets\influxdata.jpg" Pack="true" PackagePath="" />
         <None Include=".\README.md" Pack="true" PackagePath="\" />
@@ -42,5 +46,13 @@
         <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
         <PackageReference Include="System.Reactive" Version="6.0.0" />
     </ItemGroup>
+
+    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
+        <ItemGroup>
+            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
+        </ItemGroup>
+        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
+        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
+    </Target>
 
 </Project>

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -47,12 +47,4 @@
         <PackageReference Include="System.Reactive" Version="6.0.0" />
     </ItemGroup>
 
-    <Target Name="CopyReferenceFiles" BeforeTargets="Build">
-        <ItemGroup>
-            <XmlReferenceFiles Condition="Exists('$(OutputPath)%(Filename).dll')" Include="%(Reference.RelativeDir)%(Reference.Filename).xml" />
-        </ItemGroup>
-        <Message Text="Copying reference files to $(OutputPath)" Importance="High" />
-        <Copy SourceFiles="@(XmlReferenceFiles)" DestinationFolder="$(OutputPath)" Condition="Exists('%(RootDir)%(Directory)%(Filename)%(Extension)')" />
-    </Target>
-
 </Project>


### PR DESCRIPTION
Closes #574

## Proposed Changes

Changes project files for `Client`, `Client.Core`, `Client.Linq` and `Client.Legacy` to generate XML documentation and include it in nuget packages.

Installed packages before:
```
./packages/influxdb.client/4.15.0/lib/netstandard2.1/InfluxDB.Client.dll
./packages/influxdb.client/4.15.0/lib/netstandard2.0/InfluxDB.Client.dll
...
```
After changes:
```
./packages/influxdb.client/4.15.0-dev/lib/netstandard2.1/InfluxDB.Client.xml
./packages/influxdb.client/4.15.0-dev/lib/netstandard2.1/InfluxDB.Client.dll
./packages/influxdb.client/4.15.0-dev/lib/netstandard2.0/InfluxDB.Client.xml
./packages/influxdb.client/4.15.0-dev/lib/netstandard2.0/InfluxDB.Client.dll
...
```

![image](https://github.com/influxdata/influxdb-client-csharp/assets/42931850/086a4b87-ceaf-4acb-92ad-8b21058f8919)



## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
