### PR TITLE
ci: update dotnet-5.0 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,9 +102,9 @@ jobs:
               - run:
                   name: Install GPG
                   command: |
+                      apt-get update
                       apt-get install gnupg2
                       wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
-                      apt-get update
                       apt-get install gpg -y
               - run:
                   name: Collecting coverage reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,7 +221,7 @@ workflows:
       - tests-dotnet:
           name: dotnet-5.0
           code-coverage-report: true
-          dotnet-image: "mcr.microsoft.com/dotnet/sdk:5.0"
+          dotnet-image: "mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim"
       - tests-dotnet:
           name: dotnet-6.0
           dotnet-image: "mcr.microsoft.com/dotnet/sdk:6.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
               - run:
                   name: Install GPG
                   command: |
+                      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
                       apt-get update
                       apt-get install gpg -y
               - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,6 @@ jobs:
                   name: Install GPG
                   command: |
                       apt-get update
-                      apt-get install gnupg2
-                      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
                       apt-get install gpg -y
               - run:
                   name: Collecting coverage reports

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
               - run:
                   name: Install GPG
                   command: |
-                      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
+                      wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
                       apt-get update
                       apt-get install gpg -y
               - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,6 +102,7 @@ jobs:
               - run:
                   name: Install GPG
                   command: |
+                      apt-get install gnupg2
                       wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -
                       apt-get update
                       apt-get install gpg -y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 5.1.0 [unreleased]
 
+### CI
+1. [#712](https://github.com/influxdata/influxdb-client-csharp/pull/721): Update dotnet-5.0 image from "mcr.microsoft.com/dotnet/sdk:5.0" to "mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim".
+
 ## 5.0.0 [2026-01-13]
 
 ### Dependencies


### PR DESCRIPTION
Closes #

## Proposed Changes

- Update dotnet-5.0 image from "mcr.microsoft.com/dotnet/sdk:5.0" to "mcr.microsoft.com/dotnet/sdk:5.0-bullseye-slim".
- The issue has been solved, but I'm not sure that we should continue to support 5.0 anymore, current LTS is dotnet-8.0

<img width="2560" height="1440" alt="Screenshot 2026-03-04 at 09 04 22" src="https://github.com/user-attachments/assets/f24114c2-1525-41c6-accc-416a17f2fe7a" />


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `dotnet test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
