### PR TITLE
`QueryAsyncEnumerable()` now supports `FluxRecord` streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ⚠️ Important Notice: Starting from this release, we won’t be listing every dependency change in our changelog. This helps us maintain the project faster and focus on important features for our InfluxDB client.
 
+### Features:
+1. [#705](https://github.com/influxdata/influxdb-client-csharp/pull/705): `QueryAsyncEnumerable()` now supports `FluxRecord` streaming.
+
 ### CI
 1. [#681](https://github.com/influxdata/influxdb-client-csharp/pull/681): Add build for `dotnet8`
 

--- a/Client.Core/Internal/AbstractQueryClient.cs
+++ b/Client.Core/Internal/AbstractQueryClient.cs
@@ -203,10 +203,11 @@ namespace InfluxDB.Client.Core.Internal
                 )
             };
 
-            var stream = await RestClient.DownloadStreamAsync(query, cancellationToken).ConfigureAwait(false);
+            using var stream = await RestClient.DownloadStreamAsync(query, cancellationToken).ConfigureAwait(false);
+            using var sr = new StreamReader(stream);
+
             await foreach (var (_, record) in _csvParser
-                               .ParseFluxResponseAsync(new StreamReader(stream), cancellationToken)
-                               .ConfigureAwait(false))
+                               .ParseFluxResponseAsync(sr, cancellationToken).ConfigureAwait(false))
                 if (!(record is null))
                 {
                     yield return convert.Invoke(record);

--- a/Client.Test/QueryApiTest.cs
+++ b/Client.Test/QueryApiTest.cs
@@ -98,6 +98,31 @@ namespace InfluxDB.Client.Test
             await foreach (var item in measurements.ConfigureAwait(false)) list.Add(item);
 
             Assert.AreEqual(2, list.Count);
+            Assert.AreEqual("mem", list[0].Measurement);
+            Assert.AreEqual("mem", list[1].Measurement);
+            Assert.AreEqual(12.25, list[0].Value);
+            Assert.AreEqual(13.00, list[1].Value);
+        }
+
+        [Test]
+        public async Task QueryAsyncEnumerableOfFluxRecords()
+        {
+            MockServer
+                .Given(Request.Create().WithPath("/api/v2/query").UsingPost())
+                .RespondWith(CreateResponse(Data));
+
+            var measurements = _queryApi.QueryAsyncEnumerable(
+                new Query(null, "from(...)"),
+                "my-org");
+
+            var list = new List<FluxRecord>();
+            await foreach (var item in measurements.ConfigureAwait(false)) list.Add(item);
+
+            Assert.AreEqual(2, list.Count);
+            Assert.AreEqual("mem", list[0].GetMeasurement());
+            Assert.AreEqual("mem", list[1].GetMeasurement());
+            Assert.AreEqual(12.25, list[0].GetValue());
+            Assert.AreEqual(13.00, list[1].GetValue());
         }
 
         [Test]

--- a/Client/InvokableScriptsApi.cs
+++ b/Client/InvokableScriptsApi.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using InfluxDB.Client.Api.Domain;
@@ -248,15 +246,13 @@ namespace InfluxDB.Client
         /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>stream of FluxRecord</returns>
-        public async IAsyncEnumerable<FluxRecord> InvokeScriptEnumerableAsync(string scriptId,
+        public IAsyncEnumerable<FluxRecord> InvokeScriptEnumerableAsync(string scriptId,
             Dictionary<string, object> bindParams = default,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             var requestMessage = CreateRequest(scriptId, bindParams);
 
-            await foreach (var record in QueryEnumerable(requestMessage, it => it, cancellationToken)
-                               .ConfigureAwait(false))
-                yield return record;
+            return QueryEnumerable(requestMessage, r => r, cancellationToken);
         }
 
         /// <summary>
@@ -266,15 +262,13 @@ namespace InfluxDB.Client
         /// <param name="bindParams">Represent key/value pairs parameters to be injected into script</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>stream of Measurement</returns>
-        public async IAsyncEnumerable<T> InvokeScriptMeasurementsEnumerableAsync<T>(string scriptId,
+        public IAsyncEnumerable<T> InvokeScriptMeasurementsEnumerableAsync<T>(string scriptId,
             Dictionary<string, object> bindParams = default,
-            [EnumeratorCancellation] CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
         {
             var requestMessage = CreateRequest(scriptId, bindParams);
 
-            await foreach (var record in QueryEnumerable(requestMessage, it => Mapper.ConvertToEntity<T>(it),
-                               cancellationToken).ConfigureAwait(false))
-                yield return record;
+            return QueryEnumerable(requestMessage, r => Mapper.ConvertToEntity<T>(r), cancellationToken);
         }
 
         protected override void BeforeIntercept(RestRequest request)


### PR DESCRIPTION
Closes #452

## Proposed Changes

Add support for `FluxRecord` streaming with:
- `IAsyncEnumerable<FluxRecord> QueryAsyncEnumerable(string query, string org = null, CancellationToken cancellationToken = default)`
- `IAsyncEnumerable<FluxRecord> QueryAsyncEnumerable(Query query, string org = null, CancellationToken cancellationToken = default)`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
