### PR TITLE
feat: add response headers to HttpException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 4.18.0 [unreleased]
 
+### Features:
+  - [#658](https://github.com/influxdata/influxdb-client-csharp/pull/658): Add HttpHeaders as `IEnumerable<RestSharp.HttpParameter>` to `HttpException` and facilitate access in `WriteErrorEvent`.  Includes new example `HttpErrorHandling`.
+
 ## 4.17.0 [2024-08-12]
 
 ### Breaking Changes

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -57,10 +57,12 @@ namespace InfluxDB.Client.Core.Exceptions
         /// </summary>
         public int? RetryAfter { get; set; }
 
+#nullable enable
         /// <summary>
         ///     The response headers
         /// </summary>
         public IEnumerable<HeaderParameter>? Headers { get; private set; }
+#nullable disable
 
         public static HttpException Create(RestResponse requestResult, object body)
         {

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -60,7 +60,7 @@ namespace InfluxDB.Client.Core.Exceptions
         /// <summary>
         ///     The response headers
         /// </summary>
-        public IEnumerable<HeaderParameter> Headers;
+        public IEnumerable<HeaderParameter>? Headers { get; private set; }
 
         public static HttpException Create(RestResponse requestResult, object body)
         {

--- a/Client.Core/Exceptions/InfluxException.cs
+++ b/Client.Core/Exceptions/InfluxException.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 using InfluxDB.Client.Core.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -55,6 +56,11 @@ namespace InfluxDB.Client.Core.Exceptions
         ///     The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
         /// </summary>
         public int? RetryAfter { get; set; }
+
+        /// <summary>
+        ///     The response headers
+        /// </summary>
+        public IEnumerable<HeaderParameter> Headers;
 
         public static HttpException Create(RestResponse requestResult, object body)
         {
@@ -162,6 +168,7 @@ namespace InfluxDB.Client.Core.Exceptions
 
             err.ErrorBody = errorBody;
             err.RetryAfter = retryAfter;
+            err.Headers = headers;
 
             return err;
         }

--- a/Client.Test/InfluxExceptionTest.cs
+++ b/Client.Test/InfluxExceptionTest.cs
@@ -1,0 +1,51 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using InfluxDB.Client.Core.Exceptions;
+using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using RestSharp;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class InfluxExceptionTest
+    {
+        [Test]
+        public void ExceptionHeadersTest()
+        {
+            try
+            {
+                throw HttpException.Create(
+                    JObject.Parse("{\"callId\": \"123456789\", \"message\": \"error in content object\"}"),
+                    new List<HeaderParameter>
+                    {
+                        new HeaderParameter("Trace-Id", "123456789ABCDEF0"),
+                        new HeaderParameter("X-Influx-Version", "1.0.0"),
+                        new HeaderParameter("X-Platform-Error-Code", "unavailable"),
+                        new HeaderParameter("Retry-After", "60000"),
+                    },
+                    null,
+                    HttpStatusCode.ServiceUnavailable);
+            }
+            catch (HttpException he)
+            {
+                // Assert.AreEqual("error in content object", he?.Message);
+                Console.WriteLine("DEBUG he.Message {0}", he.Message);
+            
+            
+                Assert.AreEqual(4, he?.Headers.Count());
+                Dictionary<String, String> headers = new Dictionary<String, String>();
+                foreach (HeaderParameter header in he?.Headers)
+                {
+                    headers.Add(header.Name, header.Value);
+                }
+                Assert.AreEqual("123456789ABCDEF0", headers["Trace-Id"]);
+                Assert.AreEqual("1.0.0", headers["X-Influx-Version"]);
+                Assert.AreEqual("unavailable", headers["X-Platform-Error-Code"]);
+                Assert.AreEqual("60000", headers["Retry-After"]);
+            }
+        }
+    }
+}

--- a/Client.Test/InfluxExceptionTest.cs
+++ b/Client.Test/InfluxExceptionTest.cs
@@ -24,23 +24,18 @@ namespace InfluxDB.Client.Test
                         new HeaderParameter("Trace-Id", "123456789ABCDEF0"),
                         new HeaderParameter("X-Influx-Version", "1.0.0"),
                         new HeaderParameter("X-Platform-Error-Code", "unavailable"),
-                        new HeaderParameter("Retry-After", "60000"),
+                        new HeaderParameter("Retry-After", "60000")
                     },
                     null,
                     HttpStatusCode.ServiceUnavailable);
             }
             catch (HttpException he)
             {
-                // Assert.AreEqual("error in content object", he?.Message);
-                Console.WriteLine("DEBUG he.Message {0}", he.Message);
-            
-            
+                Assert.AreEqual("error in content object", he?.Message);
+
                 Assert.AreEqual(4, he?.Headers.Count());
-                Dictionary<String, String> headers = new Dictionary<String, String>();
-                foreach (HeaderParameter header in he?.Headers)
-                {
-                    headers.Add(header.Name, header.Value);
-                }
+                var headers = new Dictionary<string, string>();
+                foreach (var header in he?.Headers) headers.Add(header.Name, header.Value);
                 Assert.AreEqual("123456789ABCDEF0", headers["Trace-Id"]);
                 Assert.AreEqual("1.0.0", headers["X-Influx-Version"]);
                 Assert.AreEqual("unavailable", headers["X-Platform-Error-Code"]);

--- a/Client.Test/ItErrorEventsTest.cs
+++ b/Client.Test/ItErrorEventsTest.cs
@@ -1,0 +1,104 @@
+using System;
+using NUnit.Framework;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Writes;
+
+namespace InfluxDB.Client.Test
+{
+    [TestFixture]
+    public class ItErrorEventsTest : AbstractItClientTest
+    {
+        private Organization _org;
+        private Bucket _bucket;
+        private string _token;
+        private InfluxDBClientOptions _options;
+
+        [SetUp]
+        public new async Task SetUp()
+        {
+            _org = await FindMyOrg();
+            _bucket = await Client.GetBucketsApi()
+                .CreateBucketAsync(GenerateName("fliers"), null, _org);
+
+            //
+            // Add Permissions to read and write to the Bucket
+            //
+            var resource = new PermissionResource(PermissionResource.TypeBuckets, _bucket.Id, null,
+                _org.Id);
+
+            var readBucket = new Permission(Permission.ActionEnum.Read, resource);
+            var writeBucket = new Permission(Permission.ActionEnum.Write, resource);
+
+            var loggedUser = await Client.GetUsersApi().MeAsync();
+            Assert.IsNotNull(loggedUser);
+
+            var authorization = await Client.GetAuthorizationsApi()
+                .CreateAuthorizationAsync(_org,
+                    new List<Permission> { readBucket, writeBucket });
+
+            _token = authorization.Token;
+
+            Client.Dispose();
+
+            _options = new InfluxDBClientOptions(InfluxDbUrl)
+            {
+                Token = _token,
+                Org = _org.Id,
+                Bucket = _bucket.Id
+            };
+
+            Client = new InfluxDBClient(_options);
+        }
+
+
+        [Test]
+        public void HandleEvents()
+        {
+            using (var writeApi = Client.GetWriteApi())
+            {
+                writeApi.EventHandler += (sender, eventArgs) =>
+                {
+                    switch (eventArgs)
+                    {
+                        case WriteSuccessEvent successEvent:
+                            Assert.Fail("Call should not succeed");
+                            break;
+                        case WriteErrorEvent errorEvent:
+                            Assert.AreEqual("unable to parse 'velocity,unit=C3PO mps=': missing field value", 
+                                errorEvent.Exception.Message);
+                            var eventHeaders = errorEvent.GetHeaders();
+                            if (eventHeaders == null)
+                            {
+                                Assert.Fail("WriteErrorEvent must return headers.");
+                            }
+
+                            var headers = new Dictionary<string, string> {};
+                            foreach (var hp in eventHeaders)
+                            {
+                                Console.WriteLine("DEBUG {0}: {1}", hp.Name, hp.Value);
+                                headers.Add(hp.Name, hp.Value);
+                            }
+
+                            Assert.AreEqual(4, headers.Count);
+                            Assert.AreEqual("OSS", headers["X-Influxdb-Build"]);
+                            Assert.True(headers["X-Influxdb-Version"].StartsWith('v'));
+                            Assert.AreEqual("invalid", headers["X-Platform-Error-Code"]);
+                            Assert.AreNotEqual("missing", headers.GetValueOrDefault("Date", "missing"));
+                            break;
+                        case WriteRetriableErrorEvent retriableErrorEvent:
+                            Assert.Fail("Call should not be retriable.");
+                            break;
+                        case WriteRuntimeExceptionEvent runtimeExceptionEvent:
+                            Assert.Fail("Call should not result in runtime exception. {0}", runtimeExceptionEvent);
+                            break;
+                    }
+                };
+
+                writeApi.WriteRecord("velocity,unit=C3PO mps=", WritePrecision.S, _bucket.Name, _org.Name);
+            }
+        } 
+    }
+}

--- a/Client.Test/ItErrorEventsTest.cs
+++ b/Client.Test/ItErrorEventsTest.cs
@@ -2,7 +2,6 @@ using System;
 using NUnit.Framework;
 using System.Collections.Generic;
 using System.Threading.Tasks;
-
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Writes;
 
@@ -67,7 +66,7 @@ namespace InfluxDB.Client.Test
                             Assert.Fail("Call should not succeed");
                             break;
                         case WriteErrorEvent errorEvent:
-                            Assert.AreEqual("unable to parse 'velocity,unit=C3PO mps=': missing field value", 
+                            Assert.AreEqual("unable to parse 'velocity,unit=C3PO mps=': missing field value",
                                 errorEvent.Exception.Message);
                             var eventHeaders = errorEvent.GetHeaders();
                             if (eventHeaders == null)
@@ -75,7 +74,7 @@ namespace InfluxDB.Client.Test
                                 Assert.Fail("WriteErrorEvent must return headers.");
                             }
 
-                            var headers = new Dictionary<string, string> {};
+                            var headers = new Dictionary<string, string> { };
                             foreach (var hp in eventHeaders)
                             {
                                 Console.WriteLine("DEBUG {0}: {1}", hp.Name, hp.Value);
@@ -99,6 +98,6 @@ namespace InfluxDB.Client.Test
 
                 writeApi.WriteRecord("velocity,unit=C3PO mps=", WritePrecision.S, _bucket.Name, _org.Name);
             }
-        } 
+        }
     }
 }

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -507,7 +507,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(0, MockServer.LogEntries.Count());
         }
 
