### PR TITLE
chore(deps): upgrade RestSharp to `111.4.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 ## 4.17.0 [unreleased]
 
+### Breaking Changes
+
+#### API
+
+- `ApiResponse` headers has been changed to `IEnumerable<(string Name, string Value)>`
+
 ### Bug Fixes
 1. [#649](https://github.com/influxdata/influxdb-client-csharp/pull/649): Use HttpCompletionOption.ResponseHeadersRead for asynchronous QueryApi
+
+### Dependencies
+Update dependencies:
+
+#### Build:
+- [#650](https://github.com/influxdata/influxdb-client-csharp/pull/650): `RestSharp` to `111.4.0`
 
 ## 4.16.0 [2024-06-24]
 

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -40,7 +40,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.1.11" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="110.1.0" />
+      <PackageReference Include="RestSharp" Version="111.4.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Internal/RestSharpExtensions.cs
+++ b/Client.Core/Internal/RestSharpExtensions.cs
@@ -1,11 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 using System.Net.Http.Headers;
-using System.Reflection;
 using System.Threading;
-using System.Threading.Tasks;
 using RestSharp;
 
 namespace InfluxDB.Client.Core.Internal
@@ -27,20 +23,10 @@ namespace InfluxDB.Client.Core.Internal
                 .Select(x => new HeaderParameter(x.Key, x.y));
         }
 
-        internal static RestRequest AddAdvancedResponseHandler(this RestRequest restRequest,
-            Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
-        {
-            var field = restRequest.GetType()
-                .GetField("_advancedResponseHandler", BindingFlags.Instance | BindingFlags.NonPublic);
-            field!.SetValue(restRequest, advancedResponseWriter);
-
-            return restRequest;
-        }
-
         internal static RestResponse ExecuteSync(this RestClient client,
             RestRequest request, CancellationToken cancellationToken = default)
         {
-            return client.Execute(request, cancellationToken);
+            return client.Execute(request);
         }
     }
 }

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -423,10 +423,9 @@ namespace InfluxDB.Client.Flux
             return new RestRequest("ping");
         }
 
-        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> QueryRequest(string query)
+        private RestRequest QueryRequest(string query)
         {
-            return advancedResponseWriter => new RestRequest("api/v2/query", Method.Post)
-                .AddAdvancedResponseHandler(advancedResponseWriter)
+            return new RestRequest("api/v2/query", Method.Post)
                 .AddParameter(new BodyParameter("application/json", query, "application/json"));
         }
     }

--- a/Client/InfluxDB.Client.Api/Client/ApiResponse.cs
+++ b/Client/InfluxDB.Client.Api/Client/ApiResponse.cs
@@ -43,7 +43,7 @@ namespace InfluxDB.Client.Api.Client
         /// <param name="statusCode">HTTP status code.</param>
         /// <param name="headers">HTTP headers.</param>
         /// <param name="data">Data (parsed HTTP body)</param>
-        public ApiResponse(int statusCode, IEnumerable<(string Name, object Value)> headers, T data)
+        public ApiResponse(int statusCode, IEnumerable<(string Name, string Value)> headers, T data)
         {
             StatusCode = statusCode;
             Headers = headers

--- a/Client/InvokableScriptsApi.cs
+++ b/Client/InvokableScriptsApi.cs
@@ -300,14 +300,13 @@ namespace InfluxDB.Client
                 cancellationToken);
         }
 
-        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(string scriptId,
+        private RestRequest CreateRequest(string scriptId,
             Dictionary<string, object> bindParams = default)
         {
             Arguments.CheckNonEmptyString(scriptId, nameof(scriptId));
 
-            return advancedResponseWriter => _service
-                .PostScriptsIDInvokeWithRestRequest(scriptId, new ScriptInvocationParams(bindParams))
-                .AddAdvancedResponseHandler(advancedResponseWriter);
+            return _service
+                .PostScriptsIDInvokeWithRestRequest(scriptId, new ScriptInvocationParams(bindParams));
         }
     }
 }

--- a/Client/QueryApi.cs
+++ b/Client/QueryApi.cs
@@ -783,18 +783,18 @@ namespace InfluxDB.Client
                 cancellationToken);
         }
 
-        private Func<Func<HttpResponseMessage, RestRequest, RestResponse>, RestRequest> CreateRequest(Query query,
-            string org = null)
+        private RestRequest CreateRequest(Query query, string org = null)
         {
             Arguments.CheckNotNull(query, nameof(query));
 
             var optionsOrg = org ?? _options.Org;
             Arguments.CheckNonEmptyString(optionsOrg, OrgArgumentValidation);
 
-            return advancedResponseWriter => _service
+            var postQueryWithRestRequest = _service
                 .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
-                    HttpCompletionOption.ResponseHeadersRead)
-                .AddAdvancedResponseHandler(advancedResponseWriter);
+                    HttpCompletionOption.ResponseHeadersRead);
+
+            return postQueryWithRestRequest;
         }
 
         internal static Query CreateQuery(string query, Dialect dialect = null)

--- a/Client/QueryApiSync.cs
+++ b/Client/QueryApiSync.cs
@@ -140,15 +140,11 @@ namespace InfluxDB.Client
 
             var consumer = new FluxResponseConsumerPoco<T>(poco => { measurements.Add(poco); }, Mapper);
 
-            RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
-            {
-                return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
-                        HttpCompletionOption.ResponseHeadersRead)
-                    .AddAdvancedResponseHandler(advancedResponseWriter);
-            }
+            var restRequest = _service
+                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
+                    HttpCompletionOption.ResponseHeadersRead);
 
-            QuerySync(QueryFn, consumer, ErrorConsumer, EmptyAction, cancellationToken);
+            QuerySync(restRequest, consumer, ErrorConsumer, EmptyAction, cancellationToken);
 
             return measurements;
         }
@@ -193,15 +189,11 @@ namespace InfluxDB.Client
             var optionsOrg = org ?? _options.Org;
             Arguments.CheckNonEmptyString(optionsOrg, OrgArgumentValidation);
 
-            RestRequest QueryFn(Func<HttpResponseMessage, RestRequest, RestResponse> advancedResponseWriter)
-            {
-                return _service
-                    .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
-                        HttpCompletionOption.ResponseHeadersRead)
-                    .AddAdvancedResponseHandler(advancedResponseWriter);
-            }
+            var restRequest = _service
+                .PostQueryWithRestRequest(null, "application/json", null, optionsOrg, null, query,
+                    HttpCompletionOption.ResponseHeadersRead);
 
-            QuerySync(QueryFn, consumer, ErrorConsumer, EmptyAction, cancellationToken);
+            QuerySync(restRequest, consumer, ErrorConsumer, EmptyAction, cancellationToken);
 
             return consumer.Tables;
         }


### PR DESCRIPTION
Closes #647

## Proposed Changes

This PR upgrade `RestSharp` to `111.4.0` and also migrate our API to new APIs from RestSharp.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
