### PR TITLE
test: add test for server returning 201 Created for writes

### DIFF
--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -398,7 +398,7 @@ namespace InfluxDB.Client.Test
             _writeApi.Flush();
 
             var writeSuccessEvent = listener.Get<WriteSuccessEvent>();
-            Assert.AreEqual("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 X",
+            Assert.AreEqual("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1",
                 writeSuccessEvent.LineProtocol);
         }
 

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -397,9 +397,6 @@ namespace InfluxDB.Client.Test
                 WritePrecision.Ns, "b1", "org1");
             _writeApi.Flush();
 
-            var error = listener.Get<WriteErrorEvent>();
-            Assert.IsNull(error);
-
             var writeSuccessEvent = listener.Get<WriteSuccessEvent>();
             Assert.AreEqual("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 X",
                 writeSuccessEvent.LineProtocol);

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -382,6 +382,30 @@ namespace InfluxDB.Client.Test
         }
 
         [Test]
+        public void Created()
+        {
+            var listener = new EventListener(_writeApi);
+
+            MockServer.Reset();
+            MockServer
+                .Given(Request.Create().UsingPost())
+                .RespondWith(CreateResponse(
+                    "OK",
+                    401));
+
+            _writeApi.WriteRecord("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1",
+                WritePrecision.Ns, "b1", "org1");
+            _writeApi.Flush();
+
+            var error = listener.Get<WriteErrorEvent>();
+            Assert.IsNull(error);
+
+            var writeSuccessEvent = listener.Get<WriteSuccessEvent>();
+            Assert.AreEqual("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 X",
+                writeSuccessEvent.LineProtocol);
+        }
+
+        [Test]
         public void TwiceDispose()
         {
             _writeApi.Dispose();

--- a/Client.Test/WriteApiTest.cs
+++ b/Client.Test/WriteApiTest.cs
@@ -391,7 +391,7 @@ namespace InfluxDB.Client.Test
                 .Given(Request.Create().UsingPost())
                 .RespondWith(CreateResponse(
                     "OK",
-                    401));
+                    201));
 
             _writeApi.WriteRecord("h2o_feet,location=coyote_creek level\\ description=\"feet 1\",water_level=1.0 1",
                 WritePrecision.Ns, "b1", "org1");


### PR DESCRIPTION
## Proposed Changes

The InfluxDB v3 can also return 201 as a successful HTTP code for writes. This PR just adds a test specifically for this status code.

_No need to mention this in the CHANGELOG I guess._


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