-       [Test]
+        [Test]
         public void WriteExceptionWithHeaders()
         {
             var localWriteApi = _client.GetWriteApi(new WriteOptions { RetryInterval = 1_000 });
@@ -543,10 +543,10 @@ namespace InfluxDB.Client.Test
                         .WithStatusCode(400)
                         .WithHeaders(new Dictionary<string, string>()
                         {
-                            {"Content-Type", "application/json"},
-                            {"Trace-Id", traceId},
-                            {"X-Influxdb-Build", buildName},
-                            {"X-Influxdb-Version", version},
+                            { "Content-Type", "application/json" },
+                            { "Trace-Id", traceId },
+                            { "X-Influxdb-Build", buildName },
+                            { "X-Influxdb-Version", version }
                         })
                 );
 

--- a/Client/Writes/Events.cs
+++ b/Client/Writes/Events.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using InfluxDB.Client.Api.Domain;
 using InfluxDB.Client.Core;
+using InfluxDB.Client.Core.Exceptions;
+using RestSharp;
 
 namespace InfluxDB.Client.Writes
 {
@@ -41,6 +44,11 @@ namespace InfluxDB.Client.Writes
         internal override void LogEvent()
         {
             Trace.TraceError($"The error occurred during writing of data: {Exception.Message}");
+        }
+
+        public IEnumerable<HeaderParameter> GetHeaders()
+        {
+            return ((HttpException)Exception)?.Headers;
         }
     }
 

