### PR TITLE
chore(deps): Update RestSharp to 113.1.0 and use Timeout property

### DIFF
--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -40,7 +40,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.2.0" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="112.1.0" />
+      <PackageReference Include="RestSharp" Version="113.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -40,7 +40,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.2.0" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="114.0.0" />
+      <PackageReference Include="RestSharp" Version="113.1.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Core/Client.Core.csproj
+++ b/Client.Core/Client.Core.csproj
@@ -40,7 +40,7 @@
       <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
       <PackageReference Include="NodaTime" Version="3.2.0" />
       <PackageReference Include="NodaTime.Serialization.JsonNet" Version="3.1.0" />
-      <PackageReference Include="RestSharp" Version="113.1.0" />
+      <PackageReference Include="RestSharp" Version="114.0.0" />
     </ItemGroup>
 
 </Project>

--- a/Client.Legacy/FluxClient.cs
+++ b/Client.Legacy/FluxClient.cs
@@ -165,7 +165,7 @@ namespace InfluxDB.Client.Flux
             var version = AssemblyHelper.GetVersion(typeof(FluxClient));
             var restClientOptions = new RestClientOptions(options.Url)
             {
-                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
+                Timeout = options.Timeout,
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy
             };

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -140,7 +140,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -324,7 +324,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -416,7 +416,7 @@ namespace InfluxDB.Client.Test
             _client = new InfluxDBClient(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace InfluxDB.Client.Test
             _client = InfluxDBClientFactory.Create(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.MaxTimeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout);
         }
 
         [Test]

--- a/Client.Test/InfluxDbClientFactoryTest.cs
+++ b/Client.Test/InfluxDbClientFactoryTest.cs
@@ -140,7 +140,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -160,7 +160,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -178,7 +178,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -197,7 +197,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -215,7 +215,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -234,7 +234,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Headers, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(1, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -297,7 +297,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -324,7 +324,7 @@ namespace InfluxDB.Client.Test
             Assert.AreEqual(LogLevel.Body, _client.GetLogLevel());
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(10_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
 
             var defaultTags = GetDeclaredField<SortedDictionary<string, string>>(options.PointSettings.GetType(),
                 options.PointSettings, "_defaultTags");
@@ -416,7 +416,7 @@ namespace InfluxDB.Client.Test
             _client = new InfluxDBClient(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]
@@ -432,7 +432,7 @@ namespace InfluxDB.Client.Test
             _client = InfluxDBClientFactory.Create(options);
 
             var apiClient = GetDeclaredField<ApiClient>(_client.GetType(), _client, "_apiClient");
-            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout);
+            Assert.AreEqual(20_000, apiClient.RestClientOptions.Timeout?.TotalMilliseconds);
         }
 
         [Test]

--- a/Client/Internal/ApiClient.cs
+++ b/Client/Internal/ApiClient.cs
@@ -38,7 +38,7 @@ namespace InfluxDB.Client.Api.Client
             var version = AssemblyHelper.GetVersion(typeof(InfluxDBClient));
             RestClientOptions = new RestClientOptions(options.Url)
             {
-                MaxTimeout = (int)options.Timeout.TotalMilliseconds,
+                Timeout = options.Timeout,
                 UserAgent = $"influxdb-client-csharp/{version}",
                 Proxy = options.WebProxy,
                 FollowRedirects = options.AllowHttpRedirects,


### PR DESCRIPTION
Upgraded RestSharp from 112.1.0 to 113.1.0. Replaced all usage of RestClientOptions.MaxTimeout with RestClientOptions.Timeout in code and tests to match the updated API. No other functional changes were made.

MaxTimeout was previously obsolete and was removed in version 113.0.0.
