### PR TITLE
docs(Client.Legacy): correct 'occured' -> 'occurred' in README example

### DIFF
--- a/Client.Legacy/README.md
+++ b/Client.Legacy/README.md
@@ -94,7 +94,7 @@ fluxClient.QueryAsync(fluxQuery, record =>
             (error) =>
             {
                 // error handling while processing result
-                Console.WriteLine($"Error occured: {error}");
+                Console.WriteLine($"Error occurred: {error}");
             }, 
             () =>
             {


### PR DESCRIPTION
`Console.WriteLine` sample in `Client.Legacy/README.md:97` printed `Error occured: {error}`. Doc-only fix in the legacy client README.