--- a/Client/Writes/Events.cs
+++ b/Client/Writes/Events.cs
@@ -46,6 +46,9 @@ namespace InfluxDB.Client.Writes
             Trace.TraceError($"The error occurred during writing of data: {Exception.Message}");
         }
 
+        /// <summary>
+        /// Get headers from the nested exception.
+        /// </summary>
         public IEnumerable<HeaderParameter> GetHeaders()
         {
             return ((HttpException)Exception)?.Headers;

--- a/Examples/HttpErrorHandling.cs
+++ b/Examples/HttpErrorHandling.cs
@@ -102,11 +102,25 @@ namespace Examples
                 };
                 Console.WriteLine("Trying the records list");
                 writeApi.WriteRecords(_lpRecords, WritePrecision.Ms, "my-bucket", "my-org");
-                while (caughtErrorCount == 0) Thread.Sleep(1000);
+                var slept = 0;
+                while (caughtErrorCount == 0 && slept < 3001) slept += 1000;
+                Thread.Sleep(1000);
+                if (slept > 3000)
+                {
+                    Console.WriteLine("WARN, did not encounter expected error");
+                }
+
+
                 // manually retry the bad record
                 Console.WriteLine("Manually retrying the bad record.");
                 writeApi.WriteRecord(_lpRecords[2], WritePrecision.Ms, "my-bucket", "my-org");
-                while (caughtErrorCount == 1) Thread.Sleep(1000);
+                slept = 0;
+                while (caughtErrorCount == 1 && slept < 3001) slept += 1000;
+                Thread.Sleep(1000);
+                if (slept > 3000)
+                {
+                    Console.WriteLine("WARN, did not encounter expected error");
+                }
             }
         }
 

