### PR TITLE
add RestSharp nuget package

### DIFF
--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -40,7 +40,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.1.11" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="110.1.0" />
+      <PackageReference Include="RestSharp" Version="111.3.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -40,7 +40,7 @@ namespace InfluxDB.Client.Core.Internal
         internal static RestResponse ExecuteSync(this RestClient client,
             RestRequest request, CancellationToken cancellationToken = default)
         {
-            return client.Execute(request, cancellationToken);
+            return client.ExecuteAsync(request, cancellationToken).Result;
         }
     }
 }

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -165,7 +165,7 @@ namespace InfluxDB.Client.Flux
             var version = AssemblyHelper.GetVersion(typeof(FluxClient));
             var restClientOptions = new RestClientOptions(options.Url)
             {
-                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
+                Timeout = TimeSpan.FromMilliseconds(options.Timeout.TotalMilliseconds),
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy
             };
@@ -372,9 +372,9 @@ namespace InfluxDB.Client.Flux
 
         public void Dispose()
         {
-            // 
-            // Dispose HttpClient 
-            // 
+            //
+            // Dispose HttpClient
+            //
             RestClient.Dispose();
         }
 

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -140,7 +140,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -324,7 +324,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -416,7 +416,7 @@ namespace InfluxDB.Client.Test
             _client = new InfluxDBClient(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace InfluxDB.Client.Test
             _client = InfluxDBClientFactory.Create(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout.GetValueOrDefault().TotalMilliseconds);
         }
 
         [Test]

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -38,7 +38,7 @@ namespace InfluxDB.Client.Api.Client
             var version = AssemblyHelper.GetVersion(typeof(InfluxDBClient));
             RestClientOptions = new RestClientOptions(options.Url)
             {
-                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
+                Timeout = TimeSpan.FromMilliseconds(options.Timeout.TotalMilliseconds),
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy,
                 FollowRedirects = options.AllowHttpRedirects,


### PR DESCRIPTION
## Proposed Changes
* Update RestSharp nuget
* Replace MaxTimeout (int) of RestClientOption to Timeout (TimeSpan) 
* Fix the Execute() of RestClient which now don't get CancellationToken to ExecuteAsync().Result

Closes #

