### PR TITLE
fix: async queries also uses `HttpCompletionOption.ResponseHeadersRead`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.17.0 [unreleased]
 
+### Bug Fixes
+1. [#649](https://github.com/influxdata/influxdb-client-csharp/pull/649): Use HttpCompletionOption.ResponseHeadersRead for asynchronous QueryApi
+
 ## 4.16.0 [2024-06-24]
 
 ### Features:

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -792,7 +792,8 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(optionsOrg, OrgArgumentValidation);
 
             return advancedResponseWriter => _service
-                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, HttpCompletionOption.ResponseHeadersRead)
+                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
+                    HttpCompletionOption.ResponseHeadersRead)
                 .AddAdvancedResponseHandler(advancedResponseWriter);
         }
 

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -792,7 +792,7 @@ namespace InfluxDB.Client
             Arguments.CheckNonEmptyString(optionsOrg, OrgArgumentValidation);
 
             return advancedResponseWriter => _service
-                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query)
+                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query, HttpCompletionOption.ResponseHeadersRead)
                 .AddAdvancedResponseHandler(advancedResponseWriter);
         }
 


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-csharp/pull/632#discussion_r1685853040

## Proposed Changes

Use `HttpCompletionOption.ResponseHeadersRead` also for async queries for possibility to use large queries then 2GiB. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