--- a/Examples/HttpErrorHandling.cs
+++ b/Examples/HttpErrorHandling.cs
@@ -1,0 +1,122 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using InfluxDB.Client;
+using InfluxDB.Client.Api.Domain;
+using InfluxDB.Client.Core.Exceptions;
+using InfluxDB.Client.Writes;
+using RestSharp;
+
+namespace Examples
+{
+    public class HttpErrorHandling
+    {
+        private static InfluxDBClient _client;
+        private static List<string> _lpRecords;
+
+        private static void Setup()
+        {
+            _client = new InfluxDBClient("http://localhost:9999",
+                "my-user", "my-password");
+            var nowMillis = DateTimeOffset.Now.ToUnixTimeMilliseconds();
+
+            _lpRecords = new List<string>()
+            {
+                $"temperature,location=north value=42 {nowMillis}",
+                $"temperature,location=north value=17 {nowMillis - 10000}",
+                $"temperature,location=north value= {nowMillis - 20000}", // one flaky record 
+                $"temperature,location=north value=5 {nowMillis - 30000}"
+            };
+        }
+
+        private static void TearDown()
+        {
+            _client.Dispose();
+        }
+
+        private static Dictionary<string, string> Headers2Dictionary(IEnumerable<HeaderParameter> headers)
+        {
+            var result = new Dictionary<string, string>();
+            foreach (var hp in headers)
+                result.Add(hp.Name, hp.Value);
+            return result;
+        }
+
+        private static async Task WriteRecordsAsync()
+        {
+            Console.WriteLine("Write records async with one invalid record.");
+
+            //
+            // Write Data
+            //
+            var writeApiAsync = _client.GetWriteApiAsync();
+
+            try
+            {
+                await writeApiAsync.WriteRecordsAsync(_lpRecords, WritePrecision.Ms,
+                    "my-bucket", "my-org");
+            }
+            catch (HttpException he)
+            {
+                Console.WriteLine("   WARNING write failed");
+                var headersDix = Headers2Dictionary(he.Headers);
+                Console.WriteLine("   Caught Exception({0}) {1} with the following headers:",
+                    he.GetType(),
+                    he.Message);
+                foreach (var key in headersDix.Keys)
+                    Console.WriteLine($"      {key}: {headersDix[key]}");
+            }
+            finally
+            {
+                Console.WriteLine("   ====================");
+            }
+        }
+
+        private static void WriteRecordsWithErrorEvent()
+        {
+            Console.WriteLine("Write records with error event.");
+
+            var caughtErrorCount = 0;
+            using (var writeApi = _client.GetWriteApi())
+            {
+                writeApi.EventHandler += (sender, eventArgs) =>
+                {
+                    switch (eventArgs)
+                    {
+                        case WriteErrorEvent wee:
+                            Console.WriteLine("   WARNING write failed");
+                            Console.WriteLine("   Received event WriteErrorEvent with:");
+                            Console.WriteLine("      Status: {0}", ((HttpException)wee.Exception).Status);
+                            Console.WriteLine("      Exception: {0}", wee.Exception.GetType());
+                            Console.WriteLine("      Message: {0}", wee.Exception.Message);
+                            Console.WriteLine("      Headers:");
+                            var headersDix = Headers2Dictionary(wee.GetHeaders());
+                            foreach (var key in headersDix.Keys)
+                                Console.WriteLine($"         {key}: {headersDix[key]}");
+                            caughtErrorCount++;
+                            break;
+                        default:
+                            throw new Exception("Should only receive WriteErrorEvent");
+                    }
+                };
+                Console.WriteLine("Trying the records list");
+                writeApi.WriteRecords(_lpRecords, WritePrecision.Ms, "my-bucket", "my-org");
+                while (caughtErrorCount == 0) Thread.Sleep(1000);
+                // manually retry the bad record
+                Console.WriteLine("Manually retrying the bad record.");
+                writeApi.WriteRecord(_lpRecords[2], WritePrecision.Ms, "my-bucket", "my-org");
+                while (caughtErrorCount == 1) Thread.Sleep(1000);
+            }
+        }
+
+        public static async Task Main()
+        {
+            Console.WriteLine("Main()");
+            Setup();
+            await WriteRecordsAsync();
+            WriteRecordsWithErrorEvent();
+            TearDown();
+        }
+    }
+}

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -2,6 +2,7 @@
 
 ## Writes
 - [WriteEventHandlerExample.cs](WriteEventHandlerExample.cs) - How to use WriteAPI with batch options and how to handle events
+- [HttpErrorHandling.cs](HttpErrorHandling.cs) - How to handle errors on write and retrieve response headers.
 
 ## Others
 - [InvokableScripts.cs](InvokableScripts.cs) - How to use Invokable scripts Cloud API to create custom endpoints that query data

--- a/Examples/RunExamples.cs
+++ b/Examples/RunExamples.cs
@@ -72,6 +72,9 @@ namespace Examples
                     case "RecordRowExample":
                         await RecordRowExample.Main();
                         break;
+                    case "HttpErrorHandling":
+                        await HttpErrorHandling.Main();
+                        break;
                 }
             }
             else


### PR DESCRIPTION
## Proposed Changes

- Add Headers to `HttpException`
- Make Headers easily accessible in `WriteErrorEvent`
- Add Example showing how to use these changes
- Add tests of these changes

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